### PR TITLE
Add delete option for saved applications

### DIFF
--- a/test-form/src/components/ApplicationCard.jsx
+++ b/test-form/src/components/ApplicationCard.jsx
@@ -1,20 +1,36 @@
 import React from 'react';
 
-export default function ApplicationCard({ id, serviceName, interactionName, savedAt, onContinue }) {
+export default function ApplicationCard({
+  id,
+  serviceName,
+  interactionName,
+  savedAt,
+  onContinue,
+  onDelete,
+}) {
   const formatted = savedAt ? new Date(savedAt).toLocaleString() : '';
   return (
-    <a
-      href="#"
-      className="app-card"
-      onClick={(e) => {
-        e.preventDefault();
-        onContinue && onContinue(id);
-      }}
-    >
+    <div className="app-card">
       <h3 className="card-title">{serviceName}</h3>
       <p className="interaction-name">{interactionName}</p>
       <p className="app-id">ID: {id}</p>
       {formatted && <p className="saved-date">Saved: {formatted}</p>}
-    </a>
+      <div className="app-card-actions">
+        <button
+          onClick={() => {
+            onContinue && onContinue(id);
+          }}
+        >
+          Continue
+        </button>
+        <button
+          onClick={() => {
+            onDelete && onDelete(id);
+          }}
+        >
+          Delete
+        </button>
+      </div>
+    </div>
   );
 }

--- a/test-form/src/form.css
+++ b/test-form/src/form.css
@@ -376,3 +376,13 @@ button:disabled {
 .card-title {
   margin-top: 0;
 }
+
+.app-card-actions {
+  margin-top: 0.5rem;
+  display: flex;
+  gap: 0.5rem;
+}
+
+.app-card-actions button {
+  flex: 1;
+}

--- a/test-form/src/pages/Dashboard.jsx
+++ b/test-form/src/pages/Dashboard.jsx
@@ -1,5 +1,5 @@
 import React, { useState, useEffect } from 'react';
-import { loadApplications, saveApplications } from '../utils/appStorage';
+import { loadApplications, saveApplications, deleteApplication } from '../utils/appStorage';
 import ServiceCard from '../components/ServiceCard';
 import ApplicationCard from '../components/ApplicationCard';
 
@@ -39,6 +39,11 @@ export default function Dashboard({ onStart }) {
     onStart && onStart(key, id);
   };
 
+  const handleDelete = (id) => {
+    deleteApplication(id);
+    setApps((prev) => prev.filter((a) => a.id !== id));
+  };
+
   return (
     <div className="dashboard-page">
       <h1>Service Catalog</h1>
@@ -69,6 +74,7 @@ export default function Dashboard({ onStart }) {
                 interactionName={app.interactionName || 'Child Care Assistance Application'}
                 savedAt={app.updatedAt}
                 onContinue={handleContinue}
+                onDelete={handleDelete}
               />
             ))}
           </div>

--- a/test-form/src/utils/appStorage.js
+++ b/test-form/src/utils/appStorage.js
@@ -25,3 +25,8 @@ export function upsertApplication(id, data) {
   }
   saveApplications(apps);
 }
+
+export function deleteApplication(id) {
+  const updated = loadApplications().filter((a) => a.id !== id);
+  saveApplications(updated);
+}


### PR DESCRIPTION
## Summary
- add helper to delete saved applications
- display Continue and Delete buttons on saved application cards
- handle deleting applications in Dashboard
- style new buttons

## Testing
- `npm test --silent` *(fails: `react-scripts` not found)*

------
https://chatgpt.com/codex/tasks/task_e_6845c99ef6ec8331b2f6b7f14bb1ea46