### PR TITLE
Remove children argument from validateStep

### DIFF
--- a/test-form/src/components/FormComponent.jsx
+++ b/test-form/src/components/FormComponent.jsx
@@ -1769,7 +1769,7 @@ Object.keys(groupData).forEach(fieldId => {
 
     const handleNext = () => {
       const step = steps[currentStep];
-      const result = validateStep(step, { ...formData }, children, formErrors, touched);
+      const result = validateStep(step, { ...formData }, formErrors, touched);
       setFormErrors(result.errors);
       setTouched(result.touched);
       if (!result.valid) return;

--- a/test-form/src/components/core/Step/Step.jsx
+++ b/test-form/src/components/core/Step/Step.jsx
@@ -54,7 +54,7 @@ export default function Step({
   const handleChange = (id, value) => {
     setFormData((prev) => {
       const next = { ...prev, [id]: value };
-      const result = validateStep({ sections }, next, [], {});
+      const result = validateStep({ sections }, next, {});
       setErrors(result.errors);
       onDataChange && onDataChange(next);
       return next;
@@ -291,7 +291,6 @@ export default function Step({
     const result = validateStep(
       { sections },
       { ...formData },
-      [],
       errors
     );
     setErrors(result.errors);

--- a/test-form/src/utils/formHelpers.js
+++ b/test-form/src/utils/formHelpers.js
@@ -70,7 +70,7 @@ export function cleanupHiddenFields(step, formData) {
   return cleaned;
 }
 
-export function validateStep(step, formData, children, formErrors = {}, touched = {}) {
+export function validateStep(step, formData, formErrors = {}, touched = {}) {
   let valid = true;
   let updatedErrors = { ...formErrors };
   let updatedTouched = { ...touched };


### PR DESCRIPTION
## Summary
- drop unused `children` param from `validateStep`
- update calls in `Step` and `FormComponent`

## Testing
- `npm test --silent -- --watchAll=false` *(fails: react-scripts not found)*

------
https://chatgpt.com/codex/tasks/task_e_684259964d448331a1ebb2119697b183