### PR TITLE
Add collapsible info sections and section alerts

### DIFF
--- a/test-form/src/components/core/InfoSection/InfoSection.jsx
+++ b/test-form/src/components/core/InfoSection/InfoSection.jsx
@@ -1,0 +1,36 @@
+import React from 'react';
+import ReactMarkdown from 'react-markdown';
+
+export default function InfoSection({ title, content, ui = {}, collapsed = false, onToggle }) {
+  const isCollapsible = ui.collapsible;
+
+  return (
+    <div className="info-section">
+      <div
+        className="info-section-header"
+        onClick={isCollapsible ? onToggle : undefined}
+        style={{
+          cursor: isCollapsible ? 'pointer' : 'default',
+          fontWeight: 'bold',
+          backgroundColor: '#f0f0f0',
+          padding: '0.5rem',
+          borderRadius: '4px',
+        }}
+      >
+        {title} {isCollapsible && (collapsed ? '▶' : '▼')}
+      </div>
+      {(!isCollapsible || !collapsed) && content && (
+        <div
+          className="info-section-content"
+          style={{ marginTop: '0.5rem', paddingLeft: '1rem' }}
+        >
+          {ui.markdown ? (
+            <ReactMarkdown>{content}</ReactMarkdown>
+          ) : (
+            content.split('\n').map((line, idx) => <p key={idx}>{line}</p>)
+          )}
+        </div>
+      )}
+    </div>
+  );
+}

--- a/test-form/src/components/core/Section/Section.jsx
+++ b/test-form/src/components/core/Section/Section.jsx
@@ -1,11 +1,28 @@
 import React from 'react';
 import styles from './Section.module.css';
 
-export default function Section({ title, children }) {
+export default function Section({
+  title,
+  children,
+  isCollapsed = false,
+  onToggle,
+  showAlert = false,
+  required = false,
+}) {
   return (
     <section className={styles.section}>
-      <h3>{title}</h3>
-      {children}
+      <div
+        className={`form-section-header ${isCollapsed ? 'collapsed' : ''}`}
+        onClick={onToggle}
+      >
+        <span>
+          {title}
+          {required && <span className="required-asterisk"> *</span>}
+        </span>
+        {showAlert && <span className="form-section-alert">⚠ Input required</span>}
+        <span className="toggle-icon">{isCollapsed ? '▶' : '▼'}</span>
+      </div>
+      {!isCollapsed && children}
     </section>
   );
 }


### PR DESCRIPTION
## Summary
- implement `InfoSection` for collapsible info content
- enhance `Section` to collapse and show alerts
- manage collapsed state and form values in `Step`

## Testing
- `npm test --silent --yes` *(fails: react-scripts not found)*

------
https://chatgpt.com/codex/tasks/task_e_6840f9010b808331b4d268b1273d4c7f