### PR TITLE
fix: Resolve browser unresponsiveness on input interaction in Step

### DIFF
--- a/test-form/src/components/core/Step/Step.jsx
+++ b/test-form/src/components/core/Step/Step.jsx
@@ -74,26 +74,61 @@ export default function Step({
     });
   }, [sections, fullData]);
 
-  // Re-run validation when returning to this step if fields were previously touched
+  // Clear section-level errors when required group sections gain data
   useEffect(() => {
-    if (Object.keys(touched).length > 0) {
-      const result = validateStep(
-        { sections },
-        formData,
-        errors, // Pass current errors
-        touched // Pass current touched
-      );
-      // Only update if there are new errors or errors were cleared for touched fields
-      // This prevents infinite loops if validateStep itself causes a re-render
-      if (JSON.stringify(result.errors) !== JSON.stringify(errors)) {
-        setErrors(result.errors);
-      }
-      if (JSON.stringify(result.touched) !== JSON.stringify(touched)) {
-        setTouched(result.touched);
+    setErrors((prev) => {
+      const updated = { ...prev };
+      sections.forEach((sec) => {
+        if (!sec.required || !updated[sec.id]) return;
+        const hasGroupData = sec.fields?.some(
+          (f) => f.type === 'group' && Array.isArray(fullData[f.id]) && fullData[f.id].length > 0
+        );
+        if (hasGroupData) {
+          delete updated[sec.id];
+        }
+      });
+      return updated;
+    });
+  }, [sections, fullData]);
+
+  // This effect validates the current formData when initialData (step data from parent) changes or sections change.
+  useEffect(() => {
+    // formData here is the version that has been synced with initialData by the effect above.
+    const result = validateStep(
+      { sections },
+      formData,
+      {}, // Calculate errors fresh for this validation pass based on current formData
+      {}  // Start with a fresh perspective on what this validation pass considers "touched due to error"
+    );
+
+    const newTouchedSetByErrors = {};
+    if (result.errors) {
+      for (const fieldId in result.errors) {
+        if (result.errors[fieldId]) { // If there's an error for this field
+          newTouchedSetByErrors[fieldId] = true; // Mark it as touched to display the error
+        }
       }
     }
+
+    // Set the errors found from this validation pass.
+    // Conditional update if errors are identical can be added later if performance tuning is needed.
+    setErrors(result.errors || {});
+
+    // Merge newTouchedSetByErrors with the existing touched state.
+    // This ensures fields already touched by user interaction remain touched,
+    // and fields that now have errors also become marked as touched.
+    setTouched(prevTouched => {
+      const combinedTouched = { ...prevTouched, ...newTouchedSetByErrors };
+      // Avoid unnecessary state update if combinedTouched is effectively the same as prevTouched.
+      // A deep equals would be more robust than stringify for objects if key order can vary.
+      if (JSON.stringify(combinedTouched) !== JSON.stringify(prevTouched)) {
+        return combinedTouched;
+      }
+      return prevTouched;
+    });
+
   // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, [sections, formData]); // Removed errors and touched from dependencies to prevent potential loops if validateStep is complex
+  }, [initialData, sections]); // DEPENDENCIES CHANGED HERE
 
   useEffect(() => {
     // Check timestamp to ensure it's a new validation attempt that failed
@@ -510,7 +545,8 @@ export default function Step({
               onChange={(e) => handleChange(field.id, e.target.value)}
               error={error} // Pass error prop
             />
-          {/* Error display handled by TextInput internally */}
+            {/* Error display handled by TextInput internally */}
+          </>
         );
     }
   };


### PR DESCRIPTION
Addresses a critical performance issue where the browser could become unresponsive when interacting with UI controls (e.g., radio buttons) within a form step.

The root cause was a `useEffect` hook in `Step.jsx` that was responsible for re-validating the entire step. This hook incorrectly had `formData` (local step data) in its dependency array, causing it to execute `validateStep` (a potentially expensive full-step validation) on every single change to `formData`, such as each keystroke or radio button click.

The fix involves:
1.  Modifying the dependency array of the aforementioned `useEffect` in `Step.jsx` from `[sections, formData]` to `[initialData, sections]`. This ensures that the full step validation logic now runs only when the `initialData` prop (data for the step provided by the parent `FormRenderer`) changes, or when the `sections` structure changes. This typically occurs when navigating to a step or when data is loaded from storage, rather than on every minor input.
2.  Refining the logic within this `useEffect` to correctly set errors and merge touched states based on the validation of `formData` (which is kept in sync with `initialData` by another effect).

This change significantly reduces the frequency of full-step validations, preventing the excessive computation and re-renders that led to the browser unresponsiveness. Per-field validation within `handleChange` continues to provide immediate feedback.