### PR TITLE
Add optional tag for group headings

### DIFF
--- a/test-form/src/components/core/Step/Step.jsx
+++ b/test-form/src/components/core/Step/Step.jsx
@@ -418,6 +418,9 @@ export default function Step({
                     {groupKey !== 'default' && (
                       <div className="form-group-heading">
                         {groupFields[0].ui?.groupLabel || groupKey}
+                        {groupFields[0].ui?.optionalGroup && (
+                          <span className="text-sm text-gray-500 ml-2">(Optional)</span>
+                        )}
                       </div>
                     )}
                     <div className="form-subgroup-grid grid gap-4">


### PR DESCRIPTION
## Summary
- render optional groups with '(Optional)' tag in Step component

## Testing
- `npm test -- --watchAll=false` *(fails: react-scripts not found)*

------
https://chatgpt.com/codex/tasks/task_e_68449f25cfd0833188779bef42770f95