### PR TITLE
Fix file input display

### DIFF
--- a/test-form/src/components/shared/FileInput/FileInput.jsx
+++ b/test-form/src/components/shared/FileInput/FileInput.jsx
@@ -14,14 +14,12 @@ export default function FileInput({
   ...props
 }) {
   const [dragOver, setDragOver] = useState(false);
-  const [hasFiles, setHasFiles] = useState(false);
   const [fileNames, setFileNames] = useState([]);
   const inputRef = useRef(null);
 
   const processFiles = async (files) => {
     if (!onChange || files.length === 0) return;
     if (files.length > 0) {
-      setHasFiles(true);
       setFileNames(files.map((f) => f.name));
     }
 
@@ -93,11 +91,9 @@ export default function FileInput({
         onDragLeave={handleDragLeave}
         onDrop={handleDrop}
       >
-        {!hasFiles && (
-          <div className={styles.dropHint} style={{ display: dragOver ? 'none' : 'block' }}>
-            Drop files here
-          </div>
-        )}
+        <div className={styles.dropHint} style={{ display: dragOver ? 'none' : 'block' }}>
+          Drop files here
+        </div>
         {fileNames.length > 0 && (
           <ul className={styles.fileList}>
             {fileNames.map((name) => (

--- a/test-form/src/components/shared/FileInput/FileInput.module.css
+++ b/test-form/src/components/shared/FileInput/FileInput.module.css
@@ -20,6 +20,7 @@
   padding: 0.5rem;
   font-family: inherit;
   font-size: 1rem;
+  color: transparent; /* hide selected file names across browsers */
 }
 
 .input::-webkit-file-upload-text {
@@ -33,6 +34,7 @@
   border: 1px solid var(--border);
   border-radius: var(--radius-sm);
   background-color: var(--secondary-color);
+  color: var(--font-color); /* show button label */
   cursor: pointer;
 }
 


### PR DESCRIPTION
## Summary
- show drag-and-drop hint even after files selected
- remove redundant state for FileInput
- hide default file list in file input for cross-browser

## Testing
- `npm test` *(fails: react-scripts not found)*

------
https://chatgpt.com/codex/tasks/task_e_6848ea3581808331997ceb2ae144aba4