### PR TITLE
Enhance street address field UX

### DIFF
--- a/test-form/src/components/core/Step/Step.jsx
+++ b/test-form/src/components/core/Step/Step.jsx
@@ -34,6 +34,7 @@ export default function Step({
   const [formData, setFormData] = useState(initialData);
   const [errors, setErrors] = useState({});
   const [touched, setTouched] = useState({});
+  const [placeholders, setPlaceholders] = useState({});
 
   // Update local form data when parent data changes (e.g., returning to a step)
   useEffect(() => {
@@ -207,8 +208,12 @@ export default function Step({
                 label={field.label}
                 required={isRequired}
                 value={formData[field.id] || ''}
+                placeholder={placeholders[field.id] || field.ui?.placeholder || ''}
                 onChange={(val) => handleChange(field.id, val)}
                 onAddressSelect={(addr) => {
+                  const fullAddr = addr.formatted_address || addr.formattedAddress || '';
+                  setPlaceholders((p) => ({ ...p, [field.id]: fullAddr }));
+
                   const components = addr.address_components || addr.addressComponents || [];
                   const comps = {};
                   components.forEach((c) => {
@@ -219,7 +224,6 @@ export default function Step({
                       };
                     });
                   });
-                  handleChange(field.id, addr.formatted_address || addr.formattedAddress || '');
                   if (findFieldById('city')) {
                     const cityVal =
                       comps.locality?.long_name ||
@@ -279,6 +283,9 @@ export default function Step({
                   ) {
                     handleChange('longitude', addr.location.longitude);
                   }
+
+                  const streetOnly = fullAddr.split(',')[0];
+                  handleChange(field.id, streetOnly);
                 }}
               />
               {error && <div className="form-error-alert">{error}</div>}

--- a/test-form/src/components/shared/AddressAutocomplete/AddressAutocomplete.jsx
+++ b/test-form/src/components/shared/AddressAutocomplete/AddressAutocomplete.jsx
@@ -112,6 +112,7 @@ export default function AddressAutocomplete({
         autoComplete="off"
         {...props}
       />
+      <span className={styles.icon}>🔍</span>
       {showSuggestions && suggestions.length > 0 && (
         <ul className={styles.suggestions}>
           {suggestions.map((s, i) => (

--- a/test-form/src/components/shared/AddressAutocomplete/AddressAutocomplete.module.css
+++ b/test-form/src/components/shared/AddressAutocomplete/AddressAutocomplete.module.css
@@ -5,8 +5,17 @@
 .input {
   width: 100%;
   padding: 0.5rem;
+  padding-right: 2rem;
   font-family: inherit;
   font-size: 1rem;
+}
+.icon {
+  position: absolute;
+  right: 0.5rem;
+  top: 50%;
+  transform: translateY(-50%);
+  pointer-events: none;
+  color: #555;
 }
 .suggestions {
   position: absolute;

--- a/test-form/src/components/shared/GroupField/GroupField.jsx
+++ b/test-form/src/components/shared/GroupField/GroupField.jsx
@@ -14,6 +14,7 @@ export default function GroupField({ field, value = [], onChange, fullData = {} 
   const [editingIndex, setEditingIndex] = useState(null);
   const [showForm, setShowForm] = useState(false);
   const [entryErrors, setEntryErrors] = useState({});
+  const [placeholders, setPlaceholders] = useState({});
 
   useEffect(() => {
     setEntries(Array.isArray(value) ? value : []);
@@ -190,8 +191,12 @@ export default function GroupField({ field, value = [], onChange, fullData = {} 
               <AddressAutocomplete
                 key={subField.id}
                 {...commonProps}
+                placeholder={placeholders[subField.id] || subField.ui?.placeholder || ''}
                 onChange={(val) => handleInputChange(subField.id, val)}
                 onAddressSelect={(addr) => {
+                  const fullAddr = addr.formatted_address || addr.formattedAddress || '';
+                  setPlaceholders((p) => ({ ...p, [subField.id]: fullAddr }));
+
                   const components = addr.address_components || addr.addressComponents || [];
                   const comps = {};
                   components.forEach((c) => {
@@ -202,7 +207,6 @@ export default function GroupField({ field, value = [], onChange, fullData = {} 
                       };
                     });
                   });
-                  handleInputChange(subField.id, addr.formatted_address || addr.formattedAddress || '');
                   if (field.fields.some((f) => f.id === 'city')) {
                     const cityVal =
                       comps.locality?.long_name ||
@@ -256,6 +260,9 @@ export default function GroupField({ field, value = [], onChange, fullData = {} 
                   if (field.fields.some((f) => f.id === 'longitude') && addr.location?.longitude !== undefined) {
                     handleInputChange('longitude', addr.location.longitude);
                   }
+
+                  const streetOnly = fullAddr.split(',')[0];
+                  handleInputChange(subField.id, streetOnly);
                 }}
               />
               {error && <div className="form-error-alert">{error}</div>}


### PR DESCRIPTION
## Summary
- show search icon on address autocomplete inputs
- temporarily keep selected address in placeholder
- populate other address fields then show only the street in the input

## Testing
- `npm test --prefix test-form` *(fails: react-scripts not found)*

------
https://chatgpt.com/codex/tasks/task_e_6844f5cc9264833189b28f2b4e73bc91