### PR TITLE
Update step navigation to clean hidden fields

### DIFF
--- a/test-form/src/components/core/Step/Step.jsx
+++ b/test-form/src/components/core/Step/Step.jsx
@@ -1,5 +1,9 @@
 import React, { useState, useEffect } from 'react';
-import { validateStep, evaluateCondition } from '../../../utils/formHelpers';
+import {
+  validateStep,
+  evaluateCondition,
+  cleanupHiddenFields,
+} from '../../../utils/formHelpers';
 import Section from '../Section/Section';
 import InfoSection from '../InfoSection/InfoSection';
 import TextInput from '../../shared/TextInput/TextInput';
@@ -298,6 +302,8 @@ export default function Step({
     );
     setErrors(result.errors);
     if (!result.valid) return;
+    const cleaned = cleanupHiddenFields({ sections }, formData);
+    setFormData(cleaned);
     onNext && onNext();
   };
 


### PR DESCRIPTION
## Summary
- keep hidden form fields out of form data when moving to the next step

## Testing
- `npm test --silent` *(fails: react-scripts not found)*

------
https://chatgpt.com/codex/tasks/task_e_684118ac85bc8331b638c6960539229f