### PR TITLE
Fix group data check

### DIFF
--- a/test-form/src/utils/formHelpers.js
+++ b/test-form/src/utils/formHelpers.js
@@ -168,9 +168,14 @@ export function validateStep(step, formData, formErrors = {}, touched = {}) {
 
   step.sections.forEach((section) => {
     if (section.required) {
-      const hasGroupWithData = section.fields.some(
-        (f) => f.type === "group" && Array.isArray(formData[f.id]) && formData[f.id].length > 0
-      );
+      const hasGroupWithData =
+        Array.isArray(section.fields) &&
+        section.fields.some(
+          (f) =>
+            f.type === "group" &&
+            Array.isArray(formData[f.id]) &&
+            formData[f.id].length > 0
+        );
 
       if (hasGroupWithData && updatedErrors[section.id]) {
         delete updatedErrors[section.id];


### PR DESCRIPTION
## Summary
- ensure `validateStep` checks for array before `.some`
- run the full test suite

## Testing
- `npm test --silent`

------
https://chatgpt.com/codex/tasks/task_e_68537a59be5083319f21886d983d6db6