### PR TITLE
Fix navigation validation logic

### DIFF
--- a/test-form/src/components/core/FormRenderer/FormRenderer.jsx
+++ b/test-form/src/components/core/FormRenderer/FormRenderer.jsx
@@ -161,7 +161,7 @@ export default function FormRenderer({ applicationId, onExit }) {
     }
   };
 
-  const canNavigate = (targetIndex) => {
+  const canNavigate = (targetIndex, silent = false) => {
     if (steps.length === 0 || !steps[currentStep]) return false;
     // allow going to a previous step without checking validation
     if (targetIndex < currentStep) return true;
@@ -172,7 +172,7 @@ export default function FormRenderer({ applicationId, onExit }) {
       stepData[steps[currentStep].id] || {}
     );
 
-    if (!result.valid && targetIndex > currentStep) {
+    if (!silent && !result.valid && targetIndex > currentStep) {
       // If trying to move forward and validation fails, set errors and touched state to trigger display in Step component
       setCurrentStepValidation({ errors: result.errors, touched: result.touched, timestamp: Date.now() });
     }

--- a/test-form/src/components/core/Stepper/Stepper.jsx
+++ b/test-form/src/components/core/Stepper/Stepper.jsx
@@ -47,7 +47,7 @@ export default function Stepper({
           }
 
           // Add disabled class if navigation is not allowed
-          if (canNavigate && !canNavigate(index) && index !== currentStep) {
+          if (canNavigate && !canNavigate(index, true) && index !== currentStep) {
             itemClasses += ' jules-stepper-item-disabled';
           }
 


### PR DESCRIPTION
## Summary
- prevent `FormRenderer` state updates when `Stepper` renders
- disable step links using a silent validation check

## Testing
- `CI=true npm test --silent` *(fails: Jest encountered unexpected token errors)*

------
https://chatgpt.com/codex/tasks/task_e_6853baaf02f88331bf3066179cba34ca