### PR TITLE
Fix handleChange validation

### DIFF
--- a/test-form/src/components/core/Step/Step.jsx
+++ b/test-form/src/components/core/Step/Step.jsx
@@ -54,16 +54,8 @@ export default function Step({
   const handleChange = (id, value) => {
     setFormData((prev) => {
       const next = { ...prev, [id]: value };
-      setErrors((prevErr) => {
-        const cleared = { ...prevErr };
-        delete cleared[id];
-        Object.keys(cleared).forEach((k) => {
-          if (k.startsWith(`${id}[`) || k.startsWith(`${id}.`)) delete cleared[k];
-        });
-        const { errors: ve } = validateStep({ sections }, next, [], {});
-        if (ve[id]) cleared[id] = ve[id];
-        return cleared;
-      });
+      const result = validateStep({ sections }, next, [], {});
+      setErrors(result.errors);
       onDataChange && onDataChange(next);
       return next;
     });


### PR DESCRIPTION
## Summary
- update Step.jsx handleChange to validate entire step and refresh all errors

## Testing
- `npm test --silent` *(fails: react-scripts not found)*

------
https://chatgpt.com/codex/tasks/task_e_684258dead048331a5810e03927543a3