### PR TITLE
Fix clearing of group errors in validateStep

### DIFF
--- a/test-form/src/utils/formHelpers.js
+++ b/test-form/src/utils/formHelpers.js
@@ -74,7 +74,6 @@ export function validateStep(step, formData, formErrors = {}, touched = {}) {
   let valid = true;
   let updatedErrors = { ...formErrors };
   let updatedTouched = { ...touched };
-  let clearedErrors = { ...formErrors };
 
   step.sections.forEach((section) => {
     if (section.required) {
@@ -82,8 +81,8 @@ export function validateStep(step, formData, formErrors = {}, touched = {}) {
         (f) => f.type === "group" && Array.isArray(formData[f.id]) && formData[f.id].length > 0
       );
 
-      if (hasGroupWithData && clearedErrors[section.id]) {
-        delete clearedErrors[section.id];
+      if (hasGroupWithData && updatedErrors[section.id]) {
+        delete updatedErrors[section.id];
       }
 
       if (!hasGroupWithData) {


### PR DESCRIPTION
## Summary
- remove unused `clearedErrors`
- clear old section error when group has data
- return updatedErrors consistently

## Testing
- `npm test --silent` *(fails: react-scripts not found)*

------
https://chatgpt.com/codex/tasks/task_e_6842cc8138948331874fd259dbde64c6