### PR TITLE
Add description prop to FileInput

### DIFF
--- a/test-form/src/components/shared/FileInput/FileInput.jsx
+++ b/test-form/src/components/shared/FileInput/FileInput.jsx
@@ -1,9 +1,11 @@
 import React from 'react';
+import ReactMarkdown from 'react-markdown';
 import styles from './FileInput.module.css';
 
 export default function FileInput({
   id,
   label,
+  description,
   multiple = false,
   error,
   hint,
@@ -41,6 +43,11 @@ export default function FileInput({
   return (
     <div className={styles.field}>
       {label && <label htmlFor={id}>{label}</label>}
+      {description && (
+        <div className={styles.description}>
+          <ReactMarkdown>{description}</ReactMarkdown>
+        </div>
+      )}
       <input
         id={id}
         type="file"

--- a/test-form/src/components/shared/FileInput/FileInput.module.css
+++ b/test-form/src/components/shared/FileInput/FileInput.module.css
@@ -5,3 +5,9 @@
   font-family: inherit;
   font-size: 1rem;
 }
+
+.description {
+  margin-top: 0.25rem;
+  font-size: 0.875rem;
+  color: #6B7280; /* gray-600 */
+}


### PR DESCRIPTION
## Summary
- handle optional description in FileInput
- style FileInput description text

## Testing
- `npm test --silent --no-watch` *(fails: react-scripts not found)*

------
https://chatgpt.com/codex/tasks/task_e_6848dc2049988331b29c98205148372b