### PR TITLE
Fix tooltip style and test setup

### DIFF
--- a/test-form/package-lock.json
+++ b/test-form/package-lock.json
@@ -11,7 +11,7 @@
         "@testing-library/dom": "^10.4.0",
         "@testing-library/jest-dom": "^6.6.3",
         "@testing-library/react": "^16.3.0",
-        "@testing-library/user-event": "^13.5.0",
+        "@testing-library/user-event": "^14.6.1",
         "dotenv": "^16.3.1",
         "express": "^4.18.2",
         "multer": "^1.4.5-lts.1",
@@ -3551,15 +3551,12 @@
       }
     },
     "node_modules/@testing-library/user-event": {
-      "version": "13.5.0",
-      "resolved": "https://registry.npmjs.org/@testing-library/user-event/-/user-event-13.5.0.tgz",
-      "integrity": "sha512-5Kwtbo3Y/NowpkbRuSepbyMFkZmHgD+vPzYB/RJ4oxt5Gj/avFFBYjhw27cqSVPVw/3a67NK1PbiIr9k4Gwmdg==",
+      "version": "14.6.1",
+      "resolved": "https://registry.npmjs.org/@testing-library/user-event/-/user-event-14.6.1.tgz",
+      "integrity": "sha512-vq7fv0rnt+QTXgPxr5Hjc210p6YKq2kmdziLgnsZGgLJ9e6VAShx1pACLuRjd/AS/sr7phAR58OIIpf0LlmQNw==",
       "license": "MIT",
-      "dependencies": {
-        "@babel/runtime": "^7.12.5"
-      },
       "engines": {
-        "node": ">=10",
+        "node": ">=12",
         "npm": ">=6"
       },
       "peerDependencies": {

--- a/test-form/package.json
+++ b/test-form/package.json
@@ -6,7 +6,7 @@
     "@testing-library/dom": "^10.4.0",
     "@testing-library/jest-dom": "^6.6.3",
     "@testing-library/react": "^16.3.0",
-    "@testing-library/user-event": "^13.5.0",
+    "@testing-library/user-event": "^14.6.1",
     "dotenv": "^16.3.1",
     "express": "^4.18.2",
     "multer": "^1.4.5-lts.1",

--- a/test-form/src/components/shared/Tooltip/Tooltip.jsx
+++ b/test-form/src/components/shared/Tooltip/Tooltip.jsx
@@ -4,14 +4,25 @@ import styles from './Tooltip.module.css';
 export default function Tooltip({ text }) {
   const [show, setShow] = useState(false);
   if (!text) return null;
+
   return (
     <span
       className={styles.wrapper}
       onMouseEnter={() => setShow(true)}
       onMouseLeave={() => setShow(false)}
+      onFocus={() => setShow(true)}
+      onBlur={() => setShow(false)}
+      tabIndex="0"
     >
-      <span className={styles.icon}>ℹ️</span>
-      {show && <span className={styles.tooltip}>{text}</span>}
+      <span className={styles.icon} aria-hidden="true">
+        ℹ️
+      </span>
+      <span
+        className={`${styles.tooltip} ${show ? styles.visible : ''}`}
+        role="tooltip"
+      >
+        {text}
+      </span>
     </span>
   );
 }

--- a/test-form/src/components/shared/Tooltip/Tooltip.module.css
+++ b/test-form/src/components/shared/Tooltip/Tooltip.module.css
@@ -1,25 +1,51 @@
 .wrapper {
   position: relative;
-  display: inline-block;
-  margin-left: 0.25rem;
+  display: inline-flex;
+  align-items: center;
+  margin-left: var(--space-xs, 0.25rem);
   cursor: help;
 }
 
 .icon {
   font-size: 0.85rem;
+  color: var(--primary-color, #cc4466);
 }
 
 .tooltip {
   position: absolute;
-  bottom: 100%;
+  bottom: calc(100% + 0.25rem);
+  left: 50%;
+  transform: translateX(-50%) translateY(0.25rem);
+  background: #111827;
+  color: #fff;
+  padding: 0.5rem 0.75rem;
+  border-radius: var(--radius-sm, 4px);
+  max-width: 18rem;
+  white-space: normal;
+  word-wrap: break-word;
+  font-size: 0.75rem;
+  line-height: 1.2;
+  box-shadow: var(--shadow, 0 2px 6px rgba(0, 0, 0, 0.15));
+  opacity: 0;
+  visibility: hidden;
+  pointer-events: none;
+  transition: opacity 0.2s ease-out, transform 0.2s ease-out;
+  z-index: 10;
+}
+
+.visible {
+  opacity: 1;
+  visibility: visible;
+  transform: translateX(-50%) translateY(0);
+}
+
+.tooltip::after {
+  content: '';
+  position: absolute;
+  top: 100%;
   left: 50%;
   transform: translateX(-50%);
-  background: rgba(0, 0, 0, 0.8);
-  color: #fff;
-  padding: 0.25rem 0.5rem;
-  border-radius: 4px;
-  white-space: nowrap;
-  font-size: 0.75rem;
-  z-index: 10;
-  pointer-events: none;
+  border-width: 6px;
+  border-style: solid;
+  border-color: #111827 transparent transparent transparent;
 }

--- a/test-form/src/setupTests.js
+++ b/test-form/src/setupTests.js
@@ -3,3 +3,8 @@
 // expect(element).toHaveTextContent(/react/i)
 // learn more: https://github.com/testing-library/jest-dom
 import '@testing-library/jest-dom';
+// Mock react-markdown to avoid ESM import issues in Jest
+jest.mock('react-markdown', () => {
+  const React = require('react');
+  return ({ children }) => React.createElement('div', null, children);
+});


### PR DESCRIPTION
## Summary
- allow tooltip text wrapping and update show transition
- mock `react-markdown` in Jest setup
- bump `@testing-library/user-event` for tests

## Testing
- `npm test -- --watchAll=false` *(fails: window.scrollTo and crypto not implemented in jsdom)*

------
https://chatgpt.com/codex/tasks/task_e_6848fc3a54fc83319897ff326de73177