### PR TITLE
Add drop hint for FileInput

### DIFF
--- a/test-form/src/components/shared/FileInput/FileInput.jsx
+++ b/test-form/src/components/shared/FileInput/FileInput.jsx
@@ -14,9 +14,11 @@ export default function FileInput({
   ...props
 }) {
   const [dragOver, setDragOver] = useState(false);
+  const [hasFiles, setHasFiles] = useState(false);
 
   const processFiles = async (files) => {
     if (!onChange || files.length === 0) return;
+    if (files.length > 0) setHasFiles(true);
 
     if (applicationId) {
       const form = new FormData();
@@ -43,6 +45,7 @@ export default function FileInput({
 
   const handleFileChange = (e) => {
     const files = Array.from(e.target.files || []);
+    if (files.length > 0) setHasFiles(true);
     processFiles(files);
   };
 
@@ -51,6 +54,7 @@ export default function FileInput({
     e.stopPropagation();
     setDragOver(false);
     const files = Array.from(e.dataTransfer.files || []);
+    if (files.length > 0) setHasFiles(true);
     processFiles(files);
   };
 
@@ -78,6 +82,11 @@ export default function FileInput({
       {description && (
         <div className={styles.description}>
           <ReactMarkdown>{description}</ReactMarkdown>
+        </div>
+      )}
+      {!hasFiles && (
+        <div className={styles.dropHint} style={{ display: dragOver ? 'none' : 'block' }}>
+          Drop files here
         </div>
       )}
       <input

--- a/test-form/src/components/shared/FileInput/FileInput.module.css
+++ b/test-form/src/components/shared/FileInput/FileInput.module.css
@@ -2,6 +2,10 @@
   margin-bottom: 1rem;
   border: 2px dashed var(--border);
   padding: var(--space-md);
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  justify-content: center;
 }
 
 .dragOver {
@@ -28,5 +32,12 @@
 .description {
   margin-top: 0.25rem;
   font-size: 0.875rem;
+  color: #6B7280; /* gray-600 */
+}
+
+.dropHint {
+  margin-bottom: 0.5rem;
+  text-align: center;
+  font-size: 1.25rem;
   color: #6B7280; /* gray-600 */
 }


### PR DESCRIPTION
## Summary
- enhance drag-and-drop zone by hinting `Drop files here`
- style FileInput container for centered layout

## Testing
- `npm test --silent -- -u` *(fails: react-scripts not found)*

------
https://chatgpt.com/codex/tasks/task_e_6848e2f216a08331917e524b0d2c1dd3