### PR TITLE
Update font styles for input components

### DIFF
--- a/test-form/src/components/shared/AddressAutocomplete/AddressAutocomplete.module.css
+++ b/test-form/src/components/shared/AddressAutocomplete/AddressAutocomplete.module.css
@@ -5,6 +5,8 @@
 .input {
   width: 100%;
   padding: 0.5rem;
+  font-family: inherit;
+  font-size: 1rem;
 }
 .suggestions {
   position: absolute;

--- a/test-form/src/components/shared/FileInput/FileInput.module.css
+++ b/test-form/src/components/shared/FileInput/FileInput.module.css
@@ -1,2 +1,7 @@
 .field { margin-bottom: 1rem; }
-.input { width: 100%; padding: 0.5rem; }
+.input {
+  width: 100%;
+  padding: 0.5rem;
+  font-family: inherit;
+  font-size: 1rem;
+}

--- a/test-form/src/components/shared/MaskedInput/MaskedInput.module.css
+++ b/test-form/src/components/shared/MaskedInput/MaskedInput.module.css
@@ -1,2 +1,7 @@
 .field { margin-bottom: 1rem; }
-.input { width: 100%; padding: 0.5rem; }
+.input {
+  width: 100%;
+  padding: 0.5rem;
+  font-family: inherit;
+  font-size: 1rem;
+}

--- a/test-form/src/components/shared/SelectField/SelectField.module.css
+++ b/test-form/src/components/shared/SelectField/SelectField.module.css
@@ -1,2 +1,7 @@
 .field { margin-bottom: 1rem; }
-.select { width: 100%; padding: 0.5rem; }
+.select {
+  width: 100%;
+  padding: 0.5rem;
+  font-family: inherit;
+  font-size: 1rem;
+}

--- a/test-form/src/components/shared/TextInput/TextInput.module.css
+++ b/test-form/src/components/shared/TextInput/TextInput.module.css
@@ -1,2 +1,7 @@
 .field { margin-bottom: 1rem; }
-.input { width: 100%; padding: 0.5rem; }
+.input {
+  width: 100%;
+  padding: 0.5rem;
+  font-family: inherit;
+  font-size: 1rem;
+}

--- a/test-form/src/form.css
+++ b/test-form/src/form.css
@@ -224,6 +224,7 @@ select {
   width: 100%;
   padding: 0.6rem 0.75rem;
   font-size: 1rem;
+  font-family: inherit;
   border: 1px solid var(--border);
   border-radius: 6px;
   background: white;


### PR DESCRIPTION
## Summary
- add font inheritance & font size to input-related CSS modules
- ensure global input styles inherit font family

## Testing
- `npm test --silent -- --watchAll=false` *(fails: react-scripts not found)*

------
https://chatgpt.com/codex/tasks/task_e_6844f409ab288331837c6ca257ef223d