### PR TITLE
Add stepper layout options

### DIFF
--- a/test-form/src/components/core/FormRenderer/FormRenderer.jsx
+++ b/test-form/src/components/core/FormRenderer/FormRenderer.jsx
@@ -7,6 +7,8 @@ export default function FormRenderer() {
   const { form } = formSpec;
   const steps = form.steps || [];
   const [currentStep, setCurrentStep] = useState(0);
+  const stepperPosition = form.layout?.stepperPosition || 'right';
+  const orientation = stepperPosition === 'top' ? 'horizontal' : 'vertical';
 
   const requiredDocs =
     steps[currentStep]?.sections?.flatMap((section) =>
@@ -24,16 +26,28 @@ export default function FormRenderer() {
   };
 
   return (
-    <div className="wizard-layout-row">
-      <Stepper
-        steps={steps}
-        currentStep={currentStep}
-        onStepChange={setCurrentStep}
-        requiredDocs={requiredDocs}
-      />
+    <div className={stepperPosition === 'top' ? 'wizard-layout-column' : 'wizard-layout-row'}>
+      {stepperPosition !== 'top' && (
+        <Stepper
+          steps={steps}
+          currentStep={currentStep}
+          onStepChange={setCurrentStep}
+          requiredDocs={requiredDocs}
+          orientation={orientation}
+        />
+      )}
       <div className="form-main">
         <h1>{form.title}</h1>
         <p>{form.description}</p>
+        {stepperPosition === 'top' && (
+          <Stepper
+            steps={steps}
+            currentStep={currentStep}
+            onStepChange={setCurrentStep}
+            requiredDocs={requiredDocs}
+            orientation={orientation}
+          />
+        )}
         {steps.length > 0 && (
           <Step
             key={steps[currentStep].id}

--- a/test-form/src/components/core/Stepper/Stepper.jsx
+++ b/test-form/src/components/core/Stepper/Stepper.jsx
@@ -6,16 +6,29 @@ export default function Stepper({
   currentStep = 0,
   onStepChange,
   requiredDocs = [],
+  orientation = 'vertical',
+  canNavigate,
 }) {
+  const isHorizontal = orientation === 'horizontal';
+  const containerClass = isHorizontal ? styles.horizontalContainer : styles.sidebar;
+  const listClass = isHorizontal ? styles.horizontalList : styles.list;
+  const itemClass = isHorizontal ? styles.horizontalItem : styles.item;
+
+  const handleClick = (idx) => {
+    if (idx === currentStep) return;
+    if (canNavigate && !canNavigate(idx)) return;
+    onStepChange && onStepChange(idx);
+  };
+
   return (
-    <aside className={styles.sidebar}>
+    <aside className={containerClass}>
       <h4>Steps</h4>
-      <ul className={styles.list}>
+      <ul className={listClass}>
         {steps.map((step, index) => (
           <li
             key={step.id}
-            className={`${styles.item} ${index === currentStep ? styles.active : ''}`}
-            onClick={() => onStepChange && onStepChange(index)}
+            className={`${itemClass} ${index === currentStep ? styles.active : ''}`}
+            onClick={() => handleClick(index)}
           >
             {step.title}
           </li>

--- a/test-form/src/components/core/Stepper/Stepper.module.css
+++ b/test-form/src/components/core/Stepper/Stepper.module.css
@@ -2,14 +2,34 @@
   width: 250px;
   flex-shrink: 0;
 }
+.horizontalContainer {
+  width: 100%;
+  margin-bottom: 1rem;
+}
 .list {
   list-style: none;
   padding: 0;
   margin: 0;
 }
+.horizontalList {
+  list-style: none;
+  padding: 0;
+  margin: 0;
+  display: flex;
+  gap: 0.5rem;
+}
 .item {
   padding: 0.6rem 1rem;
   margin-bottom: 0.5rem;
+  background: #f3f4f6;
+  border-radius: 20px;
+  font-size: 0.95rem;
+  cursor: pointer;
+  transition: background 0.2s;
+}
+.horizontalItem {
+  padding: 0.6rem 1rem;
+  margin-right: 0.5rem;
   background: #f3f4f6;
   border-radius: 20px;
   font-size: 0.95rem;

--- a/test-form/src/form.css
+++ b/test-form/src/form.css
@@ -23,6 +23,11 @@ body, html, #root {
   min-height: 100vh;
   overflow: hidden;
 }
+.wizard-layout-column {
+  display: flex;
+  flex-direction: column;
+  min-height: 100vh;
+}
 
 .form-stepper-sidebar {
   width: 250px;


### PR DESCRIPTION
## Summary
- support horizontal orientation for Stepper
- render stepper at top or side in FormRenderer
- style stepper variations

## Testing
- `npm test --silent` *(fails: react-scripts not found)*

------
https://chatgpt.com/codex/tasks/task_e_6841197f94e083318bc39ded4fbb1137