### PR TITLE
Refine RadioGroup component

### DIFF
--- a/test-form/src/components/shared/RadioGroup/RadioGroup.jsx
+++ b/test-form/src/components/shared/RadioGroup/RadioGroup.jsx
@@ -1,16 +1,34 @@
 import React from 'react';
 import styles from './RadioGroup.module.css';
 
-export default function RadioGroup({ id, label, options = [], ...props }) {
+export default function RadioGroup({
+  id,
+  label,
+  options = [],
+  value,
+  onChange,
+  ...props
+}) {
   return (
     <fieldset className={styles.group}>
       {label && <legend>{label}</legend>}
-      {options.map(opt => (
-        <label key={opt} className={styles.option}>
-          <input type="radio" name={id} value={opt} {...props} />
-          {opt}
-        </label>
-      ))}
+      {options.map(opt => {
+        const optValue = typeof opt === 'string' ? opt : opt.value;
+        const optLabel = typeof opt === 'string' ? opt : opt.label;
+        return (
+          <label key={optValue} className={styles.option}>
+            <input
+              type="radio"
+              name={id}
+              value={optValue}
+              checked={value === optValue}
+              onChange={onChange}
+              {...props}
+            />
+            {optLabel}
+          </label>
+        );
+      })}
     </fieldset>
   );
 }


### PR DESCRIPTION
## Summary
- improve RadioGroup radio option handling
- support explicit `value` and `onChange`

## Testing
- `npm test --silent` *(fails: react-scripts not found)*

------
https://chatgpt.com/codex/tasks/task_e_68412836b47883318258f553862f60a2