### PR TITLE
Fix address autocomplete field checks

### DIFF
--- a/test-form/src/components/core/Step/Step.jsx
+++ b/test-form/src/components/core/Step/Step.jsx
@@ -218,26 +218,26 @@ export default function Step({
                     });
                   });
                   handleChange(field.id, addr.formatted_address || addr.formattedAddress || '');
-                  if (Object.prototype.hasOwnProperty.call(formData, 'city')) {
+                  if (findFieldById('city')) {
                     handleChange('city', comps.locality?.long_name || comps.locality?.longName || '');
                   }
-                  if (Object.prototype.hasOwnProperty.call(formData, 'state')) {
+                  if (findFieldById('state')) {
                     handleChange(
                       'state',
                       comps.administrative_area_level_1?.short_name || comps.administrativeAreaLevel1?.shortName || ''
                     );
                   }
-                  if (Object.prototype.hasOwnProperty.call(formData, 'zip_code')) {
+                  if (findFieldById('zip_code')) {
                     handleChange('zip_code', comps.postal_code?.long_name || comps.postalCode?.longName || '');
                   }
                   if (
-                    Object.prototype.hasOwnProperty.call(formData, 'latitude') &&
+                    findFieldById('latitude') &&
                     addr.location?.latitude !== undefined
                   ) {
                     handleChange('latitude', addr.location.latitude);
                   }
                   if (
-                    Object.prototype.hasOwnProperty.call(formData, 'longitude') &&
+                    findFieldById('longitude') &&
                     addr.location?.longitude !== undefined
                   ) {
                     handleChange('longitude', addr.location.longitude);


### PR DESCRIPTION
## Summary
- use `findFieldById` when setting address fields so that optional fields update when present

## Testing
- `npm run dev` *(fails: concurrently not found)*

------
https://chatgpt.com/codex/tasks/task_e_6844e196db408331be0a66a9c473bc94