### PR TITLE
Enhance dashboard with card UI

### DIFF
--- a/test-form/src/components/ApplicationCard.jsx
+++ b/test-form/src/components/ApplicationCard.jsx
@@ -1,0 +1,14 @@
+import React from 'react';
+
+export default function ApplicationCard({ id, serviceName, interactionName, savedAt, onContinue }) {
+  const formatted = savedAt ? new Date(savedAt).toLocaleString() : '';
+  return (
+    <div className="card app-card">
+      <h3 className="card-title">{serviceName}</h3>
+      <p className="interaction-name">{interactionName}</p>
+      <p className="app-id">ID: {id}</p>
+      {formatted && <p className="saved-date">Saved: {formatted}</p>}
+      <button onClick={() => onContinue(id)}>Continue</button>
+    </div>
+  );
+}

--- a/test-form/src/components/ServiceCard.jsx
+++ b/test-form/src/components/ServiceCard.jsx
@@ -1,0 +1,12 @@
+import React from 'react';
+
+export default function ServiceCard({ name, interaction, description, onStart }) {
+  return (
+    <div className="card service-card">
+      <h2 className="card-title">{name}</h2>
+      <p className="interaction-name">{interaction}</p>
+      <p className="description">{description}</p>
+      <button onClick={onStart}>Start Application</button>
+    </div>
+  );
+}

--- a/test-form/src/components/core/FormRenderer/FormRenderer.jsx
+++ b/test-form/src/components/core/FormRenderer/FormRenderer.jsx
@@ -62,6 +62,7 @@ export default function FormRenderer({ applicationId, onExit }) {
       stepData: { ...stepData, [steps[currentStep].id]: data },
       allData: { ...allData, ...data },
       currentStep,
+      updatedAt: new Date().toISOString(),
     });
     onExit && onExit();
   };

--- a/test-form/src/form.css
+++ b/test-form/src/form.css
@@ -308,3 +308,25 @@ button:disabled {
 
 
 
+
+/* Card layouts */
+.card {
+  background: var(--surface);
+  border: 1px solid var(--border);
+  border-radius: var(--radius);
+  padding: 1rem;
+  box-shadow: var(--shadow);
+  max-width: 320px;
+}
+
+.catalog-grid,
+.saved-grid {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 1rem;
+  margin-top: 1rem;
+}
+
+.card-title {
+  margin-top: 0;
+}

--- a/test-form/src/pages/Dashboard.jsx
+++ b/test-form/src/pages/Dashboard.jsx
@@ -1,5 +1,7 @@
 import React, { useState, useEffect } from 'react';
 import { loadApplications, saveApplications } from '../utils/appStorage';
+import ServiceCard from '../components/ServiceCard';
+import ApplicationCard from '../components/ApplicationCard';
 
 export default function Dashboard({ onStart }) {
   const [apps, setApps] = useState([]);
@@ -10,7 +12,15 @@ export default function Dashboard({ onStart }) {
 
   const handleNew = () => {
     const id = Date.now().toString();
-    const newApp = { id, stepData: {}, allData: {}, currentStep: 0 };
+    const newApp = {
+      id,
+      stepData: {},
+      allData: {},
+      currentStep: 0,
+      serviceName: 'Child Care Assistance',
+      interactionName: 'Child Care Assistance Application',
+      updatedAt: new Date().toISOString(),
+    };
     const updated = [...apps, newApp];
     saveApplications(updated);
     setApps(updated);
@@ -24,19 +34,30 @@ export default function Dashboard({ onStart }) {
   return (
     <div className="dashboard-page">
       <h1>Service Catalog</h1>
-      <button onClick={handleNew}>Start Child Care Assistance Application</button>
+      <div className="catalog-grid">
+        <ServiceCard
+          name="Child Care Assistance"
+          interaction="Child Care Assistance Application"
+          description="Step-by-step form for applying for Childcare Assistance"
+          onStart={handleNew}
+        />
+      </div>
 
       {apps.length > 0 && (
         <div className="draft-list">
           <h2>Saved Applications</h2>
-          <ul>
+          <div className="saved-grid">
             {apps.map((app) => (
-              <li key={app.id}>
-                Application {app.id}
-                <button onClick={() => handleContinue(app.id)}>Continue</button>
-              </li>
+              <ApplicationCard
+                key={app.id}
+                id={app.id}
+                serviceName={app.serviceName || 'Child Care Assistance'}
+                interactionName={app.interactionName || 'Child Care Assistance Application'}
+                savedAt={app.updatedAt}
+                onContinue={handleContinue}
+              />
             ))}
-          </ul>
+          </div>
         </div>
       )}
     </div>


### PR DESCRIPTION
## Summary
- add ServiceCard and ApplicationCard components
- show the service catalog item and saved applications in card style
- track the last saved time when saving drafts
- tweak styles for card layout

## Testing
- `npm test --silent` *(fails: react-scripts not found)*

------
https://chatgpt.com/codex/tasks/task_e_68450fe598c48331acaa2a09314b6772