### PR TITLE
Add AddressAutocomplete component

### DIFF
--- a/test-form/src/components/shared/AddressAutocomplete/AddressAutocomplete.jsx
+++ b/test-form/src/components/shared/AddressAutocomplete/AddressAutocomplete.jsx
@@ -1,0 +1,75 @@
+import React, { useState, useEffect } from 'react';
+import styles from './AddressAutocomplete.module.css';
+
+export default function AddressAutocomplete({ id, label, onAddressSelect, placeholder = '', ...props }) {
+  const [inputValue, setInputValue] = useState('');
+  const [suggestions, setSuggestions] = useState([]);
+  const [showSuggestions, setShowSuggestions] = useState(false);
+
+  useEffect(() => {
+    if (!showSuggestions) return;
+    if (!inputValue) {
+      setSuggestions([]);
+      return;
+    }
+
+    const controller = new AbortController();
+    const fetchSuggestions = async () => {
+      try {
+        const res = await fetch(`/api/places/autocomplete?input=${encodeURIComponent(inputValue)}`, {
+          signal: controller.signal,
+        });
+        const data = await res.json();
+        setSuggestions(data.predictions || []);
+      } catch (err) {
+        if (err.name !== 'AbortError') console.error(err);
+      }
+    };
+
+    fetchSuggestions();
+    return () => controller.abort();
+  }, [inputValue, showSuggestions]);
+
+  const handleSelect = async (place) => {
+    setInputValue(place.description);
+    setSuggestions([]);
+    setShowSuggestions(false);
+    try {
+      const res = await fetch(`/api/places/details/${place.place_id}`);
+      const data = await res.json();
+      onAddressSelect && onAddressSelect(data.result || {});
+    } catch (err) {
+      console.error(err);
+    }
+  };
+
+  return (
+    <div className={styles.field}>
+      {label && <label htmlFor={id}>{label}</label>}
+      <input
+        id={id}
+        type="text"
+        value={inputValue}
+        onChange={(e) => setInputValue(e.target.value)}
+        onFocus={() => setShowSuggestions(true)}
+        className={styles.input}
+        placeholder={placeholder}
+        autoComplete="off"
+        {...props}
+      />
+      {showSuggestions && suggestions.length > 0 && (
+        <ul className={styles.suggestions}>
+          {suggestions.map((s) => (
+            <li
+              key={s.place_id}
+              onMouseDown={() => handleSelect(s)}
+              className={styles.suggestion}
+            >
+              {s.description}
+            </li>
+          ))}
+        </ul>
+      )}
+    </div>
+  );
+}

--- a/test-form/src/components/shared/AddressAutocomplete/AddressAutocomplete.module.css
+++ b/test-form/src/components/shared/AddressAutocomplete/AddressAutocomplete.module.css
@@ -1,0 +1,29 @@
+.field {
+  position: relative;
+  margin-bottom: 1rem;
+}
+.input {
+  width: 100%;
+  padding: 0.5rem;
+}
+.suggestions {
+  position: absolute;
+  top: 100%;
+  left: 0;
+  right: 0;
+  background: #fff;
+  border: 1px solid #ccc;
+  max-height: 200px;
+  overflow-y: auto;
+  list-style: none;
+  margin: 0;
+  padding: 0;
+  z-index: 10;
+}
+.suggestion {
+  padding: 0.5rem;
+  cursor: pointer;
+}
+.suggestion:hover {
+  background: #f0f0f0;
+}

--- a/test-form/src/components/shared/AddressAutocomplete/index.js
+++ b/test-form/src/components/shared/AddressAutocomplete/index.js
@@ -1,0 +1,1 @@
+export { default } from './AddressAutocomplete';


### PR DESCRIPTION
## Summary
- add AddressAutocomplete shared component for Google Places autocomplete
- include CSS module styling
- export component via index file

## Testing
- `npm test --silent -- -u` *(fails: react-scripts not found)*

------
https://chatgpt.com/codex/tasks/task_e_6844bee6780883319b708ef088c12648