### PR TITLE
Initialize collapsed sections from default

### DIFF
--- a/test-form/src/components/core/Step/Step.jsx
+++ b/test-form/src/components/core/Step/Step.jsx
@@ -1,4 +1,4 @@
-import React, { useState } from 'react';
+import React, { useState, useEffect } from 'react';
 import Section from '../Section/Section';
 import InfoSection from '../InfoSection/InfoSection';
 import TextInput from '../../shared/TextInput/TextInput';
@@ -17,8 +17,26 @@ export default function Step({
   isFirst = false,
   isLast = false,
 }) {
-  const [collapsedSections, setCollapsedSections] = useState({});
+  const [collapsedSections, setCollapsedSections] = useState(() => {
+    const collapsed = {};
+    sections.forEach((s) => {
+      if (s.ui?.defaultCollapsed) {
+        collapsed[s.id] = true;
+      }
+    });
+    return collapsed;
+  });
   const [formData, setFormData] = useState({});
+
+  useEffect(() => {
+    const collapsed = {};
+    sections.forEach((s) => {
+      if (s.ui?.defaultCollapsed) {
+        collapsed[s.id] = true;
+      }
+    });
+    setCollapsedSections(collapsed);
+  }, [sections]);
 
   const handleToggle = (id) => {
     setCollapsedSections((prev) => ({ ...prev, [id]: !prev[id] }));


### PR DESCRIPTION
## Summary
- update Step component to import `useEffect`
- initialize `collapsedSections` from each section's `defaultCollapsed` value
- update `collapsedSections` state when `sections` change

## Testing
- `npm test --silent -- --watchAll=false` *(fails: react-scripts not found)*

------
https://chatgpt.com/codex/tasks/task_e_6841087a26248331a4caf16348d50be0