### PR TITLE
Add comprehensive component tests

### DIFF
--- a/test-form/src/components/shared/AddressAutocomplete/AddressAutocomplete.test.jsx
+++ b/test-form/src/components/shared/AddressAutocomplete/AddressAutocomplete.test.jsx
@@ -1,0 +1,21 @@
+import React from 'react';
+import { render, screen } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import '@testing-library/jest-dom';
+import AddressAutocomplete from './AddressAutocomplete';
+
+beforeAll(() => { global.crypto = { randomUUID: () => "uuid" }; });
+test('renders label and input', () => {
+  render(<AddressAutocomplete id="addr" label="Address" />);
+  const input = screen.getByLabelText('Address');
+  expect(input).toBeInTheDocument();
+});
+
+test('calls onChange when typing', async () => {
+  const user = userEvent.setup();
+  const handleChange = jest.fn();
+  render(<AddressAutocomplete id="addr" label="Address" onChange={handleChange} />);
+  const input = screen.getByLabelText('Address');
+  await user.type(input, '123');
+  expect(handleChange).toHaveBeenCalled();
+});

--- a/test-form/src/components/shared/CheckboxGroup/CheckboxGroup.test.jsx
+++ b/test-form/src/components/shared/CheckboxGroup/CheckboxGroup.test.jsx
@@ -1,0 +1,54 @@
+import React from 'react';
+import { render, screen } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import '@testing-library/jest-dom';
+import CheckboxGroup from './CheckboxGroup';
+
+test('renders label and options', () => {
+  render(
+    <CheckboxGroup id="fruit" label="Fruit" options={['Apple', 'Banana']} />
+  );
+  expect(screen.getByText('Fruit')).toBeInTheDocument();
+  expect(screen.getByLabelText('Apple')).toBeInTheDocument();
+  expect(screen.getByLabelText('Banana')).toBeInTheDocument();
+});
+
+test('handles selection and unselection', async () => {
+  const user = userEvent.setup();
+  const handleChange = jest.fn();
+  function Wrapper() {
+    const [val, setVal] = React.useState([]);
+    return (
+      <CheckboxGroup
+        id="fruit"
+        label="Fruit"
+        options={['Apple', 'Banana']}
+        value={val}
+        onChange={(v) => {
+          setVal(v);
+          handleChange(v);
+        }}
+      />
+    );
+  }
+  const { rerender } = render(<Wrapper />);
+  await user.click(screen.getByLabelText('Apple'));
+  expect(handleChange).toHaveBeenLastCalledWith(['Apple']);
+  await user.click(screen.getByLabelText('Banana'));
+  expect(handleChange).toHaveBeenLastCalledWith(['Apple', 'Banana']);
+  await user.click(screen.getByLabelText('Apple'));
+  expect(handleChange).toHaveBeenLastCalledWith(['Banana']);
+});
+
+test('checks boxes based on value prop', () => {
+  render(
+    <CheckboxGroup
+      id="fruit"
+      label="Fruit"
+      options={['Apple', 'Banana']}
+      value={['Banana']}
+    />
+  );
+  expect(screen.getByLabelText('Banana')).toBeChecked();
+  expect(screen.getByLabelText('Apple')).not.toBeChecked();
+});

--- a/test-form/src/components/shared/FileInput/FileInput.test.jsx
+++ b/test-form/src/components/shared/FileInput/FileInput.test.jsx
@@ -1,0 +1,35 @@
+import React from 'react';
+import { render, screen } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import '@testing-library/jest-dom';
+import FileInput from './FileInput';
+
+jest.mock('react-markdown', () => ({ children }) => <div>{children}</div>);
+
+test('uploads single file and displays name', async () => {
+  const user = userEvent.setup();
+  const handleChange = jest.fn();
+  render(<FileInput id="doc" label="Document" onChange={handleChange} />);
+  const file = new File(['hello'], 'hello.txt', { type: 'text/plain' });
+  const input = screen.getByLabelText('Document');
+  await user.upload(input, file);
+  expect(handleChange).toHaveBeenCalledWith(file);
+  expect(screen.getByText('hello.txt')).toBeInTheDocument();
+});
+
+test('supports multiple files', async () => {
+  const user = userEvent.setup();
+  const handleChange = jest.fn();
+  render(
+    <FileInput id="docs" label="Documents" onChange={handleChange} multiple />
+  );
+  const files = [
+    new File(['1'], 'one.txt', { type: 'text/plain' }),
+    new File(['2'], 'two.txt', { type: 'text/plain' })
+  ];
+  const input = screen.getByLabelText('Documents');
+  await user.upload(input, files);
+  expect(handleChange).toHaveBeenCalledWith(files);
+  expect(screen.getByText('one.txt')).toBeInTheDocument();
+  expect(screen.getByText('two.txt')).toBeInTheDocument();
+});

--- a/test-form/src/components/shared/GroupField/GroupField.test.js
+++ b/test-form/src/components/shared/GroupField/GroupField.test.js
@@ -1,6 +1,9 @@
+import ReactMarkdown from 'react-markdown';
 import { render, screen } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
 import GroupField from './GroupField';
+
+jest.mock('react-markdown', () => ({ children }) => <div>{children}</div>);
 
 describe('GroupField component', () => {
   const field = {

--- a/test-form/src/components/shared/MaskedInput/MaskedInput.test.jsx
+++ b/test-form/src/components/shared/MaskedInput/MaskedInput.test.jsx
@@ -1,0 +1,30 @@
+import React from 'react';
+import { render, screen } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import '@testing-library/jest-dom';
+import MaskedInput from './MaskedInput';
+
+jest.mock('react-imask', () => ({
+  IMaskInput: ({ onAccept, ...props }) => (
+    <input {...props} onChange={e => onAccept && onAccept(e.target.value)} />
+  )
+}));
+
+test('renders input with placeholder', () => {
+  render(<MaskedInput id="phone" label="Phone" mask="000" placeholder="123" />);
+  expect(screen.getByPlaceholderText('123')).toBeInTheDocument();
+});
+
+test('calls onChange when typing', async () => {
+  const user = userEvent.setup();
+  const handleChange = jest.fn();
+  render(<MaskedInput id="phone" onChange={handleChange} />);
+  const input = screen.getByRole('textbox');
+  await user.type(input, '42');
+  expect(handleChange).toHaveBeenLastCalledWith('42');
+});
+
+test('shows error text', () => {
+  render(<MaskedInput id="phone" error="Required" />);
+  expect(screen.getByText('Required')).toBeInTheDocument();
+});

--- a/test-form/src/components/shared/RadioGroup/RadioGroup.test.jsx
+++ b/test-form/src/components/shared/RadioGroup/RadioGroup.test.jsx
@@ -1,0 +1,41 @@
+import React from 'react';
+import { render, screen } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import '@testing-library/jest-dom';
+import RadioGroup from './RadioGroup';
+
+test('renders options and label', () => {
+  render(<RadioGroup id="color" label="Color" options={['Red', 'Blue']} />);
+  expect(screen.getByText('Color')).toBeInTheDocument();
+  expect(screen.getByLabelText('Red')).toBeInTheDocument();
+  expect(screen.getByLabelText('Blue')).toBeInTheDocument();
+});
+
+test('calls onChange when option selected', async () => {
+  const user = userEvent.setup();
+  const handleChange = jest.fn();
+  function Wrapper() {
+    const [val, setVal] = React.useState('');
+    return (
+      <RadioGroup
+        id="color"
+        label="Color"
+        options={['Red', 'Blue']}
+        value={val}
+        onChange={(e) => {
+          setVal(e.target.value);
+          handleChange(e);
+        }}
+      />
+    );
+  }
+  render(<Wrapper />);
+  await user.click(screen.getByLabelText('Blue'));
+  expect(handleChange).toHaveBeenCalled();
+  expect(screen.getByLabelText('Blue')).toBeChecked();
+});
+
+test('preselects value', () => {
+  render(<RadioGroup id="color" label="Color" options={['Red', 'Blue']} value="Red" />);
+  expect(screen.getByLabelText('Red')).toBeChecked();
+});

--- a/test-form/src/components/shared/Tooltip/Tooltip.test.jsx
+++ b/test-form/src/components/shared/Tooltip/Tooltip.test.jsx
@@ -1,0 +1,22 @@
+import React from 'react';
+import { render, screen } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import '@testing-library/jest-dom';
+import Tooltip from './Tooltip';
+
+test('renders nothing when no text', () => {
+  const { container } = render(<Tooltip />);
+  expect(container).toBeEmptyDOMElement();
+});
+
+test('shows tooltip on hover', async () => {
+  const user = userEvent.setup();
+  render(<Tooltip text="Info" />);
+  const tooltip = screen.getByRole('tooltip');
+  const wrapper = tooltip.parentElement;
+  expect(tooltip.className).not.toMatch(/visible/);
+  await user.hover(wrapper);
+  expect(tooltip.className).toMatch(/visible/);
+  await user.unhover(wrapper);
+  expect(tooltip.className).not.toMatch(/visible/);
+});


### PR DESCRIPTION
## Summary
- add Jest tests for AddressAutocomplete, CheckboxGroup, FileInput, MaskedInput, RadioGroup and Tooltip
- mock `react-markdown` in GroupField tests to avoid ESM issues

## Testing
- `CI=true npm test -- src/components/shared/AddressAutocomplete/AddressAutocomplete.test.jsx`
- `CI=true npm test -- src/components/shared/CheckboxGroup/CheckboxGroup.test.jsx`
- `CI=true npm test -- src/components/shared/FileInput/FileInput.test.jsx`
- `CI=true npm test -- src/components/shared/MaskedInput/MaskedInput.test.jsx`
- `CI=true npm test -- src/components/shared/RadioGroup/RadioGroup.test.jsx`
- `CI=true npm test -- src/components/shared/Tooltip/Tooltip.test.jsx`
- `CI=true npm test -- src/components/shared/**/*test*.*`

------
https://chatgpt.com/codex/tasks/task_e_684b9f272a34833188fafafb32a6f067