### PR TITLE
Add step data persistence

### DIFF
--- a/test-form/src/components/core/FormRenderer/FormRenderer.jsx
+++ b/test-form/src/components/core/FormRenderer/FormRenderer.jsx
@@ -7,6 +7,7 @@ export default function FormRenderer() {
   const { form } = formSpec;
   const steps = form.steps || [];
   const [currentStep, setCurrentStep] = useState(0);
+  const [stepData, setStepData] = useState({});
   const stepperPosition = form.layout?.stepperPosition || 'right';
   const orientation = stepperPosition === 'top' ? 'horizontal' : 'vertical';
 
@@ -17,11 +18,18 @@ export default function FormRenderer() {
         .map((f) => f.label)
     ) || [];
 
-  const handleNext = () => {
+  const handleDataChange = (data) => {
+    const stepId = steps[currentStep].id;
+    setStepData((prev) => ({ ...prev, [stepId]: data }));
+  };
+
+  const handleNext = (data) => {
+    handleDataChange(data);
     setCurrentStep((s) => Math.min(s + 1, steps.length - 1));
   };
 
-  const handleBack = () => {
+  const handleBack = (data) => {
+    handleDataChange(data);
     setCurrentStep((s) => Math.max(s - 1, 0));
   };
 
@@ -57,6 +65,8 @@ export default function FormRenderer() {
             onBack={handleBack}
             isFirst={currentStep === 0}
             isLast={currentStep === steps.length - 1}
+            formData={stepData[steps[currentStep].id] || {}}
+            onDataChange={handleDataChange}
           />
         )}
       </div>

--- a/test-form/src/components/core/Step/Step.jsx
+++ b/test-form/src/components/core/Step/Step.jsx
@@ -24,10 +24,17 @@ export default function Step({
   onBack,
   isFirst = false,
   isLast = false,
+  formData: initialData = {},
+  onDataChange,
 }) {
   const [collapsedSections, setCollapsedSections] = useState({});
-  const [formData, setFormData] = useState({});
+  const [formData, setFormData] = useState(initialData);
   const [errors, setErrors] = useState({});
+
+  // Update local form data when parent data changes (e.g., returning to a step)
+  useEffect(() => {
+    setFormData(initialData);
+  }, [initialData]);
 
   // Initialize collapsed sections based on defaultCollapsed when sections change
   useEffect(() => {
@@ -57,6 +64,7 @@ export default function Step({
         if (ve[id]) cleared[id] = ve[id];
         return cleared;
       });
+      onDataChange && onDataChange(next);
       return next;
     });
   };
@@ -298,7 +306,8 @@ export default function Step({
     if (!result.valid) return;
     const cleaned = cleanupHiddenFields({ sections }, formData);
     setFormData(cleaned);
-    onNext && onNext();
+    onDataChange && onDataChange(cleaned);
+    onNext && onNext(cleaned);
   };
 
   return (
@@ -376,7 +385,7 @@ export default function Step({
       })}
       <div className={styles.navigation}>
         {!isFirst && (
-          <button type="button" onClick={onBack}>
+          <button type="button" onClick={() => onBack && onBack(formData)}>
             Back
           </button>
         )}


### PR DESCRIPTION
## Summary
- persist step data in FormRenderer and reload it when returning to a step
- update Step component to pass data to parent and restore values

## Testing
- `npm --prefix test-form test` *(fails: react-scripts not found)*

------
https://chatgpt.com/codex/tasks/task_e_6841290c1d948331b5d587e060ff1b2f