### PR TITLE
Add placeholder prop to SelectField

### DIFF
--- a/test-form/src/components/core/Step/Step.jsx
+++ b/test-form/src/components/core/Step/Step.jsx
@@ -338,6 +338,7 @@ export default function Step({
               id={field.id}
               label={field.label}
               options={field.ui?.options || []}
+              placeholder={field.ui?.placeholder || `Select ${field.label}`}
               required={isRequired}
               value={formData[field.id] || ''}
               onChange={(e) => handleChange(field.id, e.target.value)}

--- a/test-form/src/components/shared/GroupField/GroupField.jsx
+++ b/test-form/src/components/shared/GroupField/GroupField.jsx
@@ -130,7 +130,12 @@ export default function GroupField({ field, value = [], onChange, fullData = {} 
       case 'select':
         return (
           <>
-            <SelectField key={subField.id} options={subField.ui?.options || []} {...commonProps} />
+            <SelectField
+              key={subField.id}
+              options={subField.ui?.options || []}
+              placeholder={subField.ui?.placeholder || `Select ${subField.label}`}
+              {...commonProps}
+            />
             {error && <div className="form-error-alert">{error}</div>}
           </>
         );

--- a/test-form/src/components/shared/SelectField/SelectField.jsx
+++ b/test-form/src/components/shared/SelectField/SelectField.jsx
@@ -1,11 +1,17 @@
 import React from 'react';
 import styles from './SelectField.module.css';
 
+// SelectField renders a dropdown. When a `placeholder` prop is provided and the
+// select is not in multiple mode, an empty option will be displayed with that
+// text.
+
 export default function SelectField({
   id,
   label,
   options = [],
   multiple = false,
+  // placeholder text for a default empty option when not using multiple select
+  placeholder,
   minSelections,
   maxSelections,
   ...props
@@ -21,6 +27,9 @@ export default function SelectField({
         data-max={maxSelections}
         {...props}
       >
+        {placeholder && !multiple && (
+          <option value="">{placeholder}</option>
+        )}
         {options.map((opt) => {
           const value = typeof opt === 'string' ? opt : opt.value;
           const labelText = typeof opt === 'string' ? opt : opt.label;

--- a/test-form/src/components/shared/SelectField/SelectField.test.js
+++ b/test-form/src/components/shared/SelectField/SelectField.test.js
@@ -1,0 +1,16 @@
+import { render, screen } from '@testing-library/react';
+import SelectField from './SelectField';
+
+test('renders placeholder option when provided', () => {
+  render(
+    <SelectField
+      id="test"
+      label="Test"
+      options={['One', 'Two']}
+      placeholder="Select option"
+    />
+  );
+  const placeholderOpt = screen.getByRole('option', { name: 'Select option' });
+  expect(placeholderOpt).toBeInTheDocument();
+  expect(placeholderOpt).toHaveValue('');
+});


### PR DESCRIPTION
## Summary
- add `placeholder` support in `SelectField` component
- show placeholder for single selects in `Step` and `GroupField`
- test placeholder rendering in `SelectField`

## Testing
- `npm test --silent` *(fails: react-scripts not found)*

------
https://chatgpt.com/codex/tasks/task_e_6844fa53e144833183affddbb7bc5576