### PR TITLE
Add auth context and profile page

### DIFF
--- a/test-form/package-lock.json
+++ b/test-form/package-lock.json
@@ -22,6 +22,7 @@
         "react-dom": "^19.1.0",
         "react-imask": "^7.6.1",
         "react-markdown": "^10.1.0",
+        "react-router-dom": "^6.23.0",
         "react-scripts": "5.0.1",
         "remark-gfm": "^4.0.1",
         "web-vitals": "^2.1.4"
@@ -3113,6 +3114,15 @@
         "webpack-plugin-serve": {
           "optional": true
         }
+      }
+    },
+    "node_modules/@remix-run/router": {
+      "version": "1.23.0",
+      "resolved": "https://registry.npmjs.org/@remix-run/router/-/router-1.23.0.tgz",
+      "integrity": "sha512-O3rHJzAQKamUz1fvE0Qaw0xSFqsA/yafi2iqeE0pvdFtCO1viYx8QL6f3Ln/aCCTLxs68SLf0KPM9eSeM8yBnA==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=14.0.0"
       }
     },
     "node_modules/@rollup/plugin-babel": {
@@ -15703,6 +15713,38 @@
       "license": "MIT",
       "engines": {
         "node": ">=0.10.0"
+      }
+    },
+    "node_modules/react-router": {
+      "version": "6.30.1",
+      "resolved": "https://registry.npmjs.org/react-router/-/react-router-6.30.1.tgz",
+      "integrity": "sha512-X1m21aEmxGXqENEPG3T6u0Th7g0aS4ZmoNynhbs+Cn+q+QGTLt+d5IQ2bHAXKzKcxGJjxACpVbnYQSCRcfxHlQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@remix-run/router": "1.23.0"
+      },
+      "engines": {
+        "node": ">=14.0.0"
+      },
+      "peerDependencies": {
+        "react": ">=16.8"
+      }
+    },
+    "node_modules/react-router-dom": {
+      "version": "6.30.1",
+      "resolved": "https://registry.npmjs.org/react-router-dom/-/react-router-dom-6.30.1.tgz",
+      "integrity": "sha512-llKsgOkZdbPU1Eg3zK8lCn+sjD9wMRZZPuzmdWWX5SUs8OFkN5HnFVC0u5KMeMaC9aoancFI/KoLuKPqN+hxHw==",
+      "license": "MIT",
+      "dependencies": {
+        "@remix-run/router": "1.23.0",
+        "react-router": "6.30.1"
+      },
+      "engines": {
+        "node": ">=14.0.0"
+      },
+      "peerDependencies": {
+        "react": ">=16.8",
+        "react-dom": ">=16.8"
       }
     },
     "node_modules/react-scripts": {

--- a/test-form/package.json
+++ b/test-form/package.json
@@ -17,6 +17,7 @@
     "react-dom": "^19.1.0",
     "react-imask": "^7.6.1",
     "react-markdown": "^10.1.0",
+    "react-router-dom": "^6.23.0",
     "react-scripts": "5.0.1",
     "remark-gfm": "^4.0.1",
     "web-vitals": "^2.1.4"

--- a/test-form/src/App.js
+++ b/test-form/src/App.js
@@ -1,4 +1,7 @@
-import { useState } from "react";
+import { useState, useContext } from "react";
+import { Link, Routes, Route } from 'react-router-dom';
+import { AuthContext } from './context/AuthContext';
+import Profile from './pages/Profile';
 // import "./form.css"; // Old theme - commented out
 import FormPage from "./pages/FormPage";
 import Dashboard from "./pages/Dashboard";
@@ -18,9 +21,11 @@ import "./jules_misc.css";
 
 function App() {
   const [menuOpen, setMenuOpen] = useState(false);
+  const [userMenuOpen, setUserMenuOpen] = useState(false);
   const [page, setPage] = useState('dashboard');
   const [currentId, setCurrentId] = useState(null);
   const [currentService, setCurrentService] = useState('childcare');
+  const { user } = useContext(AuthContext);
 
   const startApplication = (serviceKey, id) => {
     setCurrentService(serviceKey);
@@ -49,21 +54,48 @@ function App() {
           >
             Dashboard
           </a>
-
-          <a href="#settings">Profile</a>
+          {!user && (
+            <a href="/auth/google">Login</a>
+          )}
+          {user && (
+            <div className="user-menu">
+              <button
+                type="button"
+                aria-label="user menu"
+                className="avatar"
+                onClick={() => setUserMenuOpen(!userMenuOpen)}
+              >
+                {user.first_name ? user.first_name[0] : 'U'}
+              </button>
+              {userMenuOpen && (
+                <div className="dropdown">
+                  <Link to="/profile" onClick={() => setUserMenuOpen(false)}>Profile</Link>
+                  <a href="/auth/logout">Logout</a>
+                </div>
+              )}
+            </div>
+          )}
         </nav>
       </header>
 
       <main className="form-main">
-        {page === 'dashboard' ? (
-          <Dashboard onStart={startApplication} />
-        ) : (
-          <FormPage
-            applicationId={currentId}
-            service={currentService}
-            onExit={exitForm}
+        <Routes>
+          <Route path="/profile" element={<Profile />} />
+          <Route
+            path="*"
+            element={
+              page === 'dashboard' ? (
+                <Dashboard onStart={startApplication} />
+              ) : (
+                <FormPage
+                  applicationId={currentId}
+                  service={currentService}
+                  onExit={exitForm}
+                />
+              )
+            }
           />
-        )}
+        </Routes>
       </main>
 
       <footer className="form-footer">

--- a/test-form/src/App.test.js
+++ b/test-form/src/App.test.js
@@ -1,11 +1,19 @@
 import { render, screen } from '@testing-library/react';
+import { BrowserRouter } from 'react-router-dom';
 import App from './App';
+import { AuthProvider } from './context/AuthContext';
 
 jest.mock('react-markdown', () => ({ children }) => <div>{children}</div>);
 beforeAll(() => { window.scrollTo = jest.fn(); });
 
 test('renders application header', () => {
-  render(<App />);
+  render(
+    <BrowserRouter>
+      <AuthProvider>
+        <App />
+      </AuthProvider>
+    </BrowserRouter>
+  );
   const headerElement = screen.getByText(/MyCity Services/i);
   expect(headerElement).toBeInTheDocument();
 });

--- a/test-form/src/__mocks__/remark-gfm.js
+++ b/test-form/src/__mocks__/remark-gfm.js
@@ -1,0 +1,1 @@
+module.exports = {};

--- a/test-form/src/__tests__/AuthNavigation.test.jsx
+++ b/test-form/src/__tests__/AuthNavigation.test.jsx
@@ -1,0 +1,31 @@
+import { render, screen } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import { BrowserRouter } from 'react-router-dom';
+import App from '../App';
+import { AuthContext } from '../context/AuthContext';
+
+jest.mock('react-markdown', () => ({ children }) => <div>{children}</div>);
+jest.mock('remark-gfm', () => ({}));
+
+function renderWithUser(user) {
+  return render(
+    <BrowserRouter>
+      <AuthContext.Provider value={{ user }}>
+        <App />
+      </AuthContext.Provider>
+    </BrowserRouter>
+  );
+}
+
+test('shows Login when unauthenticated', () => {
+  renderWithUser(null);
+  expect(screen.getByRole('link', { name: /login/i })).toBeInTheDocument();
+});
+
+test('shows Profile and Logout when authenticated', async () => {
+  const user = userEvent.setup();
+  renderWithUser({ first_name: 'Jane' });
+  await user.click(screen.getByRole('button', { name: /user menu/i }));
+  expect(screen.getByRole('link', { name: /profile/i })).toBeInTheDocument();
+  expect(screen.getByRole('link', { name: /logout/i })).toBeInTheDocument();
+});

--- a/test-form/src/context/AuthContext.jsx
+++ b/test-form/src/context/AuthContext.jsx
@@ -1,0 +1,22 @@
+import { createContext, useEffect, useState } from 'react';
+
+export const AuthContext = createContext({ user: null });
+
+export function AuthProvider({ children }) {
+  const [user, setUser] = useState(null);
+  const [loading, setLoading] = useState(true);
+
+  useEffect(() => {
+    fetch('/api/me')
+      .then((res) => (res.ok ? res.json() : null))
+      .then((data) => setUser(data))
+      .catch(() => setUser(null))
+      .finally(() => setLoading(false));
+  }, []);
+
+  return (
+    <AuthContext.Provider value={{ user, setUser, loading }}>
+      {children}
+    </AuthContext.Provider>
+  );
+}

--- a/test-form/src/index.js
+++ b/test-form/src/index.js
@@ -1,13 +1,19 @@
 import React from 'react';
 import ReactDOM from 'react-dom/client';
+import { BrowserRouter } from 'react-router-dom';
 import './index.css';
 import App from './App';
 import reportWebVitals from './reportWebVitals';
+import { AuthProvider } from './context/AuthContext';
 
 const root = ReactDOM.createRoot(document.getElementById('root'));
 root.render(
   <React.StrictMode>
-    <App />
+    <BrowserRouter>
+      <AuthProvider>
+        <App />
+      </AuthProvider>
+    </BrowserRouter>
   </React.StrictMode>
 );
 

--- a/test-form/src/pages/Profile.jsx
+++ b/test-form/src/pages/Profile.jsx
@@ -1,0 +1,66 @@
+import { useContext, useEffect, useState } from 'react';
+import { AuthContext } from '../context/AuthContext';
+
+export default function Profile() {
+  const { user, setUser } = useContext(AuthContext);
+  const [form, setForm] = useState({ first_name: '', middle_initial: '', last_name: '' });
+  const [status, setStatus] = useState('');
+
+  useEffect(() => {
+    if (user) {
+      setForm({
+        first_name: user.first_name || '',
+        middle_initial: user.middle_initial || '',
+        last_name: user.last_name || ''
+      });
+    }
+  }, [user]);
+
+  const handleChange = (e) => {
+    const { name, value } = e.target;
+    setForm((prev) => ({ ...prev, [name]: value }));
+  };
+
+  const handleSubmit = async (e) => {
+    e.preventDefault();
+    const res = await fetch('/api/me', {
+      method: 'PUT',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify(form)
+    });
+    if (res.ok) {
+      const data = await res.json();
+      setUser(data);
+      setStatus('Saved');
+    } else {
+      setStatus('Failed to save');
+    }
+  };
+
+  if (!user) return <p>Please log in</p>;
+
+  return (
+    <form onSubmit={handleSubmit}>
+      <div>
+        <label>
+          First Name
+          <input name="first_name" value={form.first_name} onChange={handleChange} />
+        </label>
+      </div>
+      <div>
+        <label>
+          Middle Initial
+          <input name="middle_initial" value={form.middle_initial} onChange={handleChange} />
+        </label>
+      </div>
+      <div>
+        <label>
+          Last Name
+          <input name="last_name" value={form.last_name} onChange={handleChange} />
+        </label>
+      </div>
+      <button type="submit">Save</button>
+      {status && <span>{status}</span>}
+    </form>
+  );
+}


### PR DESCRIPTION
## Summary
- create `AuthContext` to store logged-in user
- add profile page for editing user info
- update navigation to show login or user dropdown
- wire up routing and auth provider
- test login vs. profile/logout visibility

## Testing
- `CI=true npm test --silent` *(fails: Unable to find accessible element and other errors)*

------
https://chatgpt.com/codex/tasks/task_e_6862eb19e0e883318ba47940909b6604