### PR TITLE
Skip info-only sections in review

### DIFF
--- a/test-form/src/components/core/ReviewStep/ReviewStep.jsx
+++ b/test-form/src/components/core/ReviewStep/ReviewStep.jsx
@@ -6,6 +6,11 @@ export default function ReviewStep({ steps = [], stepData = {}, onEdit, onSubmit
       <h2>Review &amp; Submit</h2>
       {steps.map((step, idx) => {
         if (step.type === 'review') return null;
+        const isInfoOnly =
+          Array.isArray(step.sections) &&
+          step.sections.length > 0 &&
+          step.sections.every(sec => sec.type === 'info');
+        if (isInfoOnly) return null;
         const data = stepData[step.id] || {};
         return (
           <div key={step.id} className="review-section">

--- a/test-form/src/components/core/ReviewStep/ReviewStep.test.jsx
+++ b/test-form/src/components/core/ReviewStep/ReviewStep.test.jsx
@@ -20,3 +20,18 @@ test('calls handlers on edit and submit', async () => {
   await user.click(screen.getByRole('button', { name: /submit application/i }));
   expect(onSubmit).toHaveBeenCalled();
 });
+
+test('skips steps that only contain info sections', () => {
+  const steps = [
+    {
+      id: 'info',
+      title: 'Info Only',
+      sections: [
+        { id: 's1', type: 'info', title: 'Info' }
+      ]
+    },
+    { id: 'review', title: 'Review & Submit', type: 'review' }
+  ];
+  render(<ReviewStep steps={steps} stepData={{}} onEdit={() => {}} onSubmit={() => {}} />);
+  expect(screen.queryByRole('heading', { level: 3, name: /info only/i })).not.toBeInTheDocument();
+});


### PR DESCRIPTION
## Summary
- hide steps comprised solely of info sections in ReviewStep
- test review skip for info-only steps

## Testing
- `npm test --silent` *(fails: Must use import to load ES Module react-imask)*

------
https://chatgpt.com/codex/tasks/task_e_6851c0acbcdc8331b9c47ab0c4f4e581