### PR TITLE
Enable address details retrieval

### DIFF
--- a/test-form/server/index.js
+++ b/test-form/server/index.js
@@ -33,7 +33,7 @@ app.get('/api/places/autocomplete', async (req, res) => {
     const headers = {
       'Content-Type': 'application/json',
       'X-Goog-Api-Key': GOOGLE_API_KEY,
-      'X-Goog-FieldMask': 'suggestions.placePrediction.text'
+      'X-Goog-FieldMask': 'suggestions.placePrediction.text,suggestions.placePrediction.placeId'
     };
     if (sessiontoken) headers['X-Goog-Session-Token'] = sessiontoken;
 
@@ -81,7 +81,7 @@ app.get('/api/places/details/:id', async (req, res) => {
 
     const headers = {
       'X-Goog-Api-Key': GOOGLE_API_KEY,
-      'X-Goog-FieldMask': 'id,displayName,formattedAddress,addressComponents',
+      'X-Goog-FieldMask': 'id,displayName,formattedAddress,addressComponents,location',
     };
     if (sessiontoken) headers['X-Goog-Session-Token'] = sessiontoken;
 

--- a/test-form/src/components/core/Step/Step.jsx
+++ b/test-form/src/components/core/Step/Step.jsx
@@ -207,21 +207,40 @@ export default function Step({
                 value={formData[field.id] || ''}
                 onChange={(val) => handleChange(field.id, val)}
                 onAddressSelect={(addr) => {
+                  const components = addr.address_components || addr.addressComponents || [];
                   const comps = {};
-                  (addr.address_components || []).forEach((c) => {
+                  components.forEach((c) => {
                     c.types.forEach((t) => {
-                      comps[t] = { long_name: c.long_name, short_name: c.short_name };
+                      comps[t] = {
+                        long_name: c.long_name || c.longName,
+                        short_name: c.short_name || c.shortName,
+                      };
                     });
                   });
-                  handleChange(field.id, addr.formatted_address || '');
+                  handleChange(field.id, addr.formatted_address || addr.formattedAddress || '');
                   if (Object.prototype.hasOwnProperty.call(formData, 'city')) {
-                    handleChange('city', comps.locality?.long_name || '');
+                    handleChange('city', comps.locality?.long_name || comps.locality?.longName || '');
                   }
                   if (Object.prototype.hasOwnProperty.call(formData, 'state')) {
-                    handleChange('state', comps.administrative_area_level_1?.short_name || '');
+                    handleChange(
+                      'state',
+                      comps.administrative_area_level_1?.short_name || comps.administrativeAreaLevel1?.shortName || ''
+                    );
                   }
                   if (Object.prototype.hasOwnProperty.call(formData, 'zip_code')) {
-                    handleChange('zip_code', comps.postal_code?.long_name || '');
+                    handleChange('zip_code', comps.postal_code?.long_name || comps.postalCode?.longName || '');
+                  }
+                  if (
+                    Object.prototype.hasOwnProperty.call(formData, 'latitude') &&
+                    addr.location?.latitude !== undefined
+                  ) {
+                    handleChange('latitude', addr.location.latitude);
+                  }
+                  if (
+                    Object.prototype.hasOwnProperty.call(formData, 'longitude') &&
+                    addr.location?.longitude !== undefined
+                  ) {
+                    handleChange('longitude', addr.location.longitude);
                   }
                 }}
               />

--- a/test-form/src/components/shared/AddressAutocomplete/AddressAutocomplete.jsx
+++ b/test-form/src/components/shared/AddressAutocomplete/AddressAutocomplete.jsx
@@ -37,6 +37,7 @@ export default function AddressAutocomplete({
           setSuggestions(
             data.suggestions?.map((s) => ({
               displayName: s.placePrediction?.text?.text ?? '',
+              placeId: s.placePrediction?.placeId,
             })) || []
           );
         } catch (err) {
@@ -60,12 +61,22 @@ export default function AddressAutocomplete({
     setSuggestions([]);
     setShowSuggestions(false);
 
-    // Since placeId is not available, we cannot call /details/:id
-    // You may implement a /searchText fallback if needed
+    let details = null;
+    if (place.placeId) {
+      try {
+        const res = await fetch(
+          `/api/places/details/${place.placeId}?sessiontoken=${sessionTokenRef.current}`
+        );
+        details = await res.json();
+      } catch (err) {
+        console.error(err);
+      }
+    }
+
     if (onAddressSelect) {
-      onAddressSelect({
+      onAddressSelect(details || {
         formatted_address: displayText,
-        place_id: null,
+        place_id: place.placeId || null,
         address_components: [],
         name: displayText,
       });

--- a/test-form/src/components/shared/GroupField/GroupField.jsx
+++ b/test-form/src/components/shared/GroupField/GroupField.jsx
@@ -192,24 +192,34 @@ export default function GroupField({ field, value = [], onChange, fullData = {} 
                 {...commonProps}
                 onChange={(val) => handleInputChange(subField.id, val)}
                 onAddressSelect={(addr) => {
+                  const components = addr.address_components || addr.addressComponents || [];
                   const comps = {};
-                  (addr.address_components || []).forEach((c) => {
+                  components.forEach((c) => {
                     c.types.forEach((t) => {
-                      comps[t] = { long_name: c.long_name, short_name: c.short_name };
+                      comps[t] = {
+                        long_name: c.long_name || c.longName,
+                        short_name: c.short_name || c.shortName,
+                      };
                     });
                   });
-                  handleInputChange(subField.id, addr.formatted_address || '');
+                  handleInputChange(subField.id, addr.formatted_address || addr.formattedAddress || '');
                   if (field.fields.some((f) => f.id === 'city')) {
-                    handleInputChange('city', comps.locality?.long_name || '');
+                    handleInputChange('city', comps.locality?.long_name || comps.locality?.longName || '');
                   }
                   if (field.fields.some((f) => f.id === 'state')) {
                     handleInputChange(
                       'state',
-                      comps.administrative_area_level_1?.short_name || ''
+                      comps.administrative_area_level_1?.short_name || comps.administrativeAreaLevel1?.shortName || ''
                     );
                   }
                   if (field.fields.some((f) => f.id === 'zip_code')) {
-                    handleInputChange('zip_code', comps.postal_code?.long_name || '');
+                    handleInputChange('zip_code', comps.postal_code?.long_name || comps.postalCode?.longName || '');
+                  }
+                  if (field.fields.some((f) => f.id === 'latitude') && addr.location?.latitude !== undefined) {
+                    handleInputChange('latitude', addr.location.latitude);
+                  }
+                  if (field.fields.some((f) => f.id === 'longitude') && addr.location?.longitude !== undefined) {
+                    handleInputChange('longitude', addr.location.longitude);
                   }
                 }}
               />


### PR DESCRIPTION
## Summary
- request place IDs and locations when using Google Places API
- fetch place details in AddressAutocomplete and pass full details to handlers
- populate lat/long fields in Step and GroupField when available

## Testing
- `npm test --prefix test-form` *(fails: react-scripts not found)*

------
https://chatgpt.com/codex/tasks/task_e_6844da56798083318685738b0c0d4abb