### PR TITLE
Forward description prop to FileInput

### DIFF
--- a/test-form/src/components/core/Step/Step.jsx
+++ b/test-form/src/components/core/Step/Step.jsx
@@ -422,6 +422,7 @@ export default function Step({
             key={field.id}
             id={field.id}
             label={field.label}
+            description={field.description}
             multiple={field.metadata?.multiple}
             required={isRequired}
             onChange={(val) => handleChange(field.id, val)}

--- a/test-form/src/components/shared/GroupField/GroupField.jsx
+++ b/test-form/src/components/shared/GroupField/GroupField.jsx
@@ -170,6 +170,7 @@ export default function GroupField({ field, value = [], onChange, fullData = {} 
         return (
           <FileInput
             key={subField.id}
+            description={subField.description}
             multiple={subField.metadata?.multiple}
             {...commonProps}
             error={error}


### PR DESCRIPTION
## Summary
- pass `description` to FileInput in Step
- forward `description` in GroupField's file input case

## Testing
- `npm test --prefix test-form --silent -- --watchAll=false` *(fails: react-scripts not found)*

------
https://chatgpt.com/codex/tasks/task_e_6848dd1326108331b5985fa284aa92bd