### PR TITLE
Add tableColumns support for GroupField

### DIFF
--- a/test-form/src/components/shared/GroupField/GroupField.jsx
+++ b/test-form/src/components/shared/GroupField/GroupField.jsx
@@ -1,4 +1,4 @@
-import React, { useState, useEffect } from 'react';
+import React, { useState, useEffect, useMemo } from 'react';
 import TextInput from '../TextInput/TextInput';
 import SelectField from '../SelectField/SelectField';
 import RadioGroup from '../RadioGroup/RadioGroup';
@@ -16,6 +16,14 @@ export default function GroupField({ field, value = [], onChange, fullData = {} 
   const [showForm, setShowForm] = useState(false);
   const [entryErrors, setEntryErrors] = useState({});
   const [placeholders, setPlaceholders] = useState({});
+
+  const tableFields = useMemo(() => {
+    const cols = field.metadata?.tableColumns;
+    if (Array.isArray(cols) && cols.length > 0) {
+      return field.fields.filter((f) => cols.includes(f.id));
+    }
+    return field.fields;
+  }, [field]);
 
   // Remove values for fields that become hidden based on current entry state
   useEffect(() => {
@@ -338,7 +346,7 @@ export default function GroupField({ field, value = [], onChange, fullData = {} 
         <table className="jules-groupfield-table">
           <thead>
             <tr>
-              {field.fields.map((f) => (
+              {tableFields.map((f) => (
                 <th key={f.id}>{f.label}</th>
               ))}
               <th>Actions</th>
@@ -347,7 +355,7 @@ export default function GroupField({ field, value = [], onChange, fullData = {} 
           <tbody>
             {entries.map((item, idx) => (
               <tr key={idx}>
-                {field.fields.map((f) => (
+                {tableFields.map((f) => (
                   <td key={f.id}>
                     {Array.isArray(item[f.id]) ? item[f.id].join(', ') : item[f.id]}
                   </td>

--- a/test-form/src/components/shared/GroupField/GroupField.test.js
+++ b/test-form/src/components/shared/GroupField/GroupField.test.js
@@ -57,4 +57,22 @@ describe('GroupField component', () => {
     expect(handleChange).not.toHaveBeenCalled();
     expect(screen.getByText('Name is required.')).toBeInTheDocument();
   });
+
+  test('renders only specified table columns', () => {
+    const fieldWithCols = {
+      ...field,
+      metadata: { multiple: true, tableColumns: ['name'] },
+    };
+    render(
+      <GroupField field={fieldWithCols} value={[{ name: 'Ann', age: '2' }]} onChange={() => {}} />
+    );
+
+    // Only Name header should be visible
+    expect(screen.getByText('Name')).toBeInTheDocument();
+    expect(screen.queryByText('Age')).not.toBeInTheDocument();
+
+    // Only name value should be rendered in the row
+    expect(screen.getByText('Ann')).toBeInTheDocument();
+    expect(screen.queryByText('2')).not.toBeInTheDocument();
+  });
 });


### PR DESCRIPTION
## Summary
- handle `metadata.tableColumns` in `GroupField`
- test column filtering logic

## Testing
- `CI=true npm test --prefix test-form` *(fails: Jest encountered an unexpected token)*

------
https://chatgpt.com/codex/tasks/task_e_685392965e748331a2fcf8f318120eac