### PR TITLE
Add SSN masking

### DIFF
--- a/test-form/src/components/core/Step/Step.jsx
+++ b/test-form/src/components/core/Step/Step.jsx
@@ -139,6 +139,25 @@ export default function Step({
       case 'email':
       case 'number':
       case 'time':
+        if (
+          field.id === 'ssn' ||
+          (typeof field.label === 'string' &&
+            field.label.toLowerCase().includes('social security'))
+        ) {
+          return (
+            <MaskedInput
+              key={field.id}
+              id={field.id}
+              label={field.label}
+              mask="000-00-0000"
+              placeholder="123-45-6789"
+              required={isRequired}
+              value={formData[field.id] || ''}
+              onChange={(val) => handleChange(field.id, val)}
+              error={error}
+            />
+          );
+        }
         return (
           <>
             <TextInput


### PR DESCRIPTION
## Summary
- mask SSN fields by default using MaskedInput

## Testing
- `npm install` *(fails: react-scripts not found)*

------
https://chatgpt.com/codex/tasks/task_e_6844a3d7cb908331ac556b3255eb5559