### PR TITLE
Implement group handling in Step component

### DIFF
--- a/test-form/src/components/core/Step/Step.jsx
+++ b/test-form/src/components/core/Step/Step.jsx
@@ -33,6 +33,16 @@ export default function Step({
     setFormData((prev) => ({ ...prev, [id]: value }));
   };
 
+  const groupFieldsByGroup = (fields = []) => {
+    const grouped = {};
+    fields.forEach((f) => {
+      const group = f.ui?.group || 'default';
+      if (!grouped[group]) grouped[group] = [];
+      grouped[group].push(f);
+    });
+    return grouped;
+  };
+
   const renderField = (field) => {
     const error = errors[field.id];
     switch (field.type) {
@@ -293,7 +303,23 @@ export default function Step({
                 ui={sec.ui}
               />
             ) : (
-              sec.fields && sec.fields.map((field) => renderField(field))
+              Object.entries(groupFieldsByGroup(sec.fields || [])).map(
+                ([groupKey, groupFields], idx) => (
+                  <div
+                    key={`${sec.id}-${groupKey}-${idx}`}
+                    className="form-group-wrapper"
+                  >
+                    {groupKey !== 'default' && (
+                      <div className="form-group-heading">
+                        {groupFields[0].ui?.groupLabel || groupKey}
+                      </div>
+                    )}
+                    <div className="form-subgroup-grid grid gap-4">
+                      {groupFields.map((field) => renderField(field))}
+                    </div>
+                  </div>
+                )
+              )
             )}
           </Section>
         );


### PR DESCRIPTION
## Summary
- add `groupFieldsByGroup` helper to `Step`
- display form fields grouped using `ui.group` and `ui.groupLabel`

## Testing
- `npm test --silent -- -u` *(fails: react-scripts not found)*

------
https://chatgpt.com/codex/tasks/task_e_68410ecb5cd083318114e3e618847078