### PR TITLE
Add hint support to FileInput and Step

### DIFF
--- a/test-form/src/components/core/Step/Step.jsx
+++ b/test-form/src/components/core/Step/Step.jsx
@@ -227,6 +227,9 @@ export default function Step({
             multiple={field.metadata?.multiple}
             required={isRequired}
             onChange={(val) => handleChange(field.id, val)}
+            hint={Array.isArray(field.metadata?.examples)
+              ? `Examples: ${field.metadata.examples.join(', ')}`
+              : field.metadata?.examples}
             error={error}
           />
         );

--- a/test-form/src/components/shared/FileInput/FileInput.jsx
+++ b/test-form/src/components/shared/FileInput/FileInput.jsx
@@ -1,7 +1,15 @@
 import React from 'react';
 import styles from './FileInput.module.css';
 
-export default function FileInput({ id, label, multiple = false, error, onChange, ...props }) {
+export default function FileInput({
+  id,
+  label,
+  multiple = false,
+  error,
+  hint,
+  onChange,
+  ...props
+}) {
   const handleFileChange = (e) => {
     const files = e.target.files;
     if (!onChange) return;
@@ -19,6 +27,9 @@ export default function FileInput({ id, label, multiple = false, error, onChange
         className={`${styles.input}${error ? ' error' : ''}`}
         {...props}
       />
+      {hint && (
+        <div className="form-hint text-sm text-gray-500 italic mt-1">{hint}</div>
+      )}
       {error && <div className="form-error-alert">{error}</div>}
     </div>
   );


### PR DESCRIPTION
## Summary
- add optional `hint` prop to `FileInput`
- pass file field examples as hints from `Step`

## Testing
- `npm test --silent --prefix test-form --passWithNoTests` *(fails: react-scripts not found)*

------
https://chatgpt.com/codex/tasks/task_e_68448b56490c8331b4238a7936fba72b