### PR TITLE
Fix visibility logic

### DIFF
--- a/test-form/src/components/core/Step/Step.jsx
+++ b/test-form/src/components/core/Step/Step.jsx
@@ -79,8 +79,11 @@ export default function Step({
   };
 
   const renderField = (field) => {
-    const visible = field.visibilityCondition
-      ? evaluateCondition(field.visibilityCondition, formData)
+    const conditionToCheck =
+      field.visibilityCondition ??
+      (field.requiredCondition?.condition || field.requiredCondition);
+    const visible = conditionToCheck
+      ? evaluateCondition(conditionToCheck, formData)
       : true;
     const isRequired = field.requiredCondition
       ? evaluateCondition(

--- a/test-form/src/components/shared/GroupField/GroupField.jsx
+++ b/test-form/src/components/shared/GroupField/GroupField.jsx
@@ -85,8 +85,11 @@ export default function GroupField({ field, value = [], onChange }) {
   };
 
   const renderField = (subField) => {
-    const visible = subField.visibilityCondition
-      ? evaluateCondition(subField.visibilityCondition, currentEntry)
+    const conditionToCheck =
+      subField.visibilityCondition ??
+      (subField.requiredCondition?.condition || subField.requiredCondition);
+    const visible = conditionToCheck
+      ? evaluateCondition(conditionToCheck, currentEntry)
       : true;
     const required = subField.requiredCondition
       ? evaluateCondition(


### PR DESCRIPTION
## Summary
- update field visibility logic in Step
- update subfield visibility logic in GroupField

## Testing
- `npm test --silent` *(fails: react-scripts not found)*

------
https://chatgpt.com/codex/tasks/task_e_684494a6c34c83319115754f6cfa7a6f