### PR TITLE
Implement step navigation in FormRenderer

### DIFF
--- a/test-form/src/components/core/FormRenderer/FormRenderer.jsx
+++ b/test-form/src/components/core/FormRenderer/FormRenderer.jsx
@@ -1,16 +1,43 @@
-import React from 'react';
+import React, { useState } from 'react';
 import Step from '../Step/Step';
+import Stepper from '../Stepper/Stepper';
 import formSpec from '../../data/childcare_form.json';
 
 export default function FormRenderer() {
   const { form } = formSpec;
+  const steps = form.steps || [];
+  const [currentStep, setCurrentStep] = useState(0);
+
+  const handleNext = () => {
+    setCurrentStep((s) => Math.min(s + 1, steps.length - 1));
+  };
+
+  const handleBack = () => {
+    setCurrentStep((s) => Math.max(s - 1, 0));
+  };
+
   return (
-    <div>
-      <h1>{form.title}</h1>
-      <p>{form.description}</p>
-      {form.steps.map(step => (
-        <Step key={step.id} title={step.title} sections={step.sections} />
-      ))}
+    <div className="wizard-layout-row">
+      <Stepper
+        steps={steps}
+        currentStep={currentStep}
+        onStepChange={setCurrentStep}
+      />
+      <div className="form-main">
+        <h1>{form.title}</h1>
+        <p>{form.description}</p>
+        {steps.length > 0 && (
+          <Step
+            key={steps[currentStep].id}
+            title={steps[currentStep].title}
+            sections={steps[currentStep].sections}
+            onNext={handleNext}
+            onBack={handleBack}
+            isFirst={currentStep === 0}
+            isLast={currentStep === steps.length - 1}
+          />
+        )}
+      </div>
     </div>
   );
 }

--- a/test-form/src/components/core/Step/Step.jsx
+++ b/test-form/src/components/core/Step/Step.jsx
@@ -6,60 +6,81 @@ import RadioGroup from '../../shared/RadioGroup/RadioGroup';
 import ReactMarkdown from 'react-markdown';
 import styles from './Step.module.css';
 
-export default function Step({ title, sections = [] }) {
+export default function Step({
+  title,
+  sections = [],
+  onNext,
+  onBack,
+  isFirst = false,
+  isLast = false,
+}) {
   return (
     <div className={styles.step}>
       <h2>{title}</h2>
-      {sections.map(sec => (
+      {sections.map((sec) => (
         <Section key={sec.id} title={sec.title}>
           {sec.content && <ReactMarkdown>{sec.content}</ReactMarkdown>}
-          {sec.fields && sec.fields.map(field => {
-            switch (field.type) {
-              case 'text':
-                return (
-                  <TextInput
-                    key={field.id}
-                    id={field.id}
-                    label={field.label}
-                    required={field.required}
-                  />
-                );
-              case 'select':
-                return (
-                  <SelectField
-                    key={field.id}
-                    id={field.id}
-                    label={field.label}
-                    options={field.ui?.options || []}
-                    required={field.required}
-                  />
-                );
-              case 'radio':
-                return (
-                  <RadioGroup
-                    key={field.id}
-                    id={field.id}
-                    label={field.label}
-                    options={field.ui?.options || []}
-                    required={field.required}
-                  />
-                );
-              case 'date':
-                return (
-                  <TextInput
-                    key={field.id}
-                    id={field.id}
-                    label={field.label}
-                    type="date"
-                    required={field.required}
-                  />
-                );
-              default:
-                return null;
-            }
-          })}
+          {sec.fields &&
+            sec.fields.map((field) => {
+              switch (field.type) {
+                case 'text':
+                  return (
+                    <TextInput
+                      key={field.id}
+                      id={field.id}
+                      label={field.label}
+                      required={field.required}
+                    />
+                  );
+                case 'select':
+                  return (
+                    <SelectField
+                      key={field.id}
+                      id={field.id}
+                      label={field.label}
+                      options={field.ui?.options || []}
+                      required={field.required}
+                    />
+                  );
+                case 'radio':
+                  return (
+                    <RadioGroup
+                      key={field.id}
+                      id={field.id}
+                      label={field.label}
+                      options={field.ui?.options || []}
+                      required={field.required}
+                    />
+                  );
+                case 'date':
+                  return (
+                    <TextInput
+                      key={field.id}
+                      id={field.id}
+                      label={field.label}
+                      type="date"
+                      required={field.required}
+                    />
+                  );
+                default:
+                  return null;
+              }
+            })}
         </Section>
       ))}
+      <div className={styles.navigation}>
+        {!isFirst && (
+          <button type="button" onClick={onBack}>
+            Back
+          </button>
+        )}
+        {!isLast && (
+          <button type="button" onClick={onNext}>
+            Next
+          </button>
+        )}
+        {isLast && <button type="button">Submit</button>}
+      </div>
     </div>
   );
 }

--- a/test-form/src/components/core/Step/Step.module.css
+++ b/test-form/src/components/core/Step/Step.module.css
@@ -1,1 +1,9 @@
-.step { margin-bottom: 3rem; }
+.step {
+  margin-bottom: 3rem;
+}
+
+.navigation {
+  margin-top: 1.5rem;
+  display: flex;
+  gap: 0.5rem;
+}

--- a/test-form/src/components/core/Stepper/Stepper.jsx
+++ b/test-form/src/components/core/Stepper/Stepper.jsx
@@ -1,0 +1,21 @@
+import React from 'react';
+import styles from './Stepper.module.css';
+
+export default function Stepper({ steps = [], currentStep = 0, onStepChange }) {
+  return (
+    <aside className={styles.sidebar}>
+      <h4>Steps</h4>
+      <ul className={styles.list}>
+        {steps.map((step, index) => (
+          <li
+            key={step.id}
+            className={`${styles.item} ${index === currentStep ? styles.active : ''}`}
+            onClick={() => onStepChange && onStepChange(index)}
+          >
+            {step.title}
+          </li>
+        ))}
+      </ul>
+    </aside>
+  );
+}

--- a/test-form/src/components/core/Stepper/Stepper.module.css
+++ b/test-form/src/components/core/Stepper/Stepper.module.css
@@ -1,0 +1,23 @@
+.sidebar {
+  width: 250px;
+  flex-shrink: 0;
+}
+.list {
+  list-style: none;
+  padding: 0;
+  margin: 0;
+}
+.item {
+  padding: 0.6rem 1rem;
+  margin-bottom: 0.5rem;
+  background: #f3f4f6;
+  border-radius: 20px;
+  font-size: 0.95rem;
+  cursor: pointer;
+  transition: background 0.2s;
+}
+.active {
+  background-color: var(--primary-color);
+  color: white;
+  font-weight: 600;
+}


### PR DESCRIPTION
## Summary
- add `Stepper` component to show list of steps
- extend `Step` component with navigation buttons and callbacks
- keep current step state in `FormRenderer` and conditionally render the active step

## Testing
- `npm test --silent -- --watchAll=false` *(fails: react-scripts not found)*

------
https://chatgpt.com/codex/tasks/task_e_6840f5864e8083319134a1c3101ca538