### PR TITLE
Add dashboard and allow saving drafts

### DIFF
--- a/test-form/src/App.js
+++ b/test-form/src/App.js
@@ -1,10 +1,22 @@
 import { useState } from "react";
 import "./form.css";
 import FormPage from "./pages/FormPage";
+import Dashboard from "./pages/Dashboard";
 import './App.css';
 
 function App() {
   const [menuOpen, setMenuOpen] = useState(false);
+  const [page, setPage] = useState('dashboard');
+  const [currentId, setCurrentId] = useState(null);
+
+  const startApplication = (id) => {
+    setCurrentId(id);
+    setPage('form');
+  };
+
+  const exitForm = () => {
+    setPage('dashboard');
+  };
 
   return (
     <div className="page-container">
@@ -17,13 +29,17 @@ function App() {
         </div>
 
         <nav className={`right ${menuOpen ? "open" : ""}`}>
-          <a href="#account">Dashboard</a>
+          <button onClick={() => setPage('dashboard')}>Dashboard</button>
           <a href="#settings">Profile</a>
         </nav>
       </header>
 
       <main className="form-body">
-        <FormPage />
+        {page === 'dashboard' ? (
+          <Dashboard onStart={startApplication} />
+        ) : (
+          <FormPage applicationId={currentId} onExit={exitForm} />
+        )}
       </main>
 
       <footer className="form-footer">

--- a/test-form/src/components/core/Step/Step.jsx
+++ b/test-form/src/components/core/Step/Step.jsx
@@ -24,6 +24,7 @@ export default function Step({
   sections = [],
   onNext,
   onBack,
+  onSaveDraft,
   isFirst = false,
   isLast = false,
   formData: initialData = {},
@@ -527,6 +528,10 @@ export default function Step({
     onBack && onBack(formData);
   };
 
+  const handleSaveDraftClick = () => {
+    onSaveDraft && onSaveDraft(formData);
+  };
+
   return (
     <div className={styles.step}>
       <h2>{title}</h2>
@@ -610,6 +615,9 @@ export default function Step({
             Back
           </button>
         )}
+        <button type="button" onClick={handleSaveDraftClick}>
+          Save Draft
+        </button>
         {!isLast && (
           <button type="button" onClick={handleNextClick}>
             Next

--- a/test-form/src/pages/Dashboard.jsx
+++ b/test-form/src/pages/Dashboard.jsx
@@ -1,0 +1,44 @@
+import React, { useState, useEffect } from 'react';
+import { loadApplications, saveApplications } from '../utils/appStorage';
+
+export default function Dashboard({ onStart }) {
+  const [apps, setApps] = useState([]);
+
+  useEffect(() => {
+    setApps(loadApplications());
+  }, []);
+
+  const handleNew = () => {
+    const id = Date.now().toString();
+    const newApp = { id, stepData: {}, allData: {}, currentStep: 0 };
+    const updated = [...apps, newApp];
+    saveApplications(updated);
+    setApps(updated);
+    onStart && onStart(id);
+  };
+
+  const handleContinue = (id) => {
+    onStart && onStart(id);
+  };
+
+  return (
+    <div className="dashboard-page">
+      <h1>Service Catalog</h1>
+      <button onClick={handleNew}>Start Child Care Assistance Application</button>
+
+      {apps.length > 0 && (
+        <div className="draft-list">
+          <h2>Saved Applications</h2>
+          <ul>
+            {apps.map((app) => (
+              <li key={app.id}>
+                Application {app.id}
+                <button onClick={() => handleContinue(app.id)}>Continue</button>
+              </li>
+            ))}
+          </ul>
+        </div>
+      )}
+    </div>
+  );
+}

--- a/test-form/src/pages/FormPage.jsx
+++ b/test-form/src/pages/FormPage.jsx
@@ -1,6 +1,6 @@
 import React from 'react';
 import FormRenderer from '../components/core/FormRenderer/FormRenderer';
 
-export default function FormPage() {
-  return <FormRenderer />;
+export default function FormPage({ applicationId, onExit }) {
+  return <FormRenderer applicationId={applicationId} onExit={onExit} />;
 }

--- a/test-form/src/utils/appStorage.js
+++ b/test-form/src/utils/appStorage.js
@@ -1,0 +1,27 @@
+export function loadApplications() {
+  try {
+    const raw = localStorage.getItem('childcareApplications');
+    return raw ? JSON.parse(raw) : [];
+  } catch {
+    return [];
+  }
+}
+
+export function saveApplications(apps) {
+  localStorage.setItem('childcareApplications', JSON.stringify(apps));
+}
+
+export function getApplication(id) {
+  return loadApplications().find((a) => a.id === id);
+}
+
+export function upsertApplication(id, data) {
+  const apps = loadApplications();
+  const idx = apps.findIndex((a) => a.id === id);
+  if (idx !== -1) {
+    apps[idx] = { ...apps[idx], ...data, id };
+  } else {
+    apps.push({ id, ...data });
+  }
+  saveApplications(apps);
+}


### PR DESCRIPTION
## Summary
- add minimal dashboard to start or resume childcare forms
- persist applications in `localStorage`
- add Save Draft button in form stepper
- wire form renderer to load/save drafts

## Testing
- `npm test` *(fails: react-scripts not found)*

------
https://chatgpt.com/codex/tasks/task_e_6845087f86c08331b720e2a01c8435da