### PR TITLE
Add column layout for grouped fields

### DIFF
--- a/test-form/src/components/core/Step/Step.jsx
+++ b/test-form/src/components/core/Step/Step.jsx
@@ -346,11 +346,13 @@ export default function Step({
                 ui={sec.ui}
               />
             ) : (
-              Object.entries(groupFieldsByGroup(sec.fields || [])).map(
-                ([groupKey, groupFields], idx) => (
+              (() => {
+                const grouped = groupFieldsByGroup(sec.fields || []);
+                const entries = Object.entries(grouped);
+                const groups = entries.map(([groupKey, groupFields], idx) => (
                   <div
                     key={`${sec.id}-${groupKey}-${idx}`}
-                    className="form-group-wrapper"
+                    className="form-group-wrapper group-col"
                   >
                     {groupKey !== 'default' && (
                       <div className="form-group-heading">
@@ -361,8 +363,13 @@ export default function Step({
                       {groupFields.map((field) => renderField(field))}
                     </div>
                   </div>
-                )
-              )
+                ));
+                return entries.length > 1 ? (
+                  <div className="group-columns">{groups}</div>
+                ) : (
+                  groups
+                );
+              })()
             )}
           </Section>
         );

--- a/test-form/src/form.css
+++ b/test-form/src/form.css
@@ -416,6 +416,16 @@ button:disabled {
   border: 1px solid #e5e7eb;
 }
 
+.group-columns {
+  display: grid;
+  grid-template-columns: 1fr 1fr;
+  gap: 1rem;
+}
+
+.group-col {
+  min-width: 0;
+}
+
 .form-group-heading {
   font-size: 1.1rem;
   font-weight: 600;


### PR DESCRIPTION
## Summary
- wrap grouped fields in a grid container when multiple groups exist
- allow groups to display side-by-side using `.group-columns`
- add `.group-col` class to group wrappers

## Testing
- `npm test --silent` *(fails: react-scripts not found)*

------
https://chatgpt.com/codex/tasks/task_e_6841200099a0833183490b70b0cad53f