### PR TITLE
Add tooltip property support in form fields

### DIFF
--- a/test-form/src/components/core/Step/Step.jsx
+++ b/test-form/src/components/core/Step/Step.jsx
@@ -16,6 +16,7 @@ import TableLayout from '../../shared/TableLayout/TableLayout';
 import MaskedInput from '../../shared/MaskedInput/MaskedInput';
 import FileInput from '../../shared/FileInput/FileInput';
 import AddressAutocomplete from '../../shared/AddressAutocomplete';
+import Tooltip from '../../shared/Tooltip/Tooltip';
 import ReactMarkdown from 'react-markdown';
 import styles from './Step.module.css';
 
@@ -307,6 +308,7 @@ export default function Step({
               key={field.id}
               id={field.id}
               label={field.label}
+              tooltip={field.tooltip}
               type={field.type}
               required={isRequired}
               value={formData[field.id] || ''}
@@ -323,6 +325,7 @@ export default function Step({
                 key={field.id}
                 id={field.id}
                 label={field.label}
+                tooltip={field.tooltip}
                 options={field.ui?.options || []}
                 required={isRequired}
                 multiple
@@ -346,6 +349,7 @@ export default function Step({
               key={field.id}
               id={field.id}
               label={field.label}
+              tooltip={field.tooltip}
               options={field.ui?.options || []}
               placeholder={field.ui?.placeholder || `Select ${field.label}`}
               required={isRequired}
@@ -362,6 +366,7 @@ export default function Step({
               key={field.id}
               id={field.id}
               label={field.label}
+              tooltip={field.tooltip}
               options={field.ui?.options || []}
               required={isRequired}
               value={formData[field.id] || ''}
@@ -378,6 +383,7 @@ export default function Step({
                 key={field.id}
                 id={field.id}
                 label={field.label}
+                tooltip={field.tooltip}
                 options={field.ui?.options || []}
                 value={formData[field.id] || []}
                 onChange={(val) => handleChange(field.id, val)}
@@ -397,7 +403,12 @@ export default function Step({
               onChange={(e) => handleChange(field.id, e.target.checked)}
               required={isRequired}
             />
-            {field.label && <label htmlFor={field.id}>{field.label}</label>}
+            {field.label && (
+              <label htmlFor={field.id}>
+                {field.label}
+                <Tooltip text={field.tooltip} />
+              </label>
+            )}
             {error && <div className="form-error-alert">{error}</div>}
           </>
         );
@@ -408,6 +419,7 @@ export default function Step({
               key={field.id}
               id={field.id}
               label={field.label}
+              tooltip={field.tooltip}
               type="date"
               required={isRequired}
               value={formData[field.id] || ''}
@@ -422,6 +434,7 @@ export default function Step({
             key={field.id}
             id={field.id}
             label={field.label}
+            tooltip={field.tooltip}
             description={field.description}
             multiple={field.metadata?.multiple}
             required={isRequired}
@@ -469,6 +482,7 @@ export default function Step({
               key={field.id}
               id={field.id}
               label={field.label}
+              tooltip={field.tooltip}
               type={field.type}
               required={isRequired}
               value={formData[field.id] || ''}

--- a/test-form/src/components/shared/CheckboxGroup/CheckboxGroup.jsx
+++ b/test-form/src/components/shared/CheckboxGroup/CheckboxGroup.jsx
@@ -1,7 +1,8 @@
 import React from 'react';
 import styles from './CheckboxGroup.module.css';
+import Tooltip from '../Tooltip/Tooltip';
 
-export default function CheckboxGroup({ id, label, options = [], value = [], onChange, ...props }) {
+export default function CheckboxGroup({ id, label, tooltip, options = [], value = [], onChange, ...props }) {
   const handleChange = (optionValue, checked) => {
     if (!onChange) return;
     const updated = checked
@@ -12,7 +13,12 @@ export default function CheckboxGroup({ id, label, options = [], value = [], onC
 
   return (
     <fieldset className={styles.group}>
-      {label && <legend>{label}</legend>}
+      {label && (
+        <legend>
+          {label}
+          <Tooltip text={tooltip} />
+        </legend>
+      )}
       {options.map(opt => {
         const optValue = typeof opt === 'string' ? opt : opt.value;
         const optLabel = typeof opt === 'string' ? opt : opt.label;

--- a/test-form/src/components/shared/FileInput/FileInput.jsx
+++ b/test-form/src/components/shared/FileInput/FileInput.jsx
@@ -1,10 +1,12 @@
 import React, { useState, useRef } from 'react';
 import ReactMarkdown from 'react-markdown';
 import styles from './FileInput.module.css';
+import Tooltip from '../Tooltip/Tooltip';
 
 export default function FileInput({
   id,
   label,
+  tooltip,
   description,
   multiple = false,
   error,
@@ -89,7 +91,12 @@ export default function FileInput({
 
   return (
     <div className={styles.container}>
-      {label && <label htmlFor={id}>{label}</label>}
+      {label && (
+        <label htmlFor={id}>
+          {label}
+          <Tooltip text={tooltip} />
+        </label>
+      )}
       {description && (
         <div className={styles.description}>
           <ReactMarkdown>{description}</ReactMarkdown>

--- a/test-form/src/components/shared/GroupField/GroupField.jsx
+++ b/test-form/src/components/shared/GroupField/GroupField.jsx
@@ -6,6 +6,7 @@ import CheckboxGroup from '../CheckboxGroup/CheckboxGroup';
 import FileInput from '../FileInput/FileInput';
 import MaskedInput from '../MaskedInput/MaskedInput';
 import AddressAutocomplete from '../AddressAutocomplete';
+import Tooltip from '../Tooltip/Tooltip';
 import { evaluateCondition } from '../../../utils/formHelpers';
 
 export default function GroupField({ field, value = [], onChange, fullData = {} }) {
@@ -117,6 +118,7 @@ export default function GroupField({ field, value = [], onChange, fullData = {} 
     const commonProps = {
       id: subField.id,
       label: subField.label,
+      tooltip: subField.tooltip,
       required,
       value: currentEntry[subField.id] || '',
       onChange: (e) => handleInputChange(subField.id, e.target ? e.target.value : e),
@@ -154,6 +156,7 @@ export default function GroupField({ field, value = [], onChange, fullData = {} 
               options={subField.ui?.options || []}
               value={currentEntry[subField.id] || []}
               onChange={(val) => handleInputChange(subField.id, val)}
+              {...commonProps}
             />
             {error && <div className="form-error-alert">{error}</div>}
           </>

--- a/test-form/src/components/shared/MaskedInput/MaskedInput.jsx
+++ b/test-form/src/components/shared/MaskedInput/MaskedInput.jsx
@@ -1,11 +1,17 @@
 import React from 'react';
 import { IMaskInput } from 'react-imask';
 import styles from './MaskedInput.module.css';
+import Tooltip from '../Tooltip/Tooltip';
 
-export default function MaskedInput({ id, label, mask, error, onChange, value, placeholder, ...props }) {
+export default function MaskedInput({ id, label, tooltip, mask, error, onChange, value, placeholder, ...props }) {
   return (
     <div className={styles.field}>
-      {label && <label htmlFor={id}>{label}</label>}
+      {label && (
+        <label htmlFor={id}>
+          {label}
+          <Tooltip text={tooltip} />
+        </label>
+      )}
       <IMaskInput
         id={id}
         mask={mask}

--- a/test-form/src/components/shared/RadioGroup/RadioGroup.jsx
+++ b/test-form/src/components/shared/RadioGroup/RadioGroup.jsx
@@ -1,9 +1,11 @@
 import React from 'react';
 import styles from './RadioGroup.module.css';
+import Tooltip from '../Tooltip/Tooltip';
 
 export default function RadioGroup({
   id,
   label,
+  tooltip,
   options = [],
   value,
   onChange,
@@ -11,7 +13,12 @@ export default function RadioGroup({
 }) {
   return (
     <fieldset className={styles.group}>
-      {label && <legend>{label}</legend>}
+      {label && (
+        <legend>
+          {label}
+          <Tooltip text={tooltip} />
+        </legend>
+      )}
       {options.map(opt => {
         const optValue = typeof opt === 'string' ? opt : opt.value;
         const optLabel = typeof opt === 'string' ? opt : opt.label;

--- a/test-form/src/components/shared/SelectField/SelectField.jsx
+++ b/test-form/src/components/shared/SelectField/SelectField.jsx
@@ -1,5 +1,6 @@
 import React from 'react';
 import styles from './SelectField.module.css';
+import Tooltip from '../Tooltip/Tooltip';
 
 // SelectField renders a dropdown. When a `placeholder` prop is provided and the
 // select is not in multiple mode, an empty option will be displayed with that
@@ -8,6 +9,7 @@ import styles from './SelectField.module.css';
 export default function SelectField({
   id,
   label,
+  tooltip,
   options = [],
   multiple = false,
   // placeholder text for a default empty option when not using multiple select
@@ -18,7 +20,12 @@ export default function SelectField({
 }) {
   return (
     <div className={styles.field}>
-      {label && <label htmlFor={id}>{label}</label>}
+      {label && (
+        <label htmlFor={id}>
+          {label}
+          <Tooltip text={tooltip} />
+        </label>
+      )}
       <select
         id={id}
         className={styles.select}

--- a/test-form/src/components/shared/TextInput/TextInput.jsx
+++ b/test-form/src/components/shared/TextInput/TextInput.jsx
@@ -1,10 +1,17 @@
 import React from 'react';
 import styles from './TextInput.module.css';
 
-export default function TextInput({ id, label, ...props }) {
+import Tooltip from '../Tooltip/Tooltip';
+
+export default function TextInput({ id, label, tooltip, ...props }) {
   return (
     <div className={styles.field}>
-      {label && <label htmlFor={id}>{label}</label>}
+      {label && (
+        <label htmlFor={id}>
+          {label}
+          <Tooltip text={tooltip} />
+        </label>
+      )}
       <input id={id} className={styles.input} {...props} />
     </div>
   );

--- a/test-form/src/components/shared/Tooltip/Tooltip.jsx
+++ b/test-form/src/components/shared/Tooltip/Tooltip.jsx
@@ -1,0 +1,17 @@
+import React, { useState } from 'react';
+import styles from './Tooltip.module.css';
+
+export default function Tooltip({ text }) {
+  const [show, setShow] = useState(false);
+  if (!text) return null;
+  return (
+    <span
+      className={styles.wrapper}
+      onMouseEnter={() => setShow(true)}
+      onMouseLeave={() => setShow(false)}
+    >
+      <span className={styles.icon}>ℹ️</span>
+      {show && <span className={styles.tooltip}>{text}</span>}
+    </span>
+  );
+}

--- a/test-form/src/components/shared/Tooltip/Tooltip.module.css
+++ b/test-form/src/components/shared/Tooltip/Tooltip.module.css
@@ -1,0 +1,25 @@
+.wrapper {
+  position: relative;
+  display: inline-block;
+  margin-left: 0.25rem;
+  cursor: help;
+}
+
+.icon {
+  font-size: 0.85rem;
+}
+
+.tooltip {
+  position: absolute;
+  bottom: 100%;
+  left: 50%;
+  transform: translateX(-50%);
+  background: rgba(0, 0, 0, 0.8);
+  color: #fff;
+  padding: 0.25rem 0.5rem;
+  border-radius: 4px;
+  white-space: nowrap;
+  font-size: 0.75rem;
+  z-index: 10;
+  pointer-events: none;
+}


### PR DESCRIPTION
## Summary
- introduce `Tooltip` component with hover effect
- display tooltip text on fields when provided
- pass tooltip prop through Step and GroupField components

## Testing
- `npm test --silent` *(fails: react-scripts not found)*

------
https://chatgpt.com/codex/tasks/task_e_6848f73633b48331a9a3eaaa1ef546d7