### PR TITLE
Add required docs sidebar

### DIFF
--- a/test-form/src/components/core/FormRenderer/FormRenderer.jsx
+++ b/test-form/src/components/core/FormRenderer/FormRenderer.jsx
@@ -8,6 +8,13 @@ export default function FormRenderer() {
   const steps = form.steps || [];
   const [currentStep, setCurrentStep] = useState(0);
 
+  const requiredDocs =
+    steps[currentStep]?.sections?.flatMap((section) =>
+      (section.fields || [])
+        .filter((f) => f.type === 'file' && f.required)
+        .map((f) => f.label)
+    ) || [];
+
   const handleNext = () => {
     setCurrentStep((s) => Math.min(s + 1, steps.length - 1));
   };
@@ -22,6 +29,7 @@ export default function FormRenderer() {
         steps={steps}
         currentStep={currentStep}
         onStepChange={setCurrentStep}
+        requiredDocs={requiredDocs}
       />
       <div className="form-main">
         <h1>{form.title}</h1>

--- a/test-form/src/components/core/Stepper/Stepper.jsx
+++ b/test-form/src/components/core/Stepper/Stepper.jsx
@@ -1,7 +1,12 @@
 import React from 'react';
 import styles from './Stepper.module.css';
 
-export default function Stepper({ steps = [], currentStep = 0, onStepChange }) {
+export default function Stepper({
+  steps = [],
+  currentStep = 0,
+  onStepChange,
+  requiredDocs = [],
+}) {
   return (
     <aside className={styles.sidebar}>
       <h4>Steps</h4>
@@ -16,6 +21,16 @@ export default function Stepper({ steps = [], currentStep = 0, onStepChange }) {
           </li>
         ))}
       </ul>
+      {requiredDocs.length > 0 && (
+        <div className={styles.requiredDocs}>
+          <h5>Required Documents</h5>
+          <ul>
+            {requiredDocs.map((doc) => (
+              <li key={doc}>{doc}</li>
+            ))}
+          </ul>
+        </div>
+      )}
     </aside>
   );
 }

--- a/test-form/src/components/core/Stepper/Stepper.module.css
+++ b/test-form/src/components/core/Stepper/Stepper.module.css
@@ -21,3 +21,13 @@
   color: white;
   font-weight: 600;
 }
+
+.requiredDocs {
+  margin-top: 2rem;
+}
+
+.requiredDocs ul {
+  list-style: disc;
+  padding-left: 1.2rem;
+  margin: 0;
+}


### PR DESCRIPTION
## Summary
- show required docs in Stepper sidebar
- compute required docs on step change

## Testing
- `npm test -- --watchAll=false` *(fails: react-scripts not found)*

------
https://chatgpt.com/codex/tasks/task_e_6841019c36448331aaf8e593eacd133e