### PR TITLE
Update address autocomplete to fill borough info

### DIFF
--- a/test-form/src/components/core/Step/Step.jsx
+++ b/test-form/src/components/core/Step/Step.jsx
@@ -221,7 +221,42 @@ export default function Step({
                   });
                   handleChange(field.id, addr.formatted_address || addr.formattedAddress || '');
                   if (findFieldById('city')) {
-                    handleChange('city', comps.locality?.long_name || comps.locality?.longName || '');
+                    const cityVal =
+                      comps.locality?.long_name ||
+                      comps.locality?.longName ||
+                      comps.postal_town?.long_name ||
+                      comps.postalTown?.longName ||
+                      comps.sublocality_level_1?.long_name ||
+                      comps.sublocalityLevel1?.longName ||
+                      comps.administrative_area_level_2?.long_name ||
+                      comps.administrativeAreaLevel2?.longName ||
+                      '';
+                    handleChange('city', cityVal);
+                  }
+                  if (findFieldById('borough')) {
+                    const boroughSource =
+                      comps.sublocality_level_1?.long_name ||
+                      comps.sublocalityLevel1?.longName ||
+                      comps.administrative_area_level_2?.long_name ||
+                      comps.administrativeAreaLevel2?.longName ||
+                      '';
+                    const boroughMap = {
+                      bronx: 'Bronx',
+                      'bronx county': 'Bronx',
+                      brooklyn: 'Brooklyn',
+                      'kings county': 'Brooklyn',
+                      manhattan: 'Manhattan',
+                      'new york': 'Manhattan',
+                      'new york county': 'Manhattan',
+                      queens: 'Queens',
+                      'queens county': 'Queens',
+                      'staten island': 'Staten Island',
+                      'richmond county': 'Staten Island',
+                    };
+                    const bName = boroughMap[boroughSource.trim().toLowerCase()];
+                    if (bName) {
+                      handleChange('borough', bName);
+                    }
                   }
                   if (findFieldById('state')) {
                     handleChange(

--- a/test-form/src/components/shared/GroupField/GroupField.jsx
+++ b/test-form/src/components/shared/GroupField/GroupField.jsx
@@ -204,7 +204,42 @@ export default function GroupField({ field, value = [], onChange, fullData = {} 
                   });
                   handleInputChange(subField.id, addr.formatted_address || addr.formattedAddress || '');
                   if (field.fields.some((f) => f.id === 'city')) {
-                    handleInputChange('city', comps.locality?.long_name || comps.locality?.longName || '');
+                    const cityVal =
+                      comps.locality?.long_name ||
+                      comps.locality?.longName ||
+                      comps.postal_town?.long_name ||
+                      comps.postalTown?.longName ||
+                      comps.sublocality_level_1?.long_name ||
+                      comps.sublocalityLevel1?.longName ||
+                      comps.administrative_area_level_2?.long_name ||
+                      comps.administrativeAreaLevel2?.longName ||
+                      '';
+                    handleInputChange('city', cityVal);
+                  }
+                  if (field.fields.some((f) => f.id === 'borough')) {
+                    const boroughSource =
+                      comps.sublocality_level_1?.long_name ||
+                      comps.sublocalityLevel1?.longName ||
+                      comps.administrative_area_level_2?.long_name ||
+                      comps.administrativeAreaLevel2?.longName ||
+                      '';
+                    const boroughMap = {
+                      bronx: 'Bronx',
+                      'bronx county': 'Bronx',
+                      brooklyn: 'Brooklyn',
+                      'kings county': 'Brooklyn',
+                      manhattan: 'Manhattan',
+                      'new york': 'Manhattan',
+                      'new york county': 'Manhattan',
+                      queens: 'Queens',
+                      'queens county': 'Queens',
+                      'staten island': 'Staten Island',
+                      'richmond county': 'Staten Island',
+                    };
+                    const bName = boroughMap[boroughSource.trim().toLowerCase()];
+                    if (bName) {
+                      handleInputChange('borough', bName);
+                    }
                   }
                   if (field.fields.some((f) => f.id === 'state')) {
                     handleInputChange(


### PR DESCRIPTION
## Summary
- enhance city determination from address components
- automatically map NYC borough from Google results
- apply same logic for grouped address fields

## Testing
- `npm run dev` *(fails: concurrently not found)*

------
https://chatgpt.com/codex/tasks/task_e_6844ee91e6ac8331b0c2970fdaf85278