### PR TITLE
Add GroupField and TableLayout components

### DIFF
--- a/test-form/src/components/core/Step/Step.jsx
+++ b/test-form/src/components/core/Step/Step.jsx
@@ -4,6 +4,8 @@ import InfoSection from '../InfoSection/InfoSection';
 import TextInput from '../../shared/TextInput/TextInput';
 import SelectField from '../../shared/SelectField/SelectField';
 import RadioGroup from '../../shared/RadioGroup/RadioGroup';
+import GroupField from '../../shared/GroupField/GroupField';
+import TableLayout from '../../shared/TableLayout/TableLayout';
 import ReactMarkdown from 'react-markdown';
 import styles from './Step.module.css';
 
@@ -75,6 +77,15 @@ export default function Step({
             onChange={(e) => handleChange(field.id, e.target.value)}
           />
         );
+      case 'group':
+        return (
+          <GroupField
+            key={field.id}
+            field={field}
+            value={formData[field.id] || []}
+            onChange={(val) => handleChange(field.id, val)}
+          />
+        );
       default:
         return null;
     }
@@ -114,7 +125,23 @@ export default function Step({
             showAlert={sectionHasMissing(sec)}
           >
             {sec.content && <ReactMarkdown>{sec.content}</ReactMarkdown>}
-            {sec.fields && sec.fields.map((field) => renderField(field))}
+            {sec.type === 'group' ? (
+              <GroupField
+                field={sec}
+                value={formData[sec.id] || []}
+                onChange={(val) => handleChange(sec.id, val)}
+              />
+            ) : sec.ui?.layout === 'table' ? (
+              <TableLayout
+                fields={sec.fields || []}
+                formData={formData}
+                onChange={handleChange}
+                errors={{}}
+                ui={sec.ui}
+              />
+            ) : (
+              sec.fields && sec.fields.map((field) => renderField(field))
+            )}
           </Section>
         );
       })}

--- a/test-form/src/components/shared/GroupField/GroupField.jsx
+++ b/test-form/src/components/shared/GroupField/GroupField.jsx
@@ -1,0 +1,119 @@
+import React, { useState, useEffect } from 'react';
+import TextInput from '../TextInput/TextInput';
+import SelectField from '../SelectField/SelectField';
+import RadioGroup from '../RadioGroup/RadioGroup';
+
+export default function GroupField({ field, value = [], onChange }) {
+  const [entries, setEntries] = useState(value);
+  const [currentEntry, setCurrentEntry] = useState({});
+  const [editingIndex, setEditingIndex] = useState(null);
+  const [showForm, setShowForm] = useState(false);
+
+  useEffect(() => {
+    setEntries(Array.isArray(value) ? value : []);
+  }, [value]);
+
+  const handleInputChange = (id, val) => {
+    setCurrentEntry((prev) => ({ ...prev, [id]: val }));
+  };
+
+  const handleSave = () => {
+    const updated = [...entries];
+    if (editingIndex !== null) {
+      updated[editingIndex] = currentEntry;
+    } else {
+      updated.push(currentEntry);
+    }
+    setEntries(updated);
+    onChange && onChange(updated);
+    setCurrentEntry({});
+    setEditingIndex(null);
+    setShowForm(false);
+  };
+
+  const handleEdit = (idx) => {
+    setCurrentEntry(entries[idx]);
+    setEditingIndex(idx);
+    setShowForm(true);
+  };
+
+  const handleDelete = (idx) => {
+    const updated = entries.filter((_, i) => i !== idx);
+    setEntries(updated);
+    onChange && onChange(updated);
+  };
+
+  const handleCancel = () => {
+    setShowForm(false);
+    setCurrentEntry({});
+    setEditingIndex(null);
+  };
+
+  const renderField = (subField) => {
+    const commonProps = {
+      id: subField.id,
+      label: subField.label,
+      required: subField.required,
+      value: currentEntry[subField.id] || '',
+      onChange: (e) => handleInputChange(subField.id, e.target ? e.target.value : e),
+    };
+    switch (subField.type) {
+      case 'select':
+        return (
+          <SelectField key={subField.id} options={subField.ui?.options || []} {...commonProps} />
+        );
+      case 'radio':
+        return (
+          <RadioGroup key={subField.id} options={subField.ui?.options || []} {...commonProps} />
+        );
+      case 'date':
+      case 'time':
+        return <TextInput key={subField.id} type={subField.type} {...commonProps} />;
+      default:
+        return <TextInput key={subField.id} {...commonProps} />;
+    }
+  };
+
+  return (
+    <div className="group-field">
+      <h4>{field.label}</h4>
+      {entries.length > 0 && (
+        <table className="modern-table">
+          <thead>
+            <tr>
+              {field.fields.map((f) => (
+                <th key={f.id}>{f.label}</th>
+              ))}
+              <th>Actions</th>
+            </tr>
+          </thead>
+          <tbody>
+            {entries.map((item, idx) => (
+              <tr key={idx}>
+                {field.fields.map((f) => (
+                  <td key={f.id}>{item[f.id]}</td>
+                ))}
+                <td>
+                  <button onClick={() => handleEdit(idx)}>Edit</button>
+                  <button onClick={() => handleDelete(idx)}>Delete</button>
+                </td>
+              </tr>
+            ))}
+          </tbody>
+        </table>
+      )}
+      <button onClick={() => { setShowForm(true); setEditingIndex(null); setCurrentEntry({}); }}>
+        Add {field.label}
+      </button>
+      {showForm && (
+        <div className="group-entry-form">
+          {field.fields.map(renderField)}
+          <div className="form-actions">
+            <button onClick={handleSave}>Save</button>
+            <button onClick={handleCancel}>Cancel</button>
+          </div>
+        </div>
+      )}
+    </div>
+  );
+}

--- a/test-form/src/components/shared/TableLayout/TableLayout.jsx
+++ b/test-form/src/components/shared/TableLayout/TableLayout.jsx
@@ -1,0 +1,98 @@
+import React, { useState } from 'react';
+
+export default function TableLayout({ fields = [], formData = {}, onChange, errors = {}, ui = {} }) {
+  const [copySourceDay, setCopySourceDay] = useState('');
+
+  const groupedRows = fields.reduce((acc, field) => {
+    const row = field.ui?.rowGroup || 'default';
+    acc[row] = acc[row] || [];
+    acc[row].push(field);
+    return acc;
+  }, {});
+
+  const handleCopySchedule = () => {
+    const { rowCopy } = ui || {};
+    if (!rowCopy || !copySourceDay) return;
+
+    const sourceFields = fields.filter(
+      (f) => f.ui?.rowGroup === copySourceDay && rowCopy.fieldsToCopy.includes(f.ui?.column)
+    );
+
+    const sourceValues = Object.fromEntries(
+      sourceFields.map((f) => [f.ui?.column, formData[f.id]])
+    );
+
+    rowCopy.targetRowValues.forEach((row) => {
+      if (row === copySourceDay) return;
+      fields.forEach((field) => {
+        if (field.ui?.rowGroup === row && rowCopy.fieldsToCopy.includes(field.ui?.column)) {
+          const val = sourceValues[field.ui?.column];
+          if (val !== undefined) {
+            onChange && onChange(field.id, val);
+          }
+        }
+      });
+    });
+  };
+
+  const columnHeaders = ui.columns || [];
+
+  return (
+    <div className="form-table-layout">
+      {ui.rowCopy?.enableUserPickSource && (
+        <div className="copy-controls">
+          <label>
+            Copy schedule from:
+            <select value={copySourceDay} onChange={(e) => setCopySourceDay(e.target.value)}>
+              <option value="">Select row</option>
+              {ui.rowCopy.sourceOptions.map((day) => (
+                <option key={day} value={day}>{day}</option>
+              ))}
+            </select>
+          </label>
+          <button type="button" onClick={handleCopySchedule} disabled={!copySourceDay}>
+            {ui.rowCopy.copyControlLabel || 'Copy row'}
+          </button>
+        </div>
+      )}
+      <table className="form-table">
+        <thead>
+          <tr>
+            <th>Day</th>
+            {columnHeaders.map((h, i) => (
+              <th key={`th-${i}`}>{h}</th>
+            ))}
+          </tr>
+        </thead>
+        <tbody>
+          {Object.entries(groupedRows).map(([rowLabel, rowFields], rowIdx) => {
+            const sorted = rowFields.slice().sort((a, b) => (a.ui?.column || 0) - (b.ui?.column || 0));
+            return (
+              <tr key={`tr-${rowIdx}`}>
+                <td>{rowLabel}</td>
+                {sorted.map((field, colIdx) => {
+                  const id = field.id;
+                  const val = formData[id] || '';
+                  const err = errors[id];
+                  return (
+                    <td key={`td-${rowIdx}-${colIdx}`}>
+                      <input
+                        type={field.type || 'text'}
+                        name={id}
+                        placeholder={field.ui?.placeholder || ''}
+                        value={val}
+                        onChange={(e) => onChange && onChange(id, e.target.value)}
+                        className={err ? 'error' : ''}
+                      />
+                      {err && <div className="form-error-alert">{err}</div>}
+                    </td>
+                  );
+                })}
+              </tr>
+            );
+          })}
+        </tbody>
+      </table>
+    </div>
+  );
+}


### PR DESCRIPTION
## Summary
- support grouped fields with add/edit/delete actions
- implement table layout with optional copy controls
- wire new components into Step rendering logic

## Testing
- `npm test` *(fails: react-scripts not found)*

------
https://chatgpt.com/codex/tasks/task_e_6840fa48303c8331a59b9597545fdf97