### PR TITLE
Track full form data across steps

### DIFF
--- a/test-form/src/components/core/FormRenderer/FormRenderer.jsx
+++ b/test-form/src/components/core/FormRenderer/FormRenderer.jsx
@@ -9,6 +9,7 @@ export default function FormRenderer() {
   const steps = form.steps || [];
   const [currentStep, setCurrentStep] = useState(0);
   const [stepData, setStepData] = useState({});
+  const [allData, setAllData] = useState({});
   const stepperPosition = form.layout?.stepperPosition || 'right';
   const orientation = stepperPosition === 'top' ? 'horizontal' : 'vertical';
 
@@ -26,15 +27,18 @@ export default function FormRenderer() {
   const handleDataChange = (data) => {
     const stepId = steps[currentStep].id;
     setStepData((prev) => ({ ...prev, [stepId]: data }));
+    setAllData((prev) => ({ ...prev, ...data }));
   };
 
   const handleNext = (data) => {
     handleDataChange(data);
+    setAllData((prev) => ({ ...prev, ...data }));
     setCurrentStep((s) => Math.min(s + 1, steps.length - 1));
   };
 
   const handleBack = (data) => {
     handleDataChange(data);
+    setAllData((prev) => ({ ...prev, ...data }));
     setCurrentStep((s) => Math.max(s - 1, 0));
   };
 
@@ -84,6 +88,7 @@ export default function FormRenderer() {
             isFirst={currentStep === 0}
             isLast={currentStep === steps.length - 1}
             formData={stepData[steps[currentStep].id] || {}}
+            fullData={allData}
             onDataChange={handleDataChange}
           />
         )}

--- a/test-form/src/components/core/Step/Step.jsx
+++ b/test-form/src/components/core/Step/Step.jsx
@@ -25,6 +25,7 @@ export default function Step({
   isFirst = false,
   isLast = false,
   formData: initialData = {},
+  fullData = {},
   onDataChange,
 }) {
   const [collapsedSections, setCollapsedSections] = useState({});
@@ -83,12 +84,12 @@ export default function Step({
       field.visibilityCondition ??
       (field.requiredCondition?.condition || field.requiredCondition);
     const visible = conditionToCheck
-      ? evaluateCondition(conditionToCheck, formData)
+      ? evaluateCondition(conditionToCheck, fullData)
       : true;
     const isRequired = field.requiredCondition
       ? evaluateCondition(
           field.requiredCondition.condition || field.requiredCondition,
-          formData
+          fullData
         )
       : field.required;
 
@@ -250,6 +251,7 @@ export default function Step({
             field={field}
             value={formData[field.id] || []}
             onChange={(val) => handleChange(field.id, val)}
+            fullData={fullData}
           />
         );
       default:
@@ -303,7 +305,7 @@ export default function Step({
       ) {
         isRequired = evaluateCondition(
           requiredCondition.condition || requiredCondition,
-          formData
+          fullData
         );
       } else if (typeof required === "boolean") {
         isRequired = required;
@@ -370,6 +372,7 @@ export default function Step({
                 field={sec}
                 value={formData[sec.id] || []}
                 onChange={(val) => handleChange(sec.id, val)}
+                fullData={fullData}
               />
             ) : sec.ui?.layout === 'table' ? (
               <TableLayout

--- a/test-form/src/components/shared/GroupField/GroupField.jsx
+++ b/test-form/src/components/shared/GroupField/GroupField.jsx
@@ -7,7 +7,7 @@ import FileInput from '../FileInput/FileInput';
 import MaskedInput from '../MaskedInput/MaskedInput';
 import { evaluateCondition } from '../../../utils/formHelpers';
 
-export default function GroupField({ field, value = [], onChange }) {
+export default function GroupField({ field, value = [], onChange, fullData = {} }) {
   const [entries, setEntries] = useState(value);
   const [currentEntry, setCurrentEntry] = useState({});
   const [editingIndex, setEditingIndex] = useState(null);
@@ -29,7 +29,7 @@ export default function GroupField({ field, value = [], onChange }) {
       const required = subField.requiredCondition
         ? evaluateCondition(
             subField.requiredCondition.condition || subField.requiredCondition,
-            currentEntry
+            fullData
           )
         : subField.required;
       const val = currentEntry[subField.id];
@@ -89,12 +89,12 @@ export default function GroupField({ field, value = [], onChange }) {
       subField.visibilityCondition ??
       (subField.requiredCondition?.condition || subField.requiredCondition);
     const visible = conditionToCheck
-      ? evaluateCondition(conditionToCheck, currentEntry)
+      ? evaluateCondition(conditionToCheck, fullData)
       : true;
     const required = subField.requiredCondition
       ? evaluateCondition(
           subField.requiredCondition.condition || subField.requiredCondition,
-          currentEntry
+          fullData
         )
       : subField.required;
     if (!visible) return null;


### PR DESCRIPTION
## Summary
- keep a combined `allData` in `FormRenderer`
- use `allData` when evaluating conditions in steps and group fields
- pass `fullData` down to `Step` and `GroupField`

## Testing
- `npm test --silent` *(fails: react-scripts not found)*

------
https://chatgpt.com/codex/tasks/task_e_68449c06974c83319b17a9aad7ec6afa