### PR TITLE
Add case management backend

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,6 +13,12 @@ npm run dev
 
 The `dev` script runs both the Express API proxy and the React app so you can access the application at `http://localhost:3000`.
 
+## Case management UI
+
+The backend exposes a simple case management dashboard that lists submitted applications stored on the server. Start the server and visit `http://localhost:5000/cases` to review applications.
+
+Selecting an application opens a page with each step's data shown in its own tab for easy review.
+
 ## Environment requirements
 
 - **Node.js**: version 18 or later is recommended.

--- a/test-form/server/data/applications.json
+++ b/test-form/server/data/applications.json
@@ -1,0 +1,10 @@
+[
+  {
+    "id": "sample-1",
+    "updatedAt": "2024-06-20T12:00:00Z",
+    "stepData": {
+      "consent_step": { "agree": true },
+      "instructions_step": { "acknowledged": true }
+    }
+  }
+]

--- a/test-form/server/views/application.ejs
+++ b/test-form/server/views/application.ejs
@@ -1,0 +1,29 @@
+<!DOCTYPE html>
+<html>
+<head>
+  <meta charset="UTF-8" />
+  <title>Application <%= app.id %></title>
+  <link href="https://cdn.jsdelivr.net/npm/bootstrap@5.3.2/dist/css/bootstrap.min.css" rel="stylesheet">
+  <script src="https://cdn.jsdelivr.net/npm/bootstrap@5.3.2/dist/js/bootstrap.bundle.min.js"></script>
+</head>
+<body class="container py-4">
+  <h1>Application <%= app.id %></h1>
+  <a class="btn btn-secondary mb-3" href="/cases">Back to list</a>
+  <ul class="nav nav-tabs" role="tablist">
+    <% Object.keys(app.stepData || {}).forEach(function(stepId, idx){ %>
+      <li class="nav-item" role="presentation">
+        <button class="nav-link <%= idx === 0 ? 'active' : '' %>" data-bs-toggle="tab" data-bs-target="#step-<%= idx %>" type="button" role="tab">
+          <%= stepId %>
+        </button>
+      </li>
+    <% }); %>
+  </ul>
+  <div class="tab-content border border-top-0 p-3">
+    <% Object.keys(app.stepData || {}).forEach(function(stepId, idx){ %>
+      <div class="tab-pane fade <%= idx === 0 ? 'show active' : '' %>" id="step-<%= idx %>" role="tabpanel">
+        <pre><%= JSON.stringify(app.stepData[stepId], null, 2) %></pre>
+      </div>
+    <% }); %>
+  </div>
+</body>
+</html>

--- a/test-form/server/views/applications.ejs
+++ b/test-form/server/views/applications.ejs
@@ -1,0 +1,25 @@
+<!DOCTYPE html>
+<html>
+<head>
+  <meta charset="UTF-8" />
+  <title>Submitted Applications</title>
+  <link href="https://cdn.jsdelivr.net/npm/bootstrap@5.3.2/dist/css/bootstrap.min.css" rel="stylesheet">
+</head>
+<body class="container py-4">
+  <h1>Submitted Applications</h1>
+  <table class="table table-striped">
+    <thead>
+      <tr><th>ID</th><th>Updated At</th><th></th></tr>
+    </thead>
+    <tbody>
+      <% apps.forEach(function(a){ %>
+        <tr>
+          <td><%= a.id %></td>
+          <td><%= a.updatedAt || '' %></td>
+          <td><a class="btn btn-sm btn-primary" href="/cases/<%= a.id %>">View</a></td>
+        </tr>
+      <% }); %>
+    </tbody>
+  </table>
+</body>
+</html>


### PR DESCRIPTION
## Summary
- add case management backend with storage helpers
- expose HTML pages for listing and viewing applications
- note dashboard in README

## Testing
- `npm test --silent --runTestsByPath src/components/shared/GroupField/GroupField.test.js src/components/shared/SelectField/SelectField.test.js src/components/shared/TableLayout/TableLayout.test.js src/__tests__/ChildcareFormNavigation.test.js` *(fails: react-scripts not found)*
- `npm run server` *(fails: Cannot find module 'dotenv')*

------
https://chatgpt.com/codex/tasks/task_e_684a64e177708331876918fd3c50841c