### PR TITLE
Add scroll to top when step changes

### DIFF
--- a/test-form/src/components/core/FormRenderer/FormRenderer.jsx
+++ b/test-form/src/components/core/FormRenderer/FormRenderer.jsx
@@ -1,4 +1,4 @@
-import React, { useState } from 'react';
+import React, { useState, useEffect } from 'react';
 import Step from '../Step/Step';
 import Stepper from '../Stepper/Stepper';
 import formSpec from '../../data/childcare_form.json';
@@ -11,6 +11,10 @@ export default function FormRenderer() {
   const [stepData, setStepData] = useState({});
   const stepperPosition = form.layout?.stepperPosition || 'right';
   const orientation = stepperPosition === 'top' ? 'horizontal' : 'vertical';
+
+  useEffect(() => {
+    window.scrollTo({ top: 0, behavior: 'auto' });
+  }, [currentStep]);
 
   const requiredDocs =
     steps[currentStep]?.sections?.flatMap((section) =>


### PR DESCRIPTION
## Summary
- use `useEffect` in `FormRenderer` to watch `currentStep`
- scroll to top on step change

## Testing
- `npm test -- -w=0` *(fails: react-scripts not found)*

------
https://chatgpt.com/codex/tasks/task_e_68448a02d534833193334cc7933158ba