### PR TITLE
Improve table style

### DIFF
--- a/test-form/src/components/FormComponent.jsx
+++ b/test-form/src/components/FormComponent.jsx
@@ -2127,8 +2127,8 @@ Object.keys(groupData).forEach(fieldId => {
                     </td>
                   ))}
                   <td className="border px-4 py-2 space-x-2">
-                    <button className="text-blue-600 hover:underline" onClick={() => handleEdit(i)}>Edit</button>
-                    <button className="text-red-600 hover:underline" onClick={() => handleDelete(i)}>Delete</button>
+                    <button onClick={() => handleEdit(i)}>Edit</button>
+                    <button onClick={() => handleDelete(i)}>Delete</button>
                   </td>
                 </tr>
               ))}

--- a/test-form/src/form.css
+++ b/test-form/src/form.css
@@ -372,26 +372,26 @@ button:disabled {
   margin-top: 1rem;
   box-shadow: 0 1px 3px rgba(0, 0, 0, 0.1);
 }
-.modern-table th, .modern-table td {
-  border: 1px solid #ccc;
+.modern-table th,
+.modern-table td {
+  border: 1px solid var(--border);
   padding: 10px 12px;
   text-align: left;
 }
 .modern-table thead {
-  background-color: #f5f5f5;
+  background-color: var(--background);
+}
+.modern-table tbody tr:nth-child(odd) {
+  background-color: var(--surface);
+}
+.modern-table tbody tr:nth-child(even) {
+  background-color: var(--background);
 }
 .modern-table tbody tr:hover {
-  background-color: #fafafa;
+  background-color: var(--secondary-color);
 }
 .modern-table button {
   margin-right: 8px;
-  color: #0066cc;
-  background: none;
-  border: none;
-  cursor: pointer;
-}
-.modern-table button:hover {
-  text-decoration: underline;
 }
 
 .inline-radio {


### PR DESCRIPTION
## Summary
- use theme variables for table borders and rows
- highlight row hover and alternate colors
- drop Tailwind classes from edit/delete buttons

## Testing
- `npm test -- --watchAll=false` *(fails: react-scripts not found)*

------
https://chatgpt.com/codex/tasks/task_e_684474383c7c8331bf5abd33053823ac