### PR TITLE
Fix tooltip layout and text wrapping

### DIFF
--- a/test-form/src/components/shared/MaskedInput/MaskedInput.jsx
+++ b/test-form/src/components/shared/MaskedInput/MaskedInput.jsx
@@ -97,7 +97,7 @@ export default function MaskedInput({
           {required && <span className="jules-required-asterisk">*</span>}
         </label>
       )}
-      {tooltip && <div style={{marginLeft: 'var(--jules-space-sm)', marginTop: 'var(--jules-space-xxs)'}}><Tooltip text={tooltip}/></div>}
+      {tooltip && <Tooltip text={tooltip} />}
       {hint && !error && <p className="jules-input-hint">{hint}</p>}
       {error && <div className="jules-alert jules-alert-error jules-input-error-message">{error}</div>}
     </div>

--- a/test-form/src/components/shared/SelectField/SelectField.jsx
+++ b/test-form/src/components/shared/SelectField/SelectField.jsx
@@ -115,7 +115,7 @@ export default function SelectField({
           {required && <span className="jules-required-asterisk">*</span>}
         </label>
       )}
-      {tooltip && <div style={{marginLeft: 'var(--jules-space-sm)', marginTop: 'var(--jules-space-xxs)'}}><Tooltip text={tooltip}/></div>}
+      {tooltip && <Tooltip text={tooltip} />}
       {hint && !error && <p className="jules-input-hint">{hint}</p>}
       {error && <div className="jules-alert jules-alert-error jules-input-error-message">{error}</div>}
     </div>

--- a/test-form/src/components/shared/TextInput/TextInput.jsx
+++ b/test-form/src/components/shared/TextInput/TextInput.jsx
@@ -92,8 +92,8 @@ export default function TextInput({
           {required && <span className="jules-required-asterisk">*</span>}
         </label>
       )}
-      {/* Render tooltip outside the label, but still associated with the field */}
-      {tooltip && <div style={{marginLeft: 'var(--jules-space-sm)', marginTop: 'var(--jules-space-xxs)'}}><Tooltip text={tooltip}/></div>}
+      {/* Render tooltip directly so it stays inline with label */}
+      {tooltip && <Tooltip text={tooltip} />}
 
       {hint && !error && <p className="jules-input-hint">{hint}</p>}
       {error && <div className="jules-alert jules-alert-error jules-input-error-message">{error}</div>}

--- a/test-form/src/components/shared/TextInput/TextInput.test.jsx
+++ b/test-form/src/components/shared/TextInput/TextInput.test.jsx
@@ -1,5 +1,5 @@
 import React from 'react';
-import { render, screen } from '@testing-library/react';
+import { render, screen, waitFor } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
 import '@testing-library/jest-dom';
 
@@ -58,11 +58,15 @@ describe('TextInput', () => {
       />
     );
 
-    const label = screen.getByText('Email');
-    await userEvent.hover(label);
+    const tooltip = screen.getByRole('tooltip');
+    const wrapper = tooltip.parentElement;
+    await userEvent.hover(wrapper);
 
     expect(screen.getByText("We’ll never share your email.")).toBeVisible();
 
-    await userEvent.unhover(label);
+    await userEvent.unhover(wrapper);
+    await waitFor(() =>
+      expect(screen.getByText("We’ll never share your email.")).not.toBeVisible()
+    );
   });
 });

--- a/test-form/src/components/shared/Tooltip/Tooltip.test.jsx
+++ b/test-form/src/components/shared/Tooltip/Tooltip.test.jsx
@@ -1,5 +1,5 @@
 import React from 'react';
-import { render, screen } from '@testing-library/react';
+import { render, screen, waitFor } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
 import '@testing-library/jest-dom';
 import Tooltip from './Tooltip';
@@ -18,5 +18,5 @@ test('shows tooltip on hover', async () => {
   await user.hover(wrapper);
   expect(tooltip.className).toMatch(/visible/);
   await user.unhover(wrapper);
-  expect(tooltip.className).not.toMatch(/visible/);
+  await waitFor(() => expect(tooltip.className).not.toMatch(/visible/));
 });

--- a/test-form/src/jules_misc.css
+++ b/test-form/src/jules_misc.css
@@ -34,7 +34,9 @@
   visibility: hidden;
   transition: opacity var(--jules-transition-duration-fast) var(--jules-transition-timing-function),
               visibility var(--jules-transition-duration-fast) var(--jules-transition-timing-function);
-  white-space: nowrap;
+  white-space: normal; /* Allow long text to wrap */
+  max-width: 250px; /* Prevent overly wide tooltips */
+  word-wrap: break-word;
   pointer-events: none; /* Prevent tooltip from interfering with mouse events on icon */
 }
 


### PR DESCRIPTION
## Summary
- keep tooltips inline with labels instead of breaking rows
- allow tooltip text to wrap so full message is visible
- update tests for tooltip hover behavior

## Testing
- `npm test --silent -- --watchAll=false` *(fails: SyntaxError in remark-gfm and others)*

------
https://chatgpt.com/codex/tasks/task_e_6862bad77bd48331b329888da6efc0a2