### PR TITLE
Implement step validation before navigation

### DIFF
--- a/test-form/src/components/core/FormRenderer/FormRenderer.jsx
+++ b/test-form/src/components/core/FormRenderer/FormRenderer.jsx
@@ -42,14 +42,11 @@ export default function FormRenderer() {
     setCurrentStep((s) => Math.max(s - 1, 0));
   };
 
-  const canNavigate = () => {
-    const stepSpec = steps[currentStep];
-    const data = stepData[stepSpec.id] || {};
-    const { valid } = validateStep(stepSpec, data);
-    if (valid) {
-      handleDataChange(data);
-      window.scrollTo(0, 0);
-    }
+  const canNavigate = (targetIndex) => {
+    const { valid } = validateStep(
+      steps[currentStep],
+      stepData[steps[currentStep].id] || {}
+    );
     return valid;
   };
 


### PR DESCRIPTION
## Summary
- implement `canNavigate(targetIndex)` in `FormRenderer`
- pass this helper into `Stepper`
- keep the navigation guard in `Stepper`

## Testing
- `npm test --silent` *(fails: react-scripts not found)*

------
https://chatgpt.com/codex/tasks/task_e_6844a2d0472c8331b1ddf3a3d939cf9c