### PR TITLE
Add section description display

### DIFF
--- a/test-form/src/components/core/Step/Step.jsx
+++ b/test-form/src/components/core/Step/Step.jsx
@@ -573,6 +573,11 @@ export default function Step({
             visible={visible}
           >
             {sec.content && <ReactMarkdown>{sec.content}</ReactMarkdown>}
+            {sec.description && (
+              <div className="form-section-description">
+                <ReactMarkdown>{sec.description}</ReactMarkdown>
+              </div>
+            )}
             {errors[sec.id] && (
               <div className="form-error-alert">{errors[sec.id]}</div>
             )}

--- a/test-form/src/form.css
+++ b/test-form/src/form.css
@@ -159,6 +159,12 @@ h5 {
   border-radius: 6px;
 }
 
+.form-section-description {
+  margin-top: var(--space-sm);
+  font-size: 0.875rem;
+  color: var(--font-muted, #6B7280);
+}
+
 /* Buttons */
 button {
   display: inline-flex;


### PR DESCRIPTION
## Summary
- show `sec.description` below section content in the Step component
- style the description in form.css

## Testing
- `npm test -- --watchAll=false` *(fails: react-scripts not found)*

------
https://chatgpt.com/codex/tasks/task_e_6848db406ddc8331b718595af0c696e8