### PR TITLE
Fix placeholder for dropdown

### DIFF
--- a/test-form/src/components/core/Step/Step.jsx
+++ b/test-form/src/components/core/Step/Step.jsx
@@ -430,7 +430,7 @@ export default function Step({
             label={field.label}
             tooltip={field.tooltip}
             options={field.ui?.options || []}
-            placeholder={field.ui?.placeholder || `Select ${field.label}`}
+            placeholder={field.ui?.placeholder}
             required={isRequired}
             value={formData[field.id] || ''}
             onChange={(e) => handleChange(field.id, e.target.value)}


### PR DESCRIPTION
## Summary
- rely on JSON form spec for placeholder text

## Testing
- `npm test --silent --runInBand` *(fails: SyntaxError: Unexpected token 'export')*


------
https://chatgpt.com/codex/tasks/task_e_6862ab06769883319b0491cd9cc38963