### PR TITLE
Add DB schema and setup docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -39,3 +39,14 @@ GOOGLE_CLIENT_SECRET=<google oauth client secret>
 ```
 
 `GOOGLE_API_KEY` is required for the backend to make Google Places API requests. `SESSION_SECRET` secures Express sessions. `DATABASE_URL` points to your PostgreSQL database. The Google OAuth credentials are needed for authentication.
+
+## Database setup
+
+Initialize Postgres and load the schema:
+
+```bash
+createdb intake_form
+psql -d intake_form -f test-form/server/db/schema.sql
+```
+
+Set `DATABASE_URL` in your `.env` file (defaults to `postgres://localhost:5432/intake_form`).

--- a/test-form/server/db/schema.sql
+++ b/test-form/server/db/schema.sql
@@ -1,0 +1,23 @@
+CREATE TABLE users (
+  id UUID PRIMARY KEY DEFAULT gen_random_uuid(),
+  provider VARCHAR(50) NOT NULL,
+  provider_id VARCHAR(100) NOT NULL,
+  email TEXT NOT NULL UNIQUE,
+  first_name TEXT,
+  middle_initial TEXT,
+  last_name TEXT,
+  created_at TIMESTAMP WITH TIME ZONE DEFAULT NOW(),
+  updated_at TIMESTAMP WITH TIME ZONE DEFAULT NOW()
+);
+
+CREATE TABLE "session" (
+  "sid" varchar NOT NULL COLLATE "default",
+  "sess" json NOT NULL,
+  "expire" timestamp(6) NOT NULL
+)
+WITH (OIDS=FALSE);
+
+ALTER TABLE "session" ADD CONSTRAINT "session_pkey" PRIMARY KEY ("sid") NOT DEFERRABLE INITIALLY IMMEDIATE;
+
+CREATE INDEX "IDX_session_expire" ON "session" ("expire");
+


### PR DESCRIPTION
## Summary
- add initial PostgreSQL schema and connect-pg-simple session table
- document running the SQL setup and configuring `DATABASE_URL`

## Testing
- `CI=true npm test` *(fails: Jest encountered unexpected token errors)*

------
https://chatgpt.com/codex/tasks/task_e_6862e9ea99cc8331b39d46c3aff37c61