### PR TITLE
Add unit tests for remaining React components

### DIFF
--- a/test-form/src/App.test.js
+++ b/test-form/src/App.test.js
@@ -1,8 +1,11 @@
 import { render, screen } from '@testing-library/react';
 import App from './App';
 
+jest.mock('react-markdown', () => ({ children }) => <div>{children}</div>);
+beforeAll(() => { window.scrollTo = jest.fn(); });
+
 test('renders application header', () => {
   render(<App />);
-  const headerElement = screen.getByText(/MyCity Childcare/i);
+  const headerElement = screen.getByText(/MyCity Services/i);
   expect(headerElement).toBeInTheDocument();
 });

--- a/test-form/src/components/ApplicationCard.test.jsx
+++ b/test-form/src/components/ApplicationCard.test.jsx
@@ -1,0 +1,29 @@
+import React from 'react';
+import { render, screen } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import ApplicationCard from './ApplicationCard';
+
+test('renders details and triggers callbacks', async () => {
+  const user = userEvent.setup();
+  const handleContinue = jest.fn();
+  const handleDelete = jest.fn();
+  render(
+    <ApplicationCard
+      id="1"
+      serviceName="Svc"
+      interactionName="Interact"
+      savedAt="2023-01-01T00:00:00Z"
+      onContinue={handleContinue}
+      onDelete={handleDelete}
+    />
+  );
+
+  expect(screen.getByText('Svc')).toBeInTheDocument();
+  expect(screen.getByText('Interact')).toBeInTheDocument();
+  expect(screen.getByText(/Saved:/)).toBeInTheDocument();
+
+  await user.click(screen.getByRole('button', { name: 'Continue' }));
+  expect(handleContinue).toHaveBeenCalledWith('1');
+  await user.click(screen.getByRole('button', { name: 'Delete' }));
+  expect(handleDelete).toHaveBeenCalledWith('1');
+});

--- a/test-form/src/components/FormComponent.test.jsx
+++ b/test-form/src/components/FormComponent.test.jsx
@@ -1,0 +1,14 @@
+import React from 'react';
+import { render, screen } from '@testing-library/react';
+import FormComponent from './FormComponent';
+
+jest.mock('react-markdown', () => ({ children }) => <div>{children}</div>);
+
+beforeAll(() => {
+  window.scrollTo = jest.fn();
+});
+
+test('renders first step title', () => {
+  render(<FormComponent />);
+  expect(screen.getByText(/MyCity Consent/i)).toBeInTheDocument();
+});

--- a/test-form/src/components/ServiceCard.test.jsx
+++ b/test-form/src/components/ServiceCard.test.jsx
@@ -1,0 +1,19 @@
+import React from 'react';
+import { render, screen } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import ServiceCard from './ServiceCard';
+
+test('calls onStart when clicked', async () => {
+  const user = userEvent.setup();
+  const onStart = jest.fn();
+  render(
+    <ServiceCard
+      name="Service"
+      interaction="Interact"
+      description="Desc"
+      onStart={onStart}
+    />
+  );
+  await user.click(screen.getByRole('link'));
+  expect(onStart).toHaveBeenCalled();
+});

--- a/test-form/src/components/core/FormRenderer/DycdFormRenderer.test.jsx
+++ b/test-form/src/components/core/FormRenderer/DycdFormRenderer.test.jsx
@@ -1,0 +1,20 @@
+import React from 'react';
+import { render, screen } from '@testing-library/react';
+import DycdFormRenderer from './DycdFormRenderer';
+
+jest.mock('react-markdown', () => ({ children }) => <div>{children}</div>);
+
+beforeAll(() => {
+  window.scrollTo = jest.fn();
+});
+
+beforeAll(() => {
+  window.scrollTo = jest.fn();
+});
+
+test('renders DYCD form title', () => {
+  render(<DycdFormRenderer />);
+  expect(
+    screen.getByRole('heading', { level: 1, name: /DYCD Youth Services Intake/i })
+  ).toBeInTheDocument();
+});

--- a/test-form/src/components/core/FormRenderer/FormRenderer.test.jsx
+++ b/test-form/src/components/core/FormRenderer/FormRenderer.test.jsx
@@ -1,0 +1,20 @@
+import React from 'react';
+import { render, screen } from '@testing-library/react';
+import FormRenderer from './FormRenderer';
+
+jest.mock('react-markdown', () => ({ children }) => <div>{children}</div>);
+
+beforeAll(() => {
+  window.scrollTo = jest.fn();
+});
+
+beforeAll(() => {
+  window.scrollTo = jest.fn();
+});
+
+test('renders form title', () => {
+  render(<FormRenderer />);
+  expect(
+    screen.getByRole('heading', { level: 1, name: /Childcare Voucher Application/i })
+  ).toBeInTheDocument();
+});

--- a/test-form/src/components/core/InfoSection/InfoSection.test.jsx
+++ b/test-form/src/components/core/InfoSection/InfoSection.test.jsx
@@ -1,0 +1,22 @@
+import React from 'react';
+import { render, screen } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import InfoSection from './InfoSection';
+
+jest.mock('react-markdown', () => ({ children }) => <div>{children}</div>);
+
+test('renders title and content', () => {
+  render(<InfoSection title="Info" content="Test" />);
+  expect(screen.getByText('Info')).toBeInTheDocument();
+  expect(screen.getByText('Test')).toBeInTheDocument();
+});
+
+test('calls onToggle when header clicked', async () => {
+  const user = userEvent.setup();
+  const onToggle = jest.fn();
+  render(
+    <InfoSection title="Collapsible" content="Content" ui={{ collapsible: true }} onToggle={onToggle} />
+  );
+  await user.click(screen.getByText('Collapsible'));
+  expect(onToggle).toHaveBeenCalled();
+});

--- a/test-form/src/components/core/Section/Section.test.jsx
+++ b/test-form/src/components/core/Section/Section.test.jsx
@@ -1,0 +1,31 @@
+import React from 'react';
+import { render, screen } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import Section from './Section';
+
+jest.mock('./Section.module.css', () => ({}));
+
+test('renders title and children', () => {
+  render(
+    <Section title="Title">
+      <div>Child</div>
+    </Section>
+  );
+  expect(screen.getByText('Title')).toBeInTheDocument();
+  expect(screen.getByText('Child')).toBeInTheDocument();
+});
+
+test('does not render when visible is false', () => {
+  const { container } = render(
+    <Section title="Hidden" visible={false} />
+  );
+  expect(container.firstChild).toBeNull();
+});
+
+test('calls onToggle when header clicked', async () => {
+  const user = userEvent.setup();
+  const onToggle = jest.fn();
+  render(<Section title="Toggle" onToggle={onToggle} />);
+  await user.click(screen.getByText('Toggle'));
+  expect(onToggle).toHaveBeenCalled();
+});

--- a/test-form/src/components/core/Step/Step.test.jsx
+++ b/test-form/src/components/core/Step/Step.test.jsx
@@ -1,0 +1,32 @@
+import React from 'react';
+import { render, screen } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import Step from './Step';
+
+jest.mock('./Step.module.css', () => ({}));
+jest.mock('../Section/Section.module.css', () => ({}));
+jest.mock('../InfoSection/InfoSection.module.css', () => ({}));
+
+// Mock ReactMarkdown to avoid parsing
+jest.mock('react-markdown', () => ({ children }) => <div>{children}</div>);
+
+test('submits data on next click', async () => {
+  const user = userEvent.setup();
+  const onNext = jest.fn();
+  const sections = [
+    {
+      id: 'sec',
+      title: 'Sec',
+      fields: [
+        { id: 'name', label: 'Name', type: 'text', required: true }
+      ]
+    }
+  ];
+  render(
+    <Step title="Step" sections={sections} onNext={onNext} />
+  );
+
+  await user.type(screen.getByLabelText('Name'), 'John');
+  await user.click(screen.getByRole('button', { name: 'Next' }));
+  expect(onNext).toHaveBeenCalledWith({ name: 'John' });
+});

--- a/test-form/src/components/core/Stepper/Stepper.test.jsx
+++ b/test-form/src/components/core/Stepper/Stepper.test.jsx
@@ -1,0 +1,20 @@
+import React from 'react';
+import { render, screen } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import Stepper from './Stepper';
+
+jest.mock('./Stepper.module.css', () => ({}));
+
+test('calls onStepChange when step clicked', async () => {
+  const user = userEvent.setup();
+  const onStepChange = jest.fn();
+  const steps = [
+    { id: 'one', title: 'One' },
+    { id: 'two', title: 'Two' },
+  ];
+  render(
+    <Stepper steps={steps} currentStep={0} onStepChange={onStepChange} />
+  );
+  await user.click(screen.getByText('Two'));
+  expect(onStepChange).toHaveBeenCalledWith(1);
+});

--- a/test-form/src/pages/Dashboard.test.jsx
+++ b/test-form/src/pages/Dashboard.test.jsx
@@ -1,0 +1,5 @@
+import Dashboard from './Dashboard';
+
+test('exports component', () => {
+  expect(typeof Dashboard).toBe('function');
+});

--- a/test-form/src/pages/FormPage.test.jsx
+++ b/test-form/src/pages/FormPage.test.jsx
@@ -1,0 +1,16 @@
+import React from 'react';
+import { render, screen } from '@testing-library/react';
+import FormPage from './FormPage';
+
+jest.mock('../components/core/FormRenderer/FormRenderer', () => () => <div>Default Form</div>);
+jest.mock('../components/core/FormRenderer/DycdFormRenderer', () => () => <div>DYCD Form</div>);
+
+test('renders DYCD renderer when service is dycd', () => {
+  render(<FormPage service="dycd" />);
+  expect(screen.getByText('DYCD Form')).toBeInTheDocument();
+});
+
+test('renders default renderer when service is childcare', () => {
+  render(<FormPage service="childcare" />);
+  expect(screen.getByText('Default Form')).toBeInTheDocument();
+});


### PR DESCRIPTION
## Summary
- add tests for each JSX component lacking coverage
- mock `react-markdown` and window.scrollTo in tests
- adjust `App.test.js` header expectation

## Testing
- `CI=true npm test -- --watchAll=false src/components/ApplicationCard.test.jsx src/components/ServiceCard.test.jsx src/components/FormComponent.test.jsx src/components/core/FormRenderer/FormRenderer.test.jsx src/components/core/FormRenderer/DycdFormRenderer.test.jsx src/components/core/InfoSection/InfoSection.test.jsx src/components/core/Section/Section.test.jsx src/components/core/Stepper/Stepper.test.jsx src/components/core/Step/Step.test.jsx src/pages/Dashboard.test.jsx src/pages/FormPage.test.jsx src/App.test.js --runInBand`

------
https://chatgpt.com/codex/tasks/task_e_684ba7f52ecc8331bab9aff115e10c05