### PR TITLE
Improve contrast and accessible font sizes

### DIFF
--- a/test-form/src/components/core/Stepper/Stepper.module.css
+++ b/test-form/src/components/core/Stepper/Stepper.module.css
@@ -23,7 +23,7 @@
   margin-bottom: 0.5rem;
   background: var(--secondary-color);
   border-radius: 24px;
-  font-size: 0.95rem;
+  font-size: var(--font-size-sm);
   cursor: pointer;
   transition: background 0.2s, box-shadow 0.2s;
 }
@@ -32,7 +32,7 @@
   margin-right: 0.5rem;
   background: var(--secondary-color);
   border-radius: 24px;
-  font-size: 0.95rem;
+  font-size: var(--font-size-sm);
   cursor: pointer;
   transition: background 0.2s, box-shadow 0.2s;
 }
@@ -41,10 +41,12 @@
 .item:focus,
 .horizontalItem:focus {
   box-shadow: 0 2px 4px rgba(0, 0, 0, 0.1);
+  outline: 2px solid var(--accent-color);
+  outline-offset: 2px;
 }
 .active {
   background: linear-gradient(90deg, var(--primary-color), var(--accent-color));
-  color: white;
+  color: var(--font-color);
   font-weight: 600;
   box-shadow: 0 2px 6px rgba(0, 0, 0, 0.15);
 }

--- a/test-form/src/form.css
+++ b/test-form/src/form.css
@@ -12,6 +12,8 @@
   --font-family: 'IBM Plex Sans', 'Segoe UI', sans-serif;
   --font-display: 'Inter', var(--font-family);
   --font-size: 16px;
+  --font-size-sm: 0.95rem;
+  --font-size-lg: 1.125rem;
   --font-color: #111827;
 }
 
@@ -77,7 +79,7 @@ h5 {
   margin-bottom: 0.5rem;
   background: #f3f4f6;
   border-radius: 24px;
-  font-size: 0.95rem;
+  font-size: var(--font-size-sm);
   cursor: pointer;
   transition: background 0.2s, box-shadow 0.2s;
 }
@@ -85,11 +87,13 @@ h5 {
 .stepper-vertical li:hover,
 .stepper-vertical li:focus {
   box-shadow: 0 2px 4px rgba(0, 0, 0, 0.1);
+  outline: 2px solid var(--accent-color);
+  outline-offset: 2px;
 }
 
 .stepper-vertical li.active {
   background: linear-gradient(90deg, var(--primary-color), var(--accent-color));
-  color: white;
+  color: var(--font-color);
   font-weight: 600;
   box-shadow: 0 2px 6px rgba(0, 0, 0, 0.15);
 }
@@ -251,9 +255,9 @@ select.error {
 /* Buttons */
 button {
   padding: 0.6rem 1.5rem;
-  font-size: 1rem;
+  font-size: var(--font-size-lg);
   background: linear-gradient(90deg, var(--primary-color), var(--accent-color));
-  color: white;
+  color: var(--font-color);
   border: none;
   border-radius: 12px;
   cursor: pointer;
@@ -267,6 +271,8 @@ button:focus {
   background: linear-gradient(90deg, var(--primary-hover), var(--accent-color));
   box-shadow: 0 4px 6px rgba(0, 0, 0, 0.15);
   transform: translateY(-1px);
+  outline: 2px solid var(--accent-color);
+  outline-offset: 2px;
 }
 
 button:disabled {


### PR DESCRIPTION
## Summary
- add `--font-size-sm` and `--font-size-lg` variables
- increase button text size and use font variables for stepper items
- switch stepper and button text to dark color for better contrast
- show outlines on focus for stepper items and buttons

## Testing
- `npm test --silent --runTestsByPath src/components/shared/GroupField/GroupField.test.js src/components/shared/TableLayout/TableLayout.test.js` *(fails: react-scripts not found)*

------
https://chatgpt.com/codex/tasks/task_e_684474fd23108331bec3f49b4ec52725