### PR TITLE
Fix placeholder in group selects

### DIFF
--- a/test-form/src/components/shared/GroupField/GroupField.jsx
+++ b/test-form/src/components/shared/GroupField/GroupField.jsx
@@ -136,7 +136,7 @@ export default function GroupField({ field, value = [], onChange, fullData = {} 
             <SelectField
               key={subField.id}
               options={subField.ui?.options || []}
-              placeholder={subField.ui?.placeholder || `Select ${subField.label}`}
+              placeholder={subField.ui?.placeholder}
               {...commonProps}
               error={error} // Pass error to SelectField
             />

--- a/test-form/src/components/shared/SelectField/SelectField.test.js
+++ b/test-form/src/components/shared/SelectField/SelectField.test.js
@@ -14,3 +14,12 @@ test('renders placeholder option when provided', () => {
   expect(placeholderOpt).toBeInTheDocument();
   expect(placeholderOpt).toHaveValue('');
 });
+
+test('does not render placeholder option when not provided', () => {
+  render(
+    <SelectField id="no-placeholder" label="NoPlaceholder" options={['One', 'Two']} />
+  );
+  const select = screen.getByLabelText('NoPlaceholder');
+  const blankOption = select.querySelector('option[value=""]');
+  expect(blankOption).toBeNull();
+});


### PR DESCRIPTION
## Summary
- avoid rendering a placeholder option for group field select inputs
- test SelectField without a placeholder

## Testing
- `npm test --silent -- --watchAll=false` *(fails: SyntaxError in react-markdown/remark-gfm)*

------
https://chatgpt.com/codex/tasks/task_e_6862ce5bf6b4833180392b7ba2c467b4