### PR TITLE
Update handleChange to clear errors on valid input

### DIFF
--- a/test-form/src/components/core/Step/Step.jsx
+++ b/test-form/src/components/core/Step/Step.jsx
@@ -30,7 +30,26 @@ export default function Step({
   };
 
   const handleChange = (id, value) => {
-    setFormData((prev) => ({ ...prev, [id]: value }));
+    const updatedData = { ...formData, [id]: value };
+    setFormData(updatedData);
+
+    // Remove existing error for this field
+    let updatedErrors = { ...errors };
+    delete updatedErrors[id];
+
+    // Revalidate the single field using validateStep
+    const { errors: validationErrors } = validateStep(
+      { sections },
+      updatedData,
+      [],
+      {}
+    );
+
+    if (validationErrors[id]) {
+      updatedErrors[id] = validationErrors[id];
+    }
+
+    setErrors(updatedErrors);
   };
 
   const groupFieldsByGroup = (fields = []) => {


### PR DESCRIPTION
## Summary
- update `handleChange` in `Step.jsx` to remove a field's errors and revalidate after each change

## Testing
- `npm test -- --watchAll=false` *(fails: react-scripts not found)*

------
https://chatgpt.com/codex/tasks/task_e_684114eb608883318e83febb4b774552