### PR TITLE
Hide file input value text

### DIFF
--- a/test-form/src/components/shared/FileInput/FileInput.module.css
+++ b/test-form/src/components/shared/FileInput/FileInput.module.css
@@ -22,6 +22,10 @@
   font-size: 1rem;
 }
 
+.input::-webkit-file-upload-text {
+  color: transparent;
+}
+
 .input::file-selector-button,
 .input::-webkit-file-upload-button {
   content: "Upload Files";


### PR DESCRIPTION
## Summary
- hide default file input value text so only the custom file list appears

## Testing
- `CI=true npm test --silent` *(fails: react-scripts not found)*

------
https://chatgpt.com/codex/tasks/task_e_6848e855831c8331a73be85d24ec2cc4