### PR TITLE
Fix tooltip display

### DIFF
--- a/test-form/src/jules_input.css
+++ b/test-form/src/jules_input.css
@@ -36,7 +36,7 @@
   background-color: var(--jules-neutral-white); /* To mask input border when floated */
   padding: 0 var(--jules-space-xxs);
   white-space: nowrap;
-  overflow: hidden;
+  overflow: visible; /* Allow tooltip content to escape the label box */
   text-overflow: ellipsis;
   max-width: calc(100% - (var(--jules-space-md) * 2)); /* Prevent overflow */
 }

--- a/test-form/src/jules_misc.css
+++ b/test-form/src/jules_misc.css
@@ -35,7 +35,7 @@
   transition: opacity var(--jules-transition-duration-fast) var(--jules-transition-timing-function),
               visibility var(--jules-transition-duration-fast) var(--jules-transition-timing-function);
   white-space: normal; /* Allow long text to wrap */
-  max-width: 250px; /* Prevent overly wide tooltips */
+  max-width: 400px; /* Allow longer lines to reduce wrapping */
   word-wrap: break-word;
   pointer-events: none; /* Prevent tooltip from interfering with mouse events on icon */
 }


### PR DESCRIPTION
## Summary
- enlarge tooltip width so it wraps less
- allow tooltips inside labels to overflow

## Testing
- `npm test --prefix test-form` *(fails: Unexpected token in remark-gfm)*

------
https://chatgpt.com/codex/tasks/task_e_6862c0486c108331a1551171e8bc74fa