### PR TITLE
Update FileInput for drag/drop

### DIFF
--- a/test-form/src/components/shared/FileInput/FileInput.jsx
+++ b/test-form/src/components/shared/FileInput/FileInput.jsx
@@ -1,4 +1,4 @@
-import React, { useState } from 'react';
+import React, { useState, useRef } from 'react';
 import ReactMarkdown from 'react-markdown';
 import styles from './FileInput.module.css';
 
@@ -16,6 +16,7 @@ export default function FileInput({
   const [dragOver, setDragOver] = useState(false);
   const [hasFiles, setHasFiles] = useState(false);
   const [fileNames, setFileNames] = useState([]);
+  const inputRef = useRef(null);
 
   const processFiles = async (files) => {
     if (!onChange || files.length === 0) return;
@@ -58,6 +59,11 @@ export default function FileInput({
     setDragOver(false);
     const files = Array.from(e.dataTransfer.files || []);
     processFiles(files);
+    const dt = new DataTransfer();
+    files.forEach((f) => dt.items.add(f));
+    if (inputRef.current) {
+      inputRef.current.files = dt.files;
+    }
   };
 
   const handleDragOver = (e) => {
@@ -100,6 +106,7 @@ export default function FileInput({
           </ul>
         )}
         <input
+          ref={inputRef}
           id={id}
           type="file"
           multiple={multiple}


### PR DESCRIPTION
## Summary
- handle dropped files in `FileInput`
- keep the native `<input>` synced

## Testing
- `npm test --silent` *(fails: react-scripts not found)*

------
https://chatgpt.com/codex/tasks/task_e_6848e7f7a80083318f8bfa1e289d9f22