### PR TITLE
Fix ReactMarkdown newline rendering

### DIFF
--- a/test-form/src/components/core/InfoSection/InfoSection.jsx
+++ b/test-form/src/components/core/InfoSection/InfoSection.jsx
@@ -4,7 +4,8 @@ import ReactMarkdown from 'react-markdown';
 export default function InfoSection({ title, content, ui = {}, collapsed = false, onToggle }) {
   const isCollapsible = ui.collapsible;
 
-  const formattedContent = content?.replace(/\n/g, '\n\n');
+  // Convert escaped newline sequences to actual line breaks for ReactMarkdown
+  const formattedContent = content?.replace(/\\n/g, '\n');
 
   return (
     <div className="info-section">


### PR DESCRIPTION
## Summary
- ensure InfoSection converts escaped newlines to actual line breaks

## Testing
- `npm test --silent --prefix test-form` *(fails: react-scripts not found)*

------
https://chatgpt.com/codex/tasks/task_e_6841251e22e4833199eafb94aecd4003