### PR TITLE
Add effect to clear errors on group section validity

### DIFF
--- a/test-form/src/components/core/Step/Step.jsx
+++ b/test-form/src/components/core/Step/Step.jsx
@@ -49,6 +49,23 @@ export default function Step({
     setCollapsedSections(initial);
   }, [sections]);
 
+  // Clear section-level errors when required group sections gain data
+  useEffect(() => {
+    setErrors((prev) => {
+      const updated = { ...prev };
+      sections.forEach((sec) => {
+        if (!sec.required || !updated[sec.id]) return;
+        const hasGroupData = sec.fields?.some(
+          (f) => f.type === 'group' && Array.isArray(fullData[f.id]) && fullData[f.id].length > 0
+        );
+        if (hasGroupData) {
+          delete updated[sec.id];
+        }
+      });
+      return updated;
+    });
+  }, [sections, fullData]);
+
   const handleToggle = (id) => {
     setCollapsedSections((prev) => ({ ...prev, [id]: !prev[id] }));
   };


### PR DESCRIPTION
## Summary
- add side effect in `Step.jsx` to remove section errors when required group data is present

## Testing
- `npm test --silent` *(fails: react-scripts not found)*

------
https://chatgpt.com/codex/tasks/task_e_68449d361cbc8331bb9159724a554c64