### PR TITLE
Add CheckboxGroup and integrate

### DIFF
--- a/test-form/src/components/core/Step/Step.jsx
+++ b/test-form/src/components/core/Step/Step.jsx
@@ -5,6 +5,7 @@ import InfoSection from '../InfoSection/InfoSection';
 import TextInput from '../../shared/TextInput/TextInput';
 import SelectField from '../../shared/SelectField/SelectField';
 import RadioGroup from '../../shared/RadioGroup/RadioGroup';
+import CheckboxGroup from '../../shared/CheckboxGroup/CheckboxGroup';
 import GroupField from '../../shared/GroupField/GroupField';
 import TableLayout from '../../shared/TableLayout/TableLayout';
 import MaskedInput from '../../shared/MaskedInput/MaskedInput';
@@ -94,6 +95,36 @@ export default function Step({
               value={formData[field.id] || ''}
               onChange={(e) => handleChange(field.id, e.target.value)}
             />
+            {error && <div className="form-error-alert">{error}</div>}
+          </>
+        );
+      case 'checkbox':
+        if (field.metadata?.multiple) {
+          return (
+            <>
+              <CheckboxGroup
+                key={field.id}
+                id={field.id}
+                label={field.label}
+                options={field.ui?.options || []}
+                value={formData[field.id] || []}
+                onChange={(val) => handleChange(field.id, val)}
+                required={field.required}
+              />
+              {error && <div className="form-error-alert">{error}</div>}
+            </>
+          );
+        }
+        return (
+          <>
+            <input
+              key={field.id}
+              type="checkbox"
+              id={field.id}
+              checked={!!formData[field.id]}
+              onChange={(e) => handleChange(field.id, e.target.checked)}
+            />
+            {field.label && <label htmlFor={field.id}>{field.label}</label>}
             {error && <div className="form-error-alert">{error}</div>}
           </>
         );

--- a/test-form/src/components/shared/CheckboxGroup/CheckboxGroup.jsx
+++ b/test-form/src/components/shared/CheckboxGroup/CheckboxGroup.jsx
@@ -1,0 +1,36 @@
+import React from 'react';
+import styles from './CheckboxGroup.module.css';
+
+export default function CheckboxGroup({ id, label, options = [], value = [], onChange, ...props }) {
+  const handleChange = (optionValue, checked) => {
+    if (!onChange) return;
+    const updated = checked
+      ? [...(Array.isArray(value) ? value : []), optionValue]
+      : (Array.isArray(value) ? value : []).filter(v => v !== optionValue);
+    onChange(updated);
+  };
+
+  return (
+    <fieldset className={styles.group}>
+      {label && <legend>{label}</legend>}
+      {options.map(opt => {
+        const optValue = typeof opt === 'string' ? opt : opt.value;
+        const optLabel = typeof opt === 'string' ? opt : opt.label;
+        const checked = Array.isArray(value) && value.includes(optValue);
+        return (
+          <label key={optValue} className={styles.option}>
+            <input
+              type="checkbox"
+              name={id}
+              value={optValue}
+              checked={checked}
+              onChange={e => handleChange(optValue, e.target.checked)}
+              {...props}
+            />
+            {optLabel}
+          </label>
+        );
+      })}
+    </fieldset>
+  );
+}

--- a/test-form/src/components/shared/CheckboxGroup/CheckboxGroup.module.css
+++ b/test-form/src/components/shared/CheckboxGroup/CheckboxGroup.module.css
@@ -1,0 +1,2 @@
+.group { margin-bottom: 1rem; }
+.option { margin-right: 0.5rem; }


### PR DESCRIPTION
## Summary
- add `CheckboxGroup` component to render multi-select checkboxes
- integrate checkbox support in `Step` component when metadata.multiple is true
- load race options correctly

## Testing
- `npm test --silent --runInBand` *(fails: react-scripts not found)*

------
https://chatgpt.com/codex/tasks/task_e_68410cf5ba708331a7a21588cb7ae92e