### PR TITLE
Fix tooltip positioning next to labels

### DIFF
--- a/test-form/src/components/shared/MaskedInput/MaskedInput.jsx
+++ b/test-form/src/components/shared/MaskedInput/MaskedInput.jsx
@@ -95,9 +95,9 @@ export default function MaskedInput({
         <label htmlFor={id} className="jules-label">
           {label}
           {required && <span className="jules-required-asterisk">*</span>}
+          {tooltip && <Tooltip text={tooltip} />}
         </label>
       )}
-      {tooltip && <Tooltip text={tooltip} />}
       {hint && !error && <p className="jules-input-hint">{hint}</p>}
       {error && <div className="jules-alert jules-alert-error jules-input-error-message">{error}</div>}
     </div>

--- a/test-form/src/components/shared/SelectField/SelectField.jsx
+++ b/test-form/src/components/shared/SelectField/SelectField.jsx
@@ -113,9 +113,9 @@ export default function SelectField({
         <label htmlFor={id} className="jules-label">
           {label}
           {required && <span className="jules-required-asterisk">*</span>}
+          {tooltip && <Tooltip text={tooltip} />}
         </label>
       )}
-      {tooltip && <Tooltip text={tooltip} />}
       {hint && !error && <p className="jules-input-hint">{hint}</p>}
       {error && <div className="jules-alert jules-alert-error jules-input-error-message">{error}</div>}
     </div>

--- a/test-form/src/components/shared/TextInput/TextInput.jsx
+++ b/test-form/src/components/shared/TextInput/TextInput.jsx
@@ -85,15 +85,13 @@ export default function TextInput({
         />
         {iconRight && <span className="jules-input-icon jules-input-icon-right">{iconRight}</span>}
       </div>
-       {label && (
-        // Tooltip removed from inside label for simplicity with absolute positioning
+      {label && (
         <label htmlFor={id} className="jules-label">
           {label}
           {required && <span className="jules-required-asterisk">*</span>}
+          {tooltip && <Tooltip text={tooltip} />}
         </label>
       )}
-      {/* Render tooltip directly so it stays inline with label */}
-      {tooltip && <Tooltip text={tooltip} />}
 
       {hint && !error && <p className="jules-input-hint">{hint}</p>}
       {error && <div className="jules-alert jules-alert-error jules-input-error-message">{error}</div>}

--- a/test-form/src/jules_input.css
+++ b/test-form/src/jules_input.css
@@ -30,6 +30,8 @@
   font-size: var(--jules-font-size-md); /* Initial size, same as input text */
   line-height: var(--jules-line-height-base); /* Match input's line-height for centering */
   pointer-events: none;
+  display: inline-flex; /* Allow tooltip to sit beside text */
+  align-items: center;
   transition: all 0.2s ease-in-out;
   background-color: var(--jules-neutral-white); /* To mask input border when floated */
   padding: 0 var(--jules-space-xxs);
@@ -37,6 +39,11 @@
   overflow: hidden;
   text-overflow: ellipsis;
   max-width: calc(100% - (var(--jules-space-md) * 2)); /* Prevent overflow */
+}
+
+.jules-label .jules-tooltip-wrapper {
+  pointer-events: auto; /* Re-enable events for tooltip */
+  margin-left: var(--jules-space-xxs);
 }
 
 /* Floating State Styles for Label */

--- a/test-form/src/jules_section.css
+++ b/test-form/src/jules_section.css
@@ -57,7 +57,7 @@
 
 .jules-section-content {
   padding: var(--jules-space-lg);
-  overflow: hidden;
+  overflow: visible; /* Allow content like tooltips to extend outside */
   transition: max-height var(--jules-transition-duration-base) var(--jules-transition-timing-function), /* Using base duration */
               opacity var(--jules-transition-duration-base) var(--jules-transition-timing-function),
               padding-top var(--jules-transition-duration-base) var(--jules-transition-timing-function),
@@ -66,12 +66,13 @@
               margin-bottom var(--jules-transition-duration-base) var(--jules-transition-timing-function);
   max-height: 1000px; /* A sufficiently large value for expanded state, adjust if very large content */
   opacity: 1;
-  /* border-top: var(--jules-border-width-sm) solid var(--jules-border-color); /* Optional: if content area needs a top border visually separating from header */
+  /* border-top: var(--jules-border-width-sm) solid var(--jules-border-color); */ /* Optional: if content area needs a top border visually separating from header */
 }
 
 .jules-section-content.jules-section-content-collapsed {
   max-height: 0;
   opacity: 0;
+  overflow: hidden;
   padding-top: 0;
   padding-bottom: 0;
   margin-top: 0;


### PR DESCRIPTION
## Summary
- keep tooltips visible when section is expanded
- allow tooltip icon inside floating labels and enable pointer events
- render tooltips inside labels for text, select and masked inputs

## Testing
- `npm test --silent` *(fails: Jest encountered unexpected token)*

------
https://chatgpt.com/codex/tasks/task_e_6862bdbfd950833192a651737d2076fa