### PR TITLE
Persist submitted applications locally

### DIFF
--- a/test-form/src/components/core/FormRenderer/DycdFormRenderer.jsx
+++ b/test-form/src/components/core/FormRenderer/DycdFormRenderer.jsx
@@ -96,6 +96,13 @@ export default function DycdFormRenderer({ applicationId, onExit }) {
       headers: { 'Content-Type': 'application/json' },
       body: JSON.stringify({ stepData, allData }),
     });
+    // Save submission locally so it appears in the dashboard
+    upsertApplication(applicationId, {
+      stepData,
+      allData,
+      currentStep,
+      updatedAt: new Date().toISOString(),
+    });
     onExit && onExit();
   };
 

--- a/test-form/src/components/core/FormRenderer/FormRenderer.jsx
+++ b/test-form/src/components/core/FormRenderer/FormRenderer.jsx
@@ -150,6 +150,13 @@ export default function FormRenderer({ applicationId, onExit }) {
             headers: { 'Content-Type': 'application/json' },
             body: JSON.stringify({ stepData, allData }),
         });
+        // Persist submitted application locally as well
+        upsertApplication(applicationId, {
+          stepData,
+          allData,
+          currentStep,
+          updatedAt: new Date().toISOString(),
+        });
         // Assuming onExit handles success navigation/feedback
         onExit && onExit();
     } catch (err) {


### PR DESCRIPTION
## Summary
- store submitted form data in local storage after posting to the API
- keep dashboard listing up‑to‑date after successful submit

## Testing
- `CI=true npm test --prefix test-form --silent` *(fails: remark-gfm ESM parsing issues)*

------
https://chatgpt.com/codex/tasks/task_e_6862cc57947083319a952dcf51fd5c9b