### PR TITLE
Add GroupField tests

### DIFF
--- a/test-form/src/components/shared/GroupField/GroupField.test.js
+++ b/test-form/src/components/shared/GroupField/GroupField.test.js
@@ -1,0 +1,37 @@
+import { render, screen } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import GroupField from './GroupField';
+
+describe('GroupField component', () => {
+  const field = {
+    id: 'children',
+    label: 'Child',
+    fields: [
+      { id: 'name', label: 'Name', type: 'text' },
+      { id: 'age', label: 'Age', type: 'text' },
+    ],
+  };
+
+  test('syncs entries with value prop', () => {
+    const { rerender } = render(<GroupField field={field} value={[]} onChange={() => {}} />);
+    expect(screen.queryByText('Ann')).not.toBeInTheDocument();
+
+    const newVal = [{ name: 'Ann', age: '2' }];
+    rerender(<GroupField field={field} value={newVal} onChange={() => {}} />);
+    expect(screen.getByText('Ann')).toBeInTheDocument();
+  });
+
+  test('onChange receives updated array on save', async () => {
+    const user = userEvent.setup();
+    const handleChange = jest.fn();
+    render(<GroupField field={field} value={[]} onChange={handleChange} />);
+
+    await user.click(screen.getByText(/Add Child/i));
+    await user.type(screen.getByLabelText('Name'), 'John');
+    await user.type(screen.getByLabelText('Age'), '4');
+    await user.click(screen.getByText('Save'));
+
+    expect(handleChange).toHaveBeenCalledWith([{ name: 'John', age: '4' }]);
+    expect(screen.getByText('John')).toBeInTheDocument();
+  });
+});


### PR DESCRIPTION
## Summary
- add tests to ensure GroupField syncs with incoming value prop
- verify onChange passes the entire entry array

## Testing
- `npm test --silent -- src/components/shared/GroupField/GroupField.test.js` *(fails: react-scripts not found)*

------
https://chatgpt.com/codex/tasks/task_e_68411f37e1ec833190700c67682721fc