### PR TITLE
Add progress and completion indicators to Stepper

### DIFF
--- a/test-form/src/components/core/Stepper/Stepper.jsx
+++ b/test-form/src/components/core/Stepper/Stepper.jsx
@@ -23,16 +23,28 @@ export default function Stepper({
   return (
     <aside className={containerClass}>
       <h4>Steps</h4>
+      <div className={styles.progress}>
+        Step {currentStep + 1} of {steps.length}
+      </div>
       <ul className={listClass}>
-        {steps.map((step, index) => (
-          <li
-            key={step.id}
-            className={`${itemClass} ${index === currentStep ? styles.active : ''}`}
-            onClick={() => handleClick(index)}
-          >
-            {step.title}
-          </li>
-        ))}
+        {steps.map((step, index) => {
+          const isActive = index === currentStep;
+          const isComplete = index < currentStep;
+          return (
+            <li
+              key={step.id}
+              className={`${itemClass} ${isActive ? styles.active : ''} ${
+                isComplete ? styles.complete : ''
+              }`}
+              onClick={() => handleClick(index)}
+            >
+              <span className={styles.icon}>
+                {isComplete ? '✓' : isActive ? '▶' : ''}
+              </span>
+              {step.title}
+            </li>
+          );
+        })}
       </ul>
       {requiredDocs.length > 0 && (
         <div className={styles.requiredDocs}>

--- a/test-form/src/components/core/Stepper/Stepper.module.css
+++ b/test-form/src/components/core/Stepper/Stepper.module.css
@@ -51,6 +51,21 @@
   box-shadow: 0 2px 6px rgba(0, 0, 0, 0.15);
 }
 
+.complete {
+  color: var(--font-color);
+}
+
+.progress {
+  font-size: var(--font-size-sm);
+  margin-bottom: 0.5rem;
+}
+
+.icon {
+  display: inline-block;
+  width: 1rem;
+  margin-right: 0.25rem;
+}
+
 .requiredDocs {
   margin-top: 2rem;
 }


### PR DESCRIPTION
## Summary
- update Stepper UI to show `Step x of y`
- mark completed steps with checkmarks and indicate current step

## Testing
- `npm test` *(fails: react-scripts not found)*

------
https://chatgpt.com/codex/tasks/task_e_6844779545848331af0cc0aa5880b472