### PR TITLE
Add back link from steps to review

### DIFF
--- a/test-form/src/components/core/FormRenderer/DycdFormRenderer.jsx
+++ b/test-form/src/components/core/FormRenderer/DycdFormRenderer.jsx
@@ -12,6 +12,8 @@ export default function DycdFormRenderer({ applicationId, onExit }) {
   const [currentStep, setCurrentStep] = useState(0);
   const [stepData, setStepData] = useState({});
   const [allData, setAllData] = useState({});
+  const reviewIndex = steps.findIndex((s) => s.type === 'review');
+  const [editingFromReview, setEditingFromReview] = useState(false);
   const stepperPosition = form.layout?.stepperPosition || 'right';
   const orientation = stepperPosition === 'top' ? 'horizontal' : 'vertical';
 
@@ -29,6 +31,12 @@ export default function DycdFormRenderer({ applicationId, onExit }) {
   useEffect(() => {
     window.scrollTo({ top: 0, behavior: 'auto' });
   }, [currentStep]);
+
+  useEffect(() => {
+    if (currentStep === reviewIndex) {
+      setEditingFromReview(false);
+    }
+  }, [currentStep, reviewIndex]);
 
   const requiredDocs =
     steps[currentStep]?.sections?.flatMap((section) =>
@@ -70,6 +78,12 @@ export default function DycdFormRenderer({ applicationId, onExit }) {
 
   const handleEdit = (idx) => {
     setCurrentStep(idx);
+    setEditingFromReview(true);
+  };
+
+  const handleBackToReview = () => {
+    setCurrentStep(reviewIndex);
+    setEditingFromReview(false);
   };
 
   const handleSubmit = async () => {
@@ -139,6 +153,9 @@ export default function DycdFormRenderer({ applicationId, onExit }) {
               fullData={allData}
               onDataChange={handleDataChange}
               applicationId={applicationId}
+              onBackToReview={
+                editingFromReview ? handleBackToReview : undefined
+              }
             />
           )
         )}

--- a/test-form/src/components/core/FormRenderer/FormRenderer.jsx
+++ b/test-form/src/components/core/FormRenderer/FormRenderer.jsx
@@ -12,6 +12,8 @@ export default function FormRenderer({ applicationId, onExit }) {
   const [currentStep, setCurrentStep] = useState(0);
   const [stepData, setStepData] = useState({});
   const [allData, setAllData] = useState({});
+  const reviewIndex = steps.findIndex((s) => s.type === 'review');
+  const [editingFromReview, setEditingFromReview] = useState(false);
   const stepperPosition = form.layout?.stepperPosition || 'right';
   const orientation = stepperPosition === 'top' ? 'horizontal' : 'vertical';
 
@@ -29,6 +31,12 @@ export default function FormRenderer({ applicationId, onExit }) {
   useEffect(() => {
     window.scrollTo({ top: 0, behavior: 'auto' });
   }, [currentStep]);
+
+  useEffect(() => {
+    if (currentStep === reviewIndex) {
+      setEditingFromReview(false);
+    }
+  }, [currentStep, reviewIndex]);
 
   const requiredDocs =
     steps[currentStep]?.sections?.flatMap((section) =>
@@ -70,6 +78,12 @@ export default function FormRenderer({ applicationId, onExit }) {
 
   const handleEdit = (idx) => {
     setCurrentStep(idx);
+    setEditingFromReview(true);
+  };
+
+  const handleBackToReview = () => {
+    setCurrentStep(reviewIndex);
+    setEditingFromReview(false);
   };
 
   const handleSubmit = async () => {
@@ -139,6 +153,9 @@ export default function FormRenderer({ applicationId, onExit }) {
               fullData={allData}
               onDataChange={handleDataChange}
               applicationId={applicationId}
+              onBackToReview={
+                editingFromReview ? handleBackToReview : undefined
+              }
             />
           )
         )}

--- a/test-form/src/components/core/Step/Step.jsx
+++ b/test-form/src/components/core/Step/Step.jsx
@@ -32,6 +32,7 @@ export default function Step({
   fullData = {},
   onDataChange,
   applicationId,
+  onBackToReview,
 }) {
   const [collapsedSections, setCollapsedSections] = useState({});
   const [formData, setFormData] = useState(initialData);
@@ -558,7 +559,18 @@ export default function Step({
 
   return (
     <div className={styles.step}>
-      <h2>{title}</h2>
+      <div className={styles.header}>
+        <h2>{title}</h2>
+        {onBackToReview && (
+          <button
+            type="button"
+            className={styles.backToReview}
+            onClick={onBackToReview}
+          >
+            Back to Review step
+          </button>
+        )}
+      </div>
       {sections.map((sec) => {
         const collapsed = collapsedSections[sec.id] || false;
         const visible = isSectionVisible(sec);

--- a/test-form/src/components/core/Step/Step.module.css
+++ b/test-form/src/components/core/Step/Step.module.css
@@ -11,3 +11,28 @@
   display: flex;
   gap: 0.5rem;
 }
+
+.header {
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+  flex-wrap: wrap;
+  gap: var(--space-sm);
+}
+
+.backToReview {
+  background: none;
+  border: none;
+  color: var(--primary-color);
+  text-decoration: underline;
+  cursor: pointer;
+  font-size: var(--font-size-sm);
+}
+
+@media (max-width: 768px) {
+  .header {
+    flex-direction: column;
+    align-items: flex-start;
+    gap: var(--space-xs);
+  }
+}


### PR DESCRIPTION
## Summary
- add optional `onBackToReview` link in `Step` component
- style back link for responsiveness
- track editing-from-review state in form renderers
- show link to return to Review step when editing

## Testing
- `npm test --silent --prefix test-form` *(fails: react-scripts not found)*

------
https://chatgpt.com/codex/tasks/task_e_6851d5b12070833199284411aa19b718