### PR TITLE
Add DYCD Youth Services form

### DIFF
--- a/test-form/src/App.js
+++ b/test-form/src/App.js
@@ -8,8 +8,10 @@ function App() {
   const [menuOpen, setMenuOpen] = useState(false);
   const [page, setPage] = useState('dashboard');
   const [currentId, setCurrentId] = useState(null);
+  const [currentService, setCurrentService] = useState('childcare');
 
-  const startApplication = (id) => {
+  const startApplication = (serviceKey, id) => {
+    setCurrentService(serviceKey);
     setCurrentId(id);
     setPage('form');
   };
@@ -25,7 +27,7 @@ function App() {
           <button className="hamburger" onClick={() => setMenuOpen(!menuOpen)}>
             ☰
           </button>
-          <div className="brand">MyCity Childcare</div>
+          <div className="brand">MyCity Services</div>
         </div>
 
         <nav className={`right ${menuOpen ? "open" : ""}`}>
@@ -38,7 +40,11 @@ function App() {
         {page === 'dashboard' ? (
           <Dashboard onStart={startApplication} />
         ) : (
-          <FormPage applicationId={currentId} onExit={exitForm} />
+          <FormPage
+            applicationId={currentId}
+            service={currentService}
+            onExit={exitForm}
+          />
         )}
       </main>
 

--- a/test-form/src/components/core/FormRenderer/DycdFormRenderer.jsx
+++ b/test-form/src/components/core/FormRenderer/DycdFormRenderer.jsx
@@ -1,0 +1,124 @@
+import React, { useState, useEffect } from 'react';
+import Step from '../Step/Step';
+import Stepper from '../Stepper/Stepper';
+import formSpec from '../../../data/dycd_form.json';
+import { validateStep } from '../../../utils/formHelpers';
+import { getApplication, upsertApplication } from '../../../utils/appStorage';
+
+export default function DycdFormRenderer({ applicationId, onExit }) {
+  const { form } = formSpec;
+  const steps = form.steps || [];
+  const [currentStep, setCurrentStep] = useState(0);
+  const [stepData, setStepData] = useState({});
+  const [allData, setAllData] = useState({});
+  const stepperPosition = form.layout?.stepperPosition || 'right';
+  const orientation = stepperPosition === 'top' ? 'horizontal' : 'vertical';
+
+  useEffect(() => {
+    if (applicationId) {
+      const saved = getApplication(applicationId);
+      if (saved) {
+        setCurrentStep(saved.currentStep || 0);
+        setStepData(saved.stepData || {});
+        setAllData(saved.allData || {});
+      }
+    }
+  }, [applicationId]);
+
+  useEffect(() => {
+    window.scrollTo({ top: 0, behavior: 'auto' });
+  }, [currentStep]);
+
+  const requiredDocs =
+    steps[currentStep]?.sections?.flatMap((section) =>
+      (section.fields || [])
+        .filter((f) => f.type === 'file' && f.required)
+        .map((f) => f.label)
+    ) || [];
+
+  const handleDataChange = (data) => {
+    const stepId = steps[currentStep].id;
+    setStepData((prev) => ({ ...prev, [stepId]: data }));
+    setAllData((prev) => ({ ...prev, ...data }));
+  };
+
+  const handleNext = (data) => {
+    handleDataChange(data);
+    setAllData((prev) => ({ ...prev, ...data }));
+    setCurrentStep((s) => Math.min(s + 1, steps.length - 1));
+    window.scrollTo({ top: 0, behavior: 'auto' });
+  };
+
+  const handleBack = (data) => {
+    handleDataChange(data);
+    setAllData((prev) => ({ ...prev, ...data }));
+    setCurrentStep((s) => Math.max(s - 1, 0));
+    window.scrollTo({ top: 0, behavior: 'auto' });
+  };
+
+  const handleSaveDraft = (data) => {
+    handleDataChange(data);
+    upsertApplication(applicationId, {
+      stepData: { ...stepData, [steps[currentStep].id]: data },
+      allData: { ...allData, ...data },
+      currentStep,
+      updatedAt: new Date().toISOString(),
+    });
+    onExit && onExit();
+  };
+
+  const canNavigate = (targetIndex) => {
+    // allow going to a previous step without checking validation
+    if (targetIndex < currentStep) return true;
+    const { valid } = validateStep(
+      steps[currentStep],
+      stepData[steps[currentStep].id] || {}
+    );
+    return valid;
+  };
+
+  return (
+    <div className={stepperPosition === 'top' ? 'wizard-layout-column' : 'wizard-layout-row'}>
+      {stepperPosition !== 'top' && (
+        <Stepper
+          steps={steps}
+          currentStep={currentStep}
+          onStepChange={setCurrentStep}
+          requiredDocs={requiredDocs}
+          orientation={orientation}
+          canNavigate={canNavigate}
+        />
+      )}
+      <div className="form-main">
+        <h1>{form.title}</h1>
+        <p>{form.description}</p>
+        {stepperPosition === 'top' && (
+          <Stepper
+            steps={steps}
+            currentStep={currentStep}
+            onStepChange={setCurrentStep}
+            requiredDocs={requiredDocs}
+            orientation={orientation}
+            canNavigate={canNavigate}
+          />
+        )}
+        {steps.length > 0 && (
+          <Step
+            key={steps[currentStep].id}
+            title={steps[currentStep].title}
+            sections={steps[currentStep].sections}
+            onNext={handleNext}
+            onBack={handleBack}
+            onSaveDraft={handleSaveDraft}
+            isFirst={currentStep === 0}
+            isLast={currentStep === steps.length - 1}
+            formData={stepData[steps[currentStep].id] || {}}
+            fullData={allData}
+            onDataChange={handleDataChange}
+            applicationId={applicationId}
+          />
+        )}
+      </div>
+    </div>
+  );
+}

--- a/test-form/src/data/dycd_form.json
+++ b/test-form/src/data/dycd_form.json
@@ -1,0 +1,38 @@
+{
+  "form": {
+    "title": "DYCD Youth Services Intake – Ages 13 and Younger",
+    "description": "Form to collect youth and guardian information for DYCD programs",
+    "layout": { "stepperPosition": "top" },
+    "steps": [
+      {
+        "id": "youth_info",
+        "title": "Youth Information",
+        "sections": [
+          {
+            "id": "basic_info",
+            "title": "Basic Information",
+            "fields": [
+              { "id": "first_name", "type": "text", "label": "First Name", "required": true },
+              { "id": "last_name", "type": "text", "label": "Last Name", "required": true },
+              { "id": "age", "type": "number", "label": "Age", "required": true }
+            ]
+          }
+        ]
+      },
+      {
+        "id": "guardian_info",
+        "title": "Guardian Information",
+        "sections": [
+          {
+            "id": "guardian_basic",
+            "title": "Guardian",
+            "fields": [
+              { "id": "guardian_name", "type": "text", "label": "Guardian Name", "required": true },
+              { "id": "guardian_phone", "type": "text", "label": "Guardian Phone", "required": true }
+            ]
+          }
+        ]
+      }
+    ]
+  }
+}

--- a/test-form/src/pages/Dashboard.jsx
+++ b/test-form/src/pages/Dashboard.jsx
@@ -10,25 +10,33 @@ export default function Dashboard({ onStart }) {
     setApps(loadApplications());
   }, []);
 
-  const handleNew = () => {
+  const createNew = (serviceKey) => {
     const id = Date.now().toString();
+    const isDycd = serviceKey === 'dycd';
     const newApp = {
       id,
+      serviceKey,
       stepData: {},
       allData: {},
       currentStep: 0,
-      serviceName: 'Child Care Assistance',
-      interactionName: 'Child Care Assistance Application',
+      serviceName: isDycd
+        ? 'DYCD Youth Services Intake – Ages 13 and Younger'
+        : 'Child Care Assistance',
+      interactionName: isDycd
+        ? 'Youth Services Intake'
+        : 'Child Care Assistance Application',
       updatedAt: new Date().toISOString(),
     };
     const updated = [...apps, newApp];
     saveApplications(updated);
     setApps(updated);
-    onStart && onStart(id);
+    onStart && onStart(serviceKey, id);
   };
 
   const handleContinue = (id) => {
-    onStart && onStart(id);
+    const app = apps.find((a) => a.id === id);
+    const key = app?.serviceKey || 'childcare';
+    onStart && onStart(key, id);
   };
 
   return (
@@ -39,7 +47,13 @@ export default function Dashboard({ onStart }) {
           name="Child Care Assistance"
           interaction="Child Care Assistance Application"
           description="Step-by-step form for applying for Childcare Assistance"
-          onStart={handleNew}
+          onStart={() => createNew('childcare')}
+        />
+        <ServiceCard
+          name="DYCD Youth Services Intake – Ages 13 and Younger"
+          interaction="Youth Services Intake"
+          description="Form to collect youth and guardian information for DYCD programs"
+          onStart={() => createNew('dycd')}
         />
       </div>
 

--- a/test-form/src/pages/FormPage.jsx
+++ b/test-form/src/pages/FormPage.jsx
@@ -1,6 +1,9 @@
 import React from 'react';
 import FormRenderer from '../components/core/FormRenderer/FormRenderer';
-
-export default function FormPage({ applicationId, onExit }) {
+import DycdFormRenderer from '../components/core/FormRenderer/DycdFormRenderer';
+export default function FormPage({ applicationId, service = 'childcare', onExit }) {
+  if (service === 'dycd') {
+    return <DycdFormRenderer applicationId={applicationId} onExit={onExit} />;
+  }
   return <FormRenderer applicationId={applicationId} onExit={onExit} />;
 }


### PR DESCRIPTION
## Summary
- display DYCD intake option in dashboard service catalog
- keep selected service when starting or continuing an application
- support rendering DYCD Youth Services Intake form spec
- add initial `dycd_form.json` data
- update branding to **MyCity Services**

## Testing
- `npm test --silent -- --watchAll=false` *(fails: react-scripts not found)*

------
https://chatgpt.com/codex/tasks/task_e_6845c7e09edc83319d86c64357b838af