### PR TITLE
Add multi-select support

### DIFF
--- a/test-form/src/components/core/Step/Step.jsx
+++ b/test-form/src/components/core/Step/Step.jsx
@@ -69,6 +69,30 @@ export default function Step({
           />
         );
       case 'select':
+        if (field.metadata?.multiple) {
+          return (
+            <>
+              <SelectField
+                key={field.id}
+                id={field.id}
+                label={field.label}
+                options={field.ui?.options || []}
+                required={field.required}
+                multiple
+                minSelections={field.constraints?.minSelections}
+                maxSelections={field.constraints?.maxSelections}
+                value={formData[field.id] || []}
+                onChange={(e) =>
+                  handleChange(
+                    field.id,
+                    Array.from(e.target.selectedOptions).map((opt) => opt.value)
+                  )
+                }
+              />
+              {error && <div className="form-error-alert">{error}</div>}
+            </>
+          );
+        }
         return (
           <>
             <SelectField

--- a/test-form/src/components/shared/SelectField/SelectField.jsx
+++ b/test-form/src/components/shared/SelectField/SelectField.jsx
@@ -1,14 +1,35 @@
 import React from 'react';
 import styles from './SelectField.module.css';
 
-export default function SelectField({ id, label, options = [], ...props }) {
+export default function SelectField({
+  id,
+  label,
+  options = [],
+  multiple = false,
+  minSelections,
+  maxSelections,
+  ...props
+}) {
   return (
     <div className={styles.field}>
       {label && <label htmlFor={id}>{label}</label>}
-      <select id={id} className={styles.select} {...props}>
-        {options.map(opt => (
-          <option key={opt} value={opt}>{opt}</option>
-        ))}
+      <select
+        id={id}
+        className={styles.select}
+        multiple={multiple}
+        data-min={minSelections}
+        data-max={maxSelections}
+        {...props}
+      >
+        {options.map((opt) => {
+          const value = typeof opt === 'string' ? opt : opt.value;
+          const labelText = typeof opt === 'string' ? opt : opt.label;
+          return (
+            <option key={value} value={value}>
+              {labelText}
+            </option>
+          );
+        })}
       </select>
     </div>
   );


### PR DESCRIPTION
## Summary
- extend SelectField to support `multiple`, `minSelections`, and `maxSelections`
- allow Step component to render multi-select fields

## Testing
- `npm test -- -u` *(fails: react-scripts not found)*

------
https://chatgpt.com/codex/tasks/task_e_68410e16a8808331839bc0679cecce2a