### PR TITLE
Fix GroupField entry errors reset

### DIFF
--- a/test-form/src/components/shared/GroupField/GroupField.jsx
+++ b/test-form/src/components/shared/GroupField/GroupField.jsx
@@ -18,6 +18,19 @@ export default function GroupField({ field, value = [], onChange, fullData = {} 
     setEntries(Array.isArray(value) ? value : []);
   }, [value]);
 
+  useEffect(() => {
+    const hasValues = Object.values(currentEntry).some((val) =>
+      val !== undefined &&
+      val !== null &&
+      !(typeof val === 'string'
+        ? val.trim() === ''
+        : Array.isArray(val) && val.length === 0)
+    );
+    if (!hasValues) {
+      setEntryErrors({});
+    }
+  }, [currentEntry]);
+
   const handleInputChange = (id, val) => {
     setCurrentEntry((prev) => ({ ...prev, [id]: val }));
     setEntryErrors((prev) => ({ ...prev, [id]: undefined }));


### PR DESCRIPTION
## Summary
- clear entry errors after removing all group entry values

## Testing
- `npm test` *(fails: react-scripts not found)*

------
https://chatgpt.com/codex/tasks/task_e_6844aeb245a08331aee1ca215ba0d91b