### PR TITLE
Refactor file input layout and show uploaded names

### DIFF
--- a/test-form/src/components/shared/FileInput/FileInput.jsx
+++ b/test-form/src/components/shared/FileInput/FileInput.jsx
@@ -15,10 +15,14 @@ export default function FileInput({
 }) {
   const [dragOver, setDragOver] = useState(false);
   const [hasFiles, setHasFiles] = useState(false);
+  const [fileNames, setFileNames] = useState([]);
 
   const processFiles = async (files) => {
     if (!onChange || files.length === 0) return;
-    if (files.length > 0) setHasFiles(true);
+    if (files.length > 0) {
+      setHasFiles(true);
+      setFileNames(files.map((f) => f.name));
+    }
 
     if (applicationId) {
       const form = new FormData();
@@ -45,7 +49,6 @@ export default function FileInput({
 
   const handleFileChange = (e) => {
     const files = Array.from(e.target.files || []);
-    if (files.length > 0) setHasFiles(true);
     processFiles(files);
   };
 
@@ -54,7 +57,6 @@ export default function FileInput({
     e.stopPropagation();
     setDragOver(false);
     const files = Array.from(e.dataTransfer.files || []);
-    if (files.length > 0) setHasFiles(true);
     processFiles(files);
   };
 
@@ -71,32 +73,41 @@ export default function FileInput({
   };
 
   return (
-    <div
-      className={`${styles.field}${dragOver ? ' ' + styles.dragOver : ''}`}
-      onDragEnter={handleDragOver}
-      onDragOver={handleDragOver}
-      onDragLeave={handleDragLeave}
-      onDrop={handleDrop}
-    >
+    <div className={styles.container}>
       {label && <label htmlFor={id}>{label}</label>}
       {description && (
         <div className={styles.description}>
           <ReactMarkdown>{description}</ReactMarkdown>
         </div>
       )}
-      {!hasFiles && (
-        <div className={styles.dropHint} style={{ display: dragOver ? 'none' : 'block' }}>
-          Drop files here
-        </div>
-      )}
-      <input
-        id={id}
-        type="file"
-        multiple={multiple}
-        onChange={handleFileChange}
-        className={`${styles.input}${error ? ' error' : ''}`}
-        {...props}
-      />
+      <div
+        className={`${styles.field}${dragOver ? ' ' + styles.dragOver : ''}`}
+        onDragEnter={handleDragOver}
+        onDragOver={handleDragOver}
+        onDragLeave={handleDragLeave}
+        onDrop={handleDrop}
+      >
+        {!hasFiles && (
+          <div className={styles.dropHint} style={{ display: dragOver ? 'none' : 'block' }}>
+            Drop files here
+          </div>
+        )}
+        {fileNames.length > 0 && (
+          <ul className={styles.fileList}>
+            {fileNames.map((name) => (
+              <li key={name} className={styles.fileName}>{name}</li>
+            ))}
+          </ul>
+        )}
+        <input
+          id={id}
+          type="file"
+          multiple={multiple}
+          onChange={handleFileChange}
+          className={`${styles.input}${error ? ' error' : ''}`}
+          {...props}
+        />
+      </div>
       {hint && (
         <div className="form-hint text-sm text-gray-500 italic mt-1">{hint}</div>
       )}

--- a/test-form/src/components/shared/FileInput/FileInput.module.css
+++ b/test-form/src/components/shared/FileInput/FileInput.module.css
@@ -1,5 +1,8 @@
-.field {
+.container {
   margin-bottom: 1rem;
+}
+
+.field {
   border: 2px dashed var(--border);
   padding: var(--space-md);
   display: flex;
@@ -40,4 +43,16 @@
   text-align: center;
   font-size: 1.25rem;
   color: #6B7280; /* gray-600 */
+}
+
+.fileList {
+  width: 100%;
+  list-style: none;
+  padding: 0;
+  margin: 0 0 0.5rem 0;
+}
+
+.fileName {
+  font-size: 0.875rem;
+  color: var(--font-color);
 }


### PR DESCRIPTION
## Summary
- adjust FileInput layout so label and description sit outside the drop zone
- track and display uploaded filenames when dropping files

## Testing
- `npm test` *(fails: react-scripts not found)*

------
https://chatgpt.com/codex/tasks/task_e_6848e60009dc83319f82bb4d700b6a49