### PR TITLE
Add Express proxy server

### DIFF
--- a/test-form/README.md
+++ b/test-form/README.md
@@ -68,3 +68,17 @@ This section has moved here: [https://facebook.github.io/create-react-app/docs/d
 ### `npm run build` fails to minify
 
 This section has moved here: [https://facebook.github.io/create-react-app/docs/troubleshooting#npm-run-build-fails-to-minify](https://facebook.github.io/create-react-app/docs/troubleshooting#npm-run-build-fails-to-minify)
+
+## Local API Server
+
+Create a `.env` file inside the `server` folder with your Google API key:
+
+```
+GOOGLE_API_KEY=<your-key>
+```
+
+Start the Express proxy and React app together with:
+
+```
+npm run dev
+```

--- a/test-form/package.json
+++ b/test-form/package.json
@@ -12,10 +12,16 @@
     "react-imask": "^7.6.1",
     "react-markdown": "^10.1.0",
     "react-scripts": "5.0.1",
-    "web-vitals": "^2.1.4"
+    "web-vitals": "^2.1.4",
+    "express": "^4.18.2",
+    "node-fetch": "^2.6.9",
+    "dotenv": "^16.3.1",
+    "concurrently": "^8.2.0"
   },
   "scripts": {
     "start": "react-scripts start",
+    "server": "node server/index.js",
+    "dev": "concurrently \"npm run server\" \"npm start\"",
     "build": "react-scripts build",
     "test": "react-scripts test",
     "eject": "react-scripts eject"
@@ -37,5 +43,6 @@
       "last 1 firefox version",
       "last 1 safari version"
     ]
-  }
+  },
+  "proxy": "http://localhost:5000"
 }

--- a/test-form/server/.env.example
+++ b/test-form/server/.env.example
@@ -1,0 +1,1 @@
+GOOGLE_API_KEY=your-api-key

--- a/test-form/server/index.js
+++ b/test-form/server/index.js
@@ -1,0 +1,40 @@
+require('dotenv').config();
+const express = require('express');
+const fetch = require('node-fetch');
+
+const app = express();
+const PORT = process.env.PORT || 5000;
+const GOOGLE_API_KEY = process.env.GOOGLE_API_KEY;
+
+app.get('/api/places/autocomplete', async (req, res) => {
+  const input = req.query.input;
+  if (!input) {
+    return res.status(400).json({ error: 'Missing input parameter' });
+  }
+  try {
+    const url = `https://maps.googleapis.com/maps/api/place/autocomplete/json?input=${encodeURIComponent(input)}&key=${GOOGLE_API_KEY}`;
+    const response = await fetch(url);
+    const data = await response.json();
+    res.json(data);
+  } catch (err) {
+    console.error(err);
+    res.status(500).json({ error: 'Failed to fetch autocomplete results' });
+  }
+});
+
+app.get('/api/places/details/:id', async (req, res) => {
+  const placeId = req.params.id;
+  try {
+    const url = `https://maps.googleapis.com/maps/api/place/details/json?place_id=${encodeURIComponent(placeId)}&key=${GOOGLE_API_KEY}`;
+    const response = await fetch(url);
+    const data = await response.json();
+    res.json(data);
+  } catch (err) {
+    console.error(err);
+    res.status(500).json({ error: 'Failed to fetch place details' });
+  }
+});
+
+app.listen(PORT, () => {
+  console.log(`Server listening on port ${PORT}`);
+});


### PR DESCRIPTION
## Summary
- add Express server to proxy Google Places API
- document API server usage and `.env` in README
- add dev script and dependencies in CRA package.json

## Testing
- `npm install --package-lock-only` *(fails: 403 Forbidden)*
- `npm test --silent` *(fails: react-scripts not found)*

------
https://chatgpt.com/codex/tasks/task_e_6844bd75c33c8331a39cb4dbf2631b84