### PR TITLE
Update radio and checkbox groups

### DIFF
--- a/test-form/src/components/shared/CheckboxGroup/CheckboxGroup.jsx
+++ b/test-form/src/components/shared/CheckboxGroup/CheckboxGroup.jsx
@@ -51,25 +51,20 @@ export default function CheckboxGroup({
           const inputId = `${id}-${optValue}`; // Create unique ID for each checkbox input
 
           return (
-            <div key={optValue} className="jules-checkbox-option">
+            <label key={optValue} className="jules-checkbox-option">
               <input
                 type="checkbox"
-                id={inputId} // Use unique id
-                name={`${id}-${optValue}`} // Unique name for each checkbox for better form handling, or share 'id' if backend expects array under one name
+                id={inputId}
+                name={`${id}-${optValue}`}
                 value={optValue}
                 checked={checked}
                 onChange={e => handleChange(optValue, e.target.checked)}
-                className="jules-checkbox-input" // Class for the input itself
-                // HTML5 'required' on a group of checkboxes is tricky.
-                // Usually handled by JS. If one must be checked, one input can have 'required'.
-                // For simplicity, not adding 'required' on individual checkboxes here unless specifically needed.
+                className="jules-checkbox-input"
                 {...props}
               />
               <span className="jules-checkbox-custom"></span>
-              <label htmlFor={inputId} className="jules-checkbox-label-text">
-                {optLabel}
-              </label>
-            </div>
+              <span className="jules-checkbox-label-text">{optLabel}</span>
+            </label>
           );
         })}
       </div>

--- a/test-form/src/components/shared/RadioGroup/RadioGroup.jsx
+++ b/test-form/src/components/shared/RadioGroup/RadioGroup.jsx
@@ -41,26 +41,21 @@ export default function RadioGroup({
           const optLabel = typeof opt === 'string' ? opt : opt.label;
           const inputId = `${id}-${optValue}`; // Create unique ID for each radio input for the label's htmlFor
           return (
-            // The prompt asked for label.jules-radio-option.
-            // My jules_input.css uses div.jules-radio-option > input + span.jules-radio-custom + label.jules-radio-label-text
-            // Let's adapt to the div wrapper structure.
-            <div key={optValue} className="jules-radio-option">
+            <label key={optValue} className="jules-radio-option">
               <input
                 type="radio"
-                id={inputId} // Use unique id
-                name={id} // Group by name (original id prop)
+                id={inputId}
+                name={id}
                 value={optValue}
                 checked={value === optValue}
                 onChange={onChange}
-                className="jules-radio-input" // Class for the input itself
-                required={required && !value} // HTML5 required only works if no option is checked
+                className="jules-radio-input"
+                required={required && !value}
                 {...props}
               />
               <span className="jules-radio-custom"></span>
-              <label htmlFor={inputId} className="jules-radio-label-text">
-                {optLabel}
-              </label>
-            </div>
+              <span className="jules-radio-label-text">{optLabel}</span>
+            </label>
           );
         })}
       </div>


### PR DESCRIPTION
## Summary
- embed radio inputs in `label` elements
- embed checkbox inputs in `label` elements

## Testing
- `CI=true npm --prefix test-form test` *(fails: unexpected token in remark-gfm and tooltip visibility test)*

------
https://chatgpt.com/codex/tasks/task_e_685374cbca0c8331b76b69e59e720cc3