### PR TITLE
Add SSN masked input support

### DIFF
--- a/test-form/src/components/core/Step/Step.jsx
+++ b/test-form/src/components/core/Step/Step.jsx
@@ -240,6 +240,25 @@ export default function Step({
           />
         );
       default:
+        if (
+          field.id === 'ssn' ||
+          (typeof field.label === 'string' &&
+            field.label.toLowerCase().includes('social security'))
+        ) {
+          return (
+            <MaskedInput
+              key={field.id}
+              id={field.id}
+              label={field.label}
+              mask="000-00-0000"
+              placeholder="123-45-6789"
+              required={isRequired}
+              value={formData[field.id] || ''}
+              onChange={(val) => handleChange(field.id, val)}
+              error={error}
+            />
+          );
+        }
         return (
           <>
             <TextInput


### PR DESCRIPTION
## Summary
- ensure SSN fields render a masked input

## Testing
- `npm test --silent --yes` *(fails: react-scripts not found)*

------
https://chatgpt.com/codex/tasks/task_e_68448a92b7f88331a63b1499be182d48