### PR TITLE
Add responsive card layout for mobile

### DIFF
--- a/test-form/src/components/shared/GroupField/GroupField.jsx
+++ b/test-form/src/components/shared/GroupField/GroupField.jsx
@@ -343,31 +343,50 @@ export default function GroupField({ field, value = [], onChange, fullData = {} 
     <div className="jules-groupfield">
       <h3 className="jules-groupfield-title">{field.label}</h3> {/* Changed h4 to h3 and added class */}
       {entries.length > 0 && (
-        <table className="jules-groupfield-table">
-          <thead>
-            <tr>
-              {tableFields.map((f) => (
-                <th key={f.id}>{f.label}</th>
-              ))}
-              <th>Actions</th>
-            </tr>
-          </thead>
-          <tbody>
-            {entries.map((item, idx) => (
-              <tr key={idx}>
+        <>
+          <table className="jules-groupfield-table">
+            <thead>
+              <tr>
                 {tableFields.map((f) => (
-                  <td key={f.id}>
-                    {Array.isArray(item[f.id]) ? item[f.id].join(', ') : item[f.id]}
-                  </td>
+                  <th key={f.id}>{f.label}</th>
                 ))}
-                <td className="jules-groupfield-actions"> {/* Added class for styling action cell */}
+                <th>Actions</th>
+              </tr>
+            </thead>
+            <tbody>
+              {entries.map((item, idx) => (
+                <tr key={idx}>
+                  {tableFields.map((f) => (
+                    <td key={f.id}>
+                      {Array.isArray(item[f.id]) ? item[f.id].join(', ') : item[f.id]}
+                    </td>
+                  ))}
+                  <td className="jules-groupfield-actions"> {/* Added class for styling action cell */}
+                    <button type="button" className="jules-button jules-button-tertiary jules-button-small" onClick={() => handleEdit(idx)}>Edit</button>
+                    <button type="button" className="jules-button jules-button-destructive jules-button-small" onClick={() => handleDelete(idx)}>Delete</button>
+                  </td>
+                </tr>
+              ))}
+            </tbody>
+          </table>
+
+          <div className="jules-groupfield-card-list">
+            {entries.map((item, idx) => (
+              <div key={idx} className="jules-card jules-groupfield-card">
+                {tableFields.map((f) => (
+                  <div key={f.id} className="jules-groupfield-card-row">
+                    <span className="jules-groupfield-card-label">{f.label}</span>
+                    <span className="jules-groupfield-card-value">{Array.isArray(item[f.id]) ? item[f.id].join(', ') : item[f.id]}</span>
+                  </div>
+                ))}
+                <div className="jules-groupfield-card-actions">
                   <button type="button" className="jules-button jules-button-tertiary jules-button-small" onClick={() => handleEdit(idx)}>Edit</button>
                   <button type="button" className="jules-button jules-button-destructive jules-button-small" onClick={() => handleDelete(idx)}>Delete</button>
-                </td>
-              </tr>
+                </div>
+              </div>
             ))}
-          </tbody>
-        </table>
+          </div>
+        </>
       )}
       {!showForm && ( // Only show "Add" button if form is not visible
         <button

--- a/test-form/src/jules_groupfield.css
+++ b/test-form/src/jules_groupfield.css
@@ -139,4 +139,43 @@
     padding: var(--jules-space-xs);
     font-size: var(--jules-font-size-sm);
   }
+
+  .jules-groupfield-table {
+    display: none;
+  }
+
+  .jules-groupfield-card-list {
+    display: block;
+  }
+}
+
+@media (min-width: 769px) {
+  .jules-groupfield-card-list {
+    display: none;
+  }
+}
+
+.jules-groupfield-card {
+  margin-bottom: var(--jules-space-md);
+}
+
+.jules-groupfield-card-row {
+  display: flex;
+  justify-content: space-between;
+  padding: var(--jules-space-xs) 0;
+  border-bottom: var(--jules-border-width-sm) solid var(--jules-border-color);
+}
+
+.jules-groupfield-card-row:last-child {
+  border-bottom: none;
+}
+
+.jules-groupfield-card-label {
+  font-weight: var(--jules-font-weight-semibold);
+}
+
+.jules-groupfield-card-actions {
+  margin-top: var(--jules-space-sm);
+  display: flex;
+  gap: var(--jules-space-sm);
 }


### PR DESCRIPTION
## Summary
- display group field entries as cards on small screens
- adjust `jules_groupfield.css` with mobile card styles

## Testing
- `npm test --prefix test-form --silent` *(fails: Jest encountered unexpected token errors)*

------
https://chatgpt.com/codex/tasks/task_e_68539ed4f9688331a11b7fd94193f2b5