### PR TITLE
Fix duplicate useEffect

### DIFF
--- a/test-form/src/components/core/Step/Step.jsx
+++ b/test-form/src/components/core/Step/Step.jsx
@@ -57,22 +57,6 @@ export default function Step({
     setCollapsedSections(initial);
   }, [sections]);
 
-  // Clear section-level errors when required group sections gain data
-  useEffect(() => {
-    setErrors((prev) => {
-      const updated = { ...prev };
-      sections.forEach((sec) => {
-        if (!sec.required || !updated[sec.id]) return;
-        const hasGroupData = sec.fields?.some(
-          (f) => f.type === 'group' && Array.isArray(fullData[f.id]) && fullData[f.id].length > 0
-        );
-        if (hasGroupData) {
-          delete updated[sec.id];
-        }
-      });
-      return updated;
-    });
-  }, [sections, fullData]);
 
   // Clear section-level errors when required group sections gain data
   useEffect(() => {


### PR DESCRIPTION
## Summary
- remove duplicate effect in Step.jsx

## Testing
- `npm test --silent` *(fails: Jest encountered an unexpected token)*
- `npx eslint src/components/core/Step/Step.jsx --max-warnings=0`

------
https://chatgpt.com/codex/tasks/task_e_68537600cac083318694c7aa1037b94d