### PR TITLE
Fix stepper side-effects and key warning

### DIFF
--- a/test-form/src/components/core/FormRenderer/FormRenderer.jsx
+++ b/test-form/src/components/core/FormRenderer/FormRenderer.jsx
@@ -156,7 +156,7 @@ export default function FormRenderer({ applicationId, onExit }) {
     onExit && onExit();
   };
 
-  const canNavigate = (targetIndex) => {
+  const canNavigateStep = (targetIndex) => {
     if (steps.length === 0 || !steps[currentStep]) return false;
     // allow going to a previous step without checking validation
     if (targetIndex < currentStep) return true;
@@ -167,11 +167,20 @@ export default function FormRenderer({ applicationId, onExit }) {
       stepData[steps[currentStep].id] || {}
     );
 
-    if (!result.valid && targetIndex > currentStep) {
-      // If trying to move forward and validation fails, set errors and touched state to trigger display in Step component
+    return result.valid;
+  };
+
+  const handleStepChange = (targetIndex) => {
+    if (canNavigateStep(targetIndex)) {
+      setCurrentStep(targetIndex);
+      window.scrollTo({ top: 0, behavior: 'auto' });
+    } else {
+      const result = validateStep(
+        steps[currentStep],
+        stepData[steps[currentStep].id] || {}
+      );
       setCurrentStepValidation({ errors: result.errors, touched: result.touched, timestamp: Date.now() });
     }
-    return result.valid;
   };
 
   if (isLoading) {
@@ -192,10 +201,10 @@ export default function FormRenderer({ applicationId, onExit }) {
         <Stepper
           steps={steps}
           currentStep={currentStep}
-          onStepChange={setCurrentStep}
+          onStepChange={handleStepChange}
           requiredDocs={requiredDocs}
           orientation={orientation}
-          canNavigate={canNavigate}
+          canNavigate={canNavigateStep}
         />
       )}
       <div className="form-main">
@@ -205,10 +214,10 @@ export default function FormRenderer({ applicationId, onExit }) {
           <Stepper
             steps={steps}
             currentStep={currentStep}
-            onStepChange={setCurrentStep}
+            onStepChange={handleStepChange}
             requiredDocs={requiredDocs}
             orientation={orientation}
-            canNavigate={canNavigate}
+            canNavigate={canNavigateStep}
           />
         )}
         {steps.length > 0 && steps[currentStep] && (

--- a/test-form/src/components/core/Step/Step.jsx
+++ b/test-form/src/components/core/Step/Step.jsx
@@ -249,16 +249,15 @@ export default function Step({
           );
         }
         if (isStreet) {
-          return (
-            <>
-              <AddressAutocomplete
-                key={field.id}
-                id={field.id}
-                label={field.label}
-                required={isRequired}
-                value={formData[field.id] || ''}
-                placeholder={placeholders[field.id] || field.ui?.placeholder || ''}
-                onChange={(val) => handleChange(field.id, val)}
+            return (
+              <React.Fragment key={field.id}>
+                <AddressAutocomplete
+                  id={field.id}
+                  label={field.label}
+                  required={isRequired}
+                  value={formData[field.id] || ''}
+                  placeholder={placeholders[field.id] || field.ui?.placeholder || ''}
+                  onChange={(val) => handleChange(field.id, val)}
                 onAddressSelect={(addr) => {
                   const fullAddr = addr.formatted_address || addr.formattedAddress || '';
                   setPlaceholders((p) => ({ ...p, [field.id]: fullAddr }));
@@ -337,11 +336,11 @@ export default function Step({
                   handleChange(field.id, streetOnly);
                 }}
                 error={error} // Pass error to AddressAutocomplete
-              />
-              {/* AddressAutocomplete does not currently use the error prop to display jules-alert, so keep this if needed */}
-              {error && <div className="jules-alert jules-alert-error jules-input-error-message">{error}</div>}
-            </>
-          );
+                />
+                {/* AddressAutocomplete does not currently use the error prop to display jules-alert, so keep this if needed */}
+                {error && <div className="jules-alert jules-alert-error jules-input-error-message">{error}</div>}
+              </React.Fragment>
+            );
         }
         return (
           <TextInput


### PR DESCRIPTION
## Summary
- remove state updates during Stepper render to avoid React warning
- pass navigation handler and pure validator to Stepper
- add key to AddressAutocomplete fragment to fix list key warning

## Testing
- `npm install --silent` *(fails: react-scripts not found)*
- `npm test --silent` *(fails: Jest failed to parse ECMAScript modules)*

------
https://chatgpt.com/codex/tasks/task_e_68537b54d0d88331be0556555845f5b3