### PR TITLE
Fix responsive tables for mobile

### DIFF
--- a/test-form/src/jules_groupfield.css
+++ b/test-form/src/jules_groupfield.css
@@ -8,6 +8,11 @@
   background-color: var(--jules-neutral-gray-50); /* Light background for the group container */
 }
 
+/* Wrapper around the table to allow horizontal scrolling on small screens */
+.jules-groupfield {
+  overflow-x: auto;
+}
+
 .jules-groupfield-header {
   display: flex;
   justify-content: space-between;
@@ -30,6 +35,8 @@
   box-shadow: var(--jules-shadow-sm);
   border-radius: var(--jules-border-radius-md);
   overflow: hidden; /* To respect border-radius on th/td */
+  table-layout: fixed; /* Prevents overflow on small screens */
+  word-wrap: break-word;
 }
 
 .jules-groupfield-table th,
@@ -123,4 +130,13 @@
 .jules-groupfield-empty-text {
   margin-bottom: var(--jules-space-md);
   font-size: var(--jules-font-size-md);
+}
+
+/* Mobile adjustments */
+@media (max-width: 768px) {
+  .jules-groupfield-table th,
+  .jules-groupfield-table td {
+    padding: var(--jules-space-xs);
+    font-size: var(--jules-font-size-sm);
+  }
 }

--- a/test-form/src/jules_tablelayout.css
+++ b/test-form/src/jules_tablelayout.css
@@ -1,5 +1,10 @@
 @import './jules_tokens.css';
 
+/* Wrapper around table layout to prevent page overflow on mobile */
+.jules-tablelayout {
+  overflow-x: auto;
+}
+
 .jules-tablelayout-container {
   margin-bottom: var(--jules-space-lg);
   /* No default border/background, table itself will have it */
@@ -13,6 +18,7 @@
   overflow: hidden; /* Important for border-radius to apply to th/td */
   background-color: var(--jules-neutral-white);
   box-shadow: var(--jules-shadow-sm);
+  table-layout: fixed; /* Helps keep table within container */
 }
 
 .jules-tablelayout-table th,
@@ -23,6 +29,7 @@
   text-align: left;
   vertical-align: middle; /* Default vertical alignment */
   font-size: var(--jules-font-size-md);
+  word-break: break-word;
 }
 
 .jules-tablelayout-table th:last-child,
@@ -114,4 +121,13 @@
   /* Assuming .jules-button is used */
   padding: var(--jules-space-xs) var(--jules-space-sm); /* Smaller button for this context */
   font-size: var(--jules-font-size-sm);
+}
+
+/* Mobile adjustments */
+@media (max-width: 768px) {
+  .jules-tablelayout-table th,
+  .jules-tablelayout-table td {
+    padding: var(--jules-space-xs);
+    font-size: var(--jules-font-size-sm);
+  }
 }


### PR DESCRIPTION
## Summary
- allow horizontal scroll for GroupField and TableLayout containers
- set table layout to fixed to avoid overflow
- tweak padding and font size on mobile

## Testing
- `npm install --legacy-peer-deps`
- `CI=true npm test --silent` *(fails: SyntaxError: Unexpected token 'export')*

------
https://chatgpt.com/codex/tasks/task_e_68539c36c4f083318673358444bbfff0