### PR TITLE
Add back link from steps to review

### DIFF
--- a/test-form/src/components/core/FormRenderer/DycdFormRenderer.jsx
+++ b/test-form/src/components/core/FormRenderer/DycdFormRenderer.jsx
@@ -12,6 +12,8 @@ export default function DycdFormRenderer({ applicationId, onExit }) {
   const [currentStep, setCurrentStep] = useState(0);
   const [stepData, setStepData] = useState({});
   const [allData, setAllData] = useState({});
+  const reviewIndex = steps.findIndex((s) => s.type === 'review');
+  const [editingFromReview, setEditingFromReview] = useState(false);
   const stepperPosition = form.layout?.stepperPosition || 'right';
   const orientation = stepperPosition === 'top' ? 'horizontal' : 'vertical';
 
@@ -29,6 +31,12 @@ export default function DycdFormRenderer({ applicationId, onExit }) {
   useEffect(() => {
     window.scrollTo({ top: 0, behavior: 'auto' });
   }, [currentStep]);
+
+  useEffect(() => {
+    if (currentStep === reviewIndex) {
+      setEditingFromReview(false);
+    }
+  }, [currentStep, reviewIndex]);
 
   const requiredDocs =
     steps[currentStep]?.sections?.flatMap((section) =>
@@ -70,6 +78,15 @@ export default function DycdFormRenderer({ applicationId, onExit }) {
 
   const handleEdit = (idx) => {
     setCurrentStep(idx);
+    setEditingFromReview(true);
+  };
+
+  const handleBackToReview = (data) => {
+    handleDataChange(data);
+    setAllData((prev) => ({ ...prev, ...data }));
+    setCurrentStep(reviewIndex);
+    setEditingFromReview(false);
+    window.scrollTo({ top: 0, behavior: 'auto' });
   };
 
   const handleSubmit = async () => {
@@ -139,6 +156,9 @@ export default function DycdFormRenderer({ applicationId, onExit }) {
               fullData={allData}
               onDataChange={handleDataChange}
               applicationId={applicationId}
+              onBackToReview={
+                editingFromReview ? handleBackToReview : undefined
+              }
             />
           )
         )}

--- a/test-form/src/components/core/FormRenderer/FormRenderer.jsx
+++ b/test-form/src/components/core/FormRenderer/FormRenderer.jsx
@@ -12,6 +12,8 @@ export default function FormRenderer({ applicationId, onExit }) {
   const [currentStep, setCurrentStep] = useState(0);
   const [stepData, setStepData] = useState({});
   const [allData, setAllData] = useState({});
+  const reviewIndex = steps.findIndex((s) => s.type === 'review');
+  const [editingFromReview, setEditingFromReview] = useState(false);
   const stepperPosition = form.layout?.stepperPosition || 'right';
   const orientation = stepperPosition === 'top' ? 'horizontal' : 'vertical';
 
@@ -29,6 +31,12 @@ export default function FormRenderer({ applicationId, onExit }) {
   useEffect(() => {
     window.scrollTo({ top: 0, behavior: 'auto' });
   }, [currentStep]);
+
+  useEffect(() => {
+    if (currentStep === reviewIndex) {
+      setEditingFromReview(false);
+    }
+  }, [currentStep, reviewIndex]);
 
   const requiredDocs =
     steps[currentStep]?.sections?.flatMap((section) =>
@@ -70,6 +78,15 @@ export default function FormRenderer({ applicationId, onExit }) {
 
   const handleEdit = (idx) => {
     setCurrentStep(idx);
+    setEditingFromReview(true);
+  };
+
+  const handleBackToReview = (data) => {
+    handleDataChange(data);
+    setAllData((prev) => ({ ...prev, ...data }));
+    setCurrentStep(reviewIndex);
+    setEditingFromReview(false);
+    window.scrollTo({ top: 0, behavior: 'auto' });
   };
 
   const handleSubmit = async () => {
@@ -139,6 +156,9 @@ export default function FormRenderer({ applicationId, onExit }) {
               fullData={allData}
               onDataChange={handleDataChange}
               applicationId={applicationId}
+              onBackToReview={
+                editingFromReview ? handleBackToReview : undefined
+              }
             />
           )
         )}

--- a/test-form/src/components/core/ReviewStep/ReviewStep.module.css
+++ b/test-form/src/components/core/ReviewStep/ReviewStep.module.css
@@ -40,4 +40,10 @@
   cursor: pointer;
   text-decoration: underline;
   font-size: var(--font-size-sm, 0.9rem);
+  transition: background 0.2s ease;
+}
+
+.viewJson:hover,
+.viewJson:focus-visible {
+  background: #fef2f2;
 }

--- a/test-form/src/components/core/Step/Step.jsx
+++ b/test-form/src/components/core/Step/Step.jsx
@@ -32,6 +32,7 @@ export default function Step({
   fullData = {},
   onDataChange,
   applicationId,
+  onBackToReview,
 }) {
   const [collapsedSections, setCollapsedSections] = useState({});
   const [formData, setFormData] = useState(initialData);
@@ -552,13 +553,39 @@ export default function Step({
     onBack && onBack(formData);
   };
 
+  const handleBackToReviewClick = () => {
+    const result = validateStep(
+      { sections },
+      { ...formData },
+      errors,
+      touched
+    );
+    setErrors(result.errors);
+    setTouched(result.touched);
+    const cleaned = cleanupHiddenFields({ sections }, formData);
+    setFormData(cleaned);
+    onDataChange && onDataChange(cleaned);
+    onBackToReview && onBackToReview(cleaned);
+  };
+
   const handleSaveDraftClick = () => {
     onSaveDraft && onSaveDraft(formData);
   };
 
   return (
     <div className={styles.step}>
-      <h2>{title}</h2>
+      <div className={styles.header}>
+        <h2>{title}</h2>
+        {onBackToReview && (
+          <button
+            type="button"
+            className={styles.backToReview}
+            onClick={handleBackToReviewClick}
+          >
+            Back to Review step
+          </button>
+        )}
+      </div>
       {sections.map((sec) => {
         const collapsed = collapsedSections[sec.id] || false;
         const visible = isSectionVisible(sec);

--- a/test-form/src/components/core/Step/Step.module.css
+++ b/test-form/src/components/core/Step/Step.module.css
@@ -11,3 +11,34 @@
   display: flex;
   gap: 0.5rem;
 }
+
+.header {
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+  flex-wrap: wrap;
+  gap: var(--space-sm);
+}
+
+.backToReview {
+  background: none;
+  border: none;
+  color: var(--primary-color);
+  text-decoration: underline;
+  cursor: pointer;
+  font-size: var(--font-size-sm);
+  transition: background 0.2s ease;
+}
+
+.backToReview:hover,
+.backToReview:focus-visible {
+  background: #fef2f2;
+}
+
+@media (max-width: 768px) {
+  .header {
+    flex-direction: column;
+    align-items: flex-start;
+    gap: var(--space-xs);
+  }
+}


### PR DESCRIPTION
## Summary
- add validation and cleanup when returning to Review step
- pass step data to review handlers
- tweak hover styles for back link and JSON link

## Testing
- `npm test --silent --prefix test-form` *(fails: react-scripts not found)*

------
https://chatgpt.com/codex/tasks/task_e_6851d5b12070833199284411aa19b718