### PR TITLE
Fix address autocomplete component integration

### DIFF
--- a/test-form/src/components/core/Step/Step.jsx
+++ b/test-form/src/components/core/Step/Step.jsx
@@ -205,7 +205,7 @@ export default function Step({
                 label={field.label}
                 required={isRequired}
                 value={formData[field.id] || ''}
-                onChange={(e) => handleChange(field.id, e.target.value)}
+                onChange={(val) => handleChange(field.id, val)}
                 onAddressSelect={(addr) => {
                   const comps = {};
                   (addr.address_components || []).forEach((c) => {

--- a/test-form/src/components/shared/GroupField/GroupField.jsx
+++ b/test-form/src/components/shared/GroupField/GroupField.jsx
@@ -190,7 +190,7 @@ export default function GroupField({ field, value = [], onChange, fullData = {} 
               <AddressAutocomplete
                 key={subField.id}
                 {...commonProps}
-                onChange={(e) => handleInputChange(subField.id, e.target.value)}
+                onChange={(val) => handleInputChange(subField.id, val)}
                 onAddressSelect={(addr) => {
                   const comps = {};
                   (addr.address_components || []).forEach((c) => {


### PR DESCRIPTION
## Summary
- implement controlled `AddressAutocomplete` that fetches suggestions based on passed value
- update `Step` and `GroupField` to pass value changes directly

## Testing
- `npm test` *(fails: react-scripts not found)*

------
https://chatgpt.com/codex/tasks/task_e_684485b3118c833198b02a95d917280f