### PR TITLE
Extend components for file and masked inputs

### DIFF
--- a/test-form/src/components/FormComponent.jsx
+++ b/test-form/src/components/FormComponent.jsx
@@ -1,5 +1,6 @@
 import React, { useState, useEffect } from "react";
-import { IMaskInput } from 'react-imask';
+import FileInput from './shared/FileInput/FileInput';
+import MaskedInput from './shared/MaskedInput/MaskedInput';
 import ReactMarkdown from "react-markdown";
 import { evaluateCondition, validateStep, cleanupHiddenFields } from "../utils/formHelpers";
 
@@ -1951,11 +1952,10 @@ Object.keys(groupData).forEach(fieldId => {
             })}
           </div>
         ) : f.id === "ssn" ? (
-            <IMaskInput
+            <MaskedInput
               mask="000-00-0000"
               value={value}
-              unmask={false}
-              onAccept={(val) => onChange(f.id, val)}
+              onChange={(val) => onChange(f.id, val)}
               className={"form-input" + (error ? " error" : "")}
               placeholder={f.ui?.placeholder || "123-45-6789"}
             />
@@ -2580,8 +2580,7 @@ Object.keys(groupData).forEach(fieldId => {
 
     const commonProps = {
       ...Object.fromEntries(Object.entries(attrs).filter(([_, v]) => v !== undefined)),
-      className: "form-input" + (error ? " error" : ""),
-      onChange: (e) => handleChange(id, e.target.files ? e.target.files[0] : e.target.value)
+      className: "form-input" + (error ? " error" : "")
     };
 
     const errorElement = error ? <div className="form-error-alert">{error}</div> : null;
@@ -2598,14 +2597,10 @@ Object.keys(groupData).forEach(fieldId => {
               Examples: {metadata.examples.join(", ")}
             </div>
           )}
-          <input
-            type="file"
+          <FileInput
             {...commonProps}
             multiple={metadata.multiple || false}
-            onChange={(e) => {
-              const files = e.target.files;
-              handleChange(id, metadata.multiple ? Array.from(files) : files[0]);
-            }}
+            onChange={(files) => handleChange(id, files)}
           />
           {errorElement}
         </label>
@@ -2732,7 +2727,7 @@ Object.keys(groupData).forEach(fieldId => {
           {(field.required === true || (field.requiredCondition && evaluateCondition(field.requiredCondition.condition, formData))) && (
             <span className="required-asterisk"> *</span>
           )}
-          <textarea {...commonProps}></textarea>
+          <textarea {...commonProps} onChange={(e) => handleChange(id, e.target.value)}></textarea>
           {errorElement}
         </label>
       );
@@ -2855,11 +2850,10 @@ Object.keys(groupData).forEach(fieldId => {
             {(field.required === true || (field.requiredCondition && evaluateCondition(field.requiredCondition.condition, formData))) && (
               <span className="required-asterisk"> *</span>
             )}
-            <IMaskInput
+            <MaskedInput
               mask="(000) 000-0000"
               value={value}
-              unmask={false}
-              onAccept={(val) => handleChange(id, val)}
+              onChange={(val) => handleChange(id, val)}
               className={"form-input" + (error ? " error" : "")}
               placeholder="(123) 456-7890"
             />
@@ -2875,11 +2869,10 @@ Object.keys(groupData).forEach(fieldId => {
               <span className="required-asterisk"> *</span>
             )}
             {label}
-              <IMaskInput
+              <MaskedInput
                 mask="000-00-0000"
                 value={value}
-                unmask={false}
-                onAccept={(val) => handleChange(id, val)}
+                onChange={(val) => handleChange(id, val)}
                 className={"form-input" + (error ? " error" : "")}
                 placeholder="123-45-6789"
               />
@@ -2894,7 +2887,12 @@ Object.keys(groupData).forEach(fieldId => {
         {(field.required === true || (field.requiredCondition && evaluateCondition(field.requiredCondition.condition, formData))) && (
           <span className="required-asterisk"> *</span>
         )}
-        <input type={type} value={value} {...commonProps} />
+        <input
+          type={type}
+          value={value}
+          {...commonProps}
+          onChange={(e) => handleChange(id, e.target.value)}
+        />
         {errorElement}
       </label>
     );

--- a/test-form/src/components/shared/FileInput/FileInput.jsx
+++ b/test-form/src/components/shared/FileInput/FileInput.jsx
@@ -1,0 +1,25 @@
+import React from 'react';
+import styles from './FileInput.module.css';
+
+export default function FileInput({ id, label, multiple = false, error, onChange, ...props }) {
+  const handleFileChange = (e) => {
+    const files = e.target.files;
+    if (!onChange) return;
+    onChange(multiple ? Array.from(files) : files[0]);
+  };
+
+  return (
+    <div className={styles.field}>
+      {label && <label htmlFor={id}>{label}</label>}
+      <input
+        id={id}
+        type="file"
+        multiple={multiple}
+        onChange={handleFileChange}
+        className={`${styles.input}${error ? ' error' : ''}`}
+        {...props}
+      />
+      {error && <div className="form-error-alert">{error}</div>}
+    </div>
+  );
+}

--- a/test-form/src/components/shared/FileInput/FileInput.module.css
+++ b/test-form/src/components/shared/FileInput/FileInput.module.css
@@ -1,0 +1,2 @@
+.field { margin-bottom: 1rem; }
+.input { width: 100%; padding: 0.5rem; }

--- a/test-form/src/components/shared/GroupField/GroupField.jsx
+++ b/test-form/src/components/shared/GroupField/GroupField.jsx
@@ -2,6 +2,8 @@ import React, { useState, useEffect } from 'react';
 import TextInput from '../TextInput/TextInput';
 import SelectField from '../SelectField/SelectField';
 import RadioGroup from '../RadioGroup/RadioGroup';
+import FileInput from '../FileInput/FileInput';
+import MaskedInput from '../MaskedInput/MaskedInput';
 
 export default function GroupField({ field, value = [], onChange }) {
   const [entries, setEntries] = useState(value);
@@ -69,7 +71,42 @@ export default function GroupField({ field, value = [], onChange }) {
       case 'date':
       case 'time':
         return <TextInput key={subField.id} type={subField.type} {...commonProps} />;
+      case 'file':
+        return (
+          <FileInput
+            key={subField.id}
+            multiple={subField.metadata?.multiple}
+            {...commonProps}
+          />
+        );
       default:
+        if (
+          subField.id === 'ssn' ||
+          subField.label?.toLowerCase().includes('social security')
+        ) {
+          return (
+            <MaskedInput
+              key={subField.id}
+              mask="000-00-0000"
+              placeholder="123-45-6789"
+              {...commonProps}
+            />
+          );
+        }
+        if (
+          subField.type === 'tel' ||
+          subField.id.includes('telephone') ||
+          subField.label?.toLowerCase().includes('phone')
+        ) {
+          return (
+            <MaskedInput
+              key={subField.id}
+              mask="(000) 000-0000"
+              placeholder="(123) 456-7890"
+              {...commonProps}
+            />
+          );
+        }
         return <TextInput key={subField.id} {...commonProps} />;
     }
   };

--- a/test-form/src/components/shared/MaskedInput/MaskedInput.jsx
+++ b/test-form/src/components/shared/MaskedInput/MaskedInput.jsx
@@ -1,0 +1,22 @@
+import React from 'react';
+import { IMaskInput } from 'react-imask';
+import styles from './MaskedInput.module.css';
+
+export default function MaskedInput({ id, label, mask, error, onChange, value, placeholder, ...props }) {
+  return (
+    <div className={styles.field}>
+      {label && <label htmlFor={id}>{label}</label>}
+      <IMaskInput
+        id={id}
+        mask={mask}
+        value={value}
+        unmask={false}
+        onAccept={(val) => onChange && onChange(val)}
+        placeholder={placeholder}
+        className={`${styles.input}${error ? ' error' : ''}`}
+        {...props}
+      />
+      {error && <div className="form-error-alert">{error}</div>}
+    </div>
+  );
+}

--- a/test-form/src/components/shared/MaskedInput/MaskedInput.module.css
+++ b/test-form/src/components/shared/MaskedInput/MaskedInput.module.css
@@ -1,0 +1,2 @@
+.field { margin-bottom: 1rem; }
+.input { width: 100%; padding: 0.5rem; }


### PR DESCRIPTION
## Summary
- add new `FileInput` component
- add new `MaskedInput` component
- update `GroupField` to use the new inputs
- refactor `FormComponent` to use shared inputs and wire up change handlers

## Testing
- `npm test --silent` *(fails: react-scripts not found)*

------
https://chatgpt.com/codex/tasks/task_e_6840ff7a43a48331abc4d831b937c2cb