### PR TITLE
Fix schema extension and provider queries

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,6 +9,8 @@ Ensure PostgreSQL is running locally on port **5432** and the database schema ha
 ```bash
 # start postgres locally and create the database
 createdb intake_form
+# enable pgcrypto for gen_random_uuid()
+psql -d intake_form -c 'CREATE EXTENSION IF NOT EXISTS pgcrypto;'
 psql -d intake_form -f test-form/server/db/schema.sql
 
 # install dependencies and run the server/client together
@@ -51,6 +53,8 @@ Initialize Postgres and load the schema:
 
 ```bash
 createdb intake_form
+# enable pgcrypto for gen_random_uuid()
+psql -d intake_form -c 'CREATE EXTENSION IF NOT EXISTS pgcrypto;'
 psql -d intake_form -f test-form/server/db/schema.sql
 # connect-pg-simple requires a session table
 # you can also create it using:
@@ -70,3 +74,5 @@ DATABASE_URL=<postgres connection url>
 ```
 
 `GOOGLE_CLIENT_ID` and `GOOGLE_CLIENT_SECRET` must match your OAuth credentials on the Google Cloud console. `DATABASE_URL` should point to the PostgreSQL instance used by the server.
+
+The `users` table stores OAuth provider information using `provider` and `provider_id` columns. The server queries these fields to locate or create the authenticated user.

--- a/test-form/server/db/schema.sql
+++ b/test-form/server/db/schema.sql
@@ -1,3 +1,5 @@
+CREATE EXTENSION IF NOT EXISTS pgcrypto;
+
 CREATE TABLE users (
   id UUID PRIMARY KEY DEFAULT gen_random_uuid(),
   provider VARCHAR(50) NOT NULL,

--- a/test-form/server/index.js
+++ b/test-form/server/index.js
@@ -45,12 +45,12 @@ passport.use(
         const middle = profile.name.middleName ? profile.name.middleName[0] : null;
         const last = profile.name.familyName || '';
 
-        let res = await pool.query('SELECT * FROM users WHERE google_id = $1', [profile.id]);
+        let res = await pool.query('SELECT * FROM users WHERE provider = $1 AND provider_id = $2', ['google', profile.id]);
         let user = res.rows[0];
         if (!user) {
           res = await pool.query(
-            'INSERT INTO users (google_id, email, first_name, middle_initial, last_name) VALUES ($1,$2,$3,$4,$5) RETURNING *',
-            [profile.id, email, first, middle, last]
+            'INSERT INTO users (provider, provider_id, email, first_name, middle_initial, last_name) VALUES ($1,$2,$3,$4,$5,$6) RETURNING *',
+            ['google', profile.id, email, first, middle, last]
           );
           user = res.rows[0];
         }


### PR DESCRIPTION
## Summary
- query for users by `provider` and `provider_id`
- include `CREATE EXTENSION IF NOT EXISTS pgcrypto;` in the schema
- document pgcrypto setup and mention provider fields in README

## Testing
- `CI=true npm test --silent -- --watchAll=false` *(fails: SyntaxError in react-markdown; 5 failing tests)*

------
https://chatgpt.com/codex/tasks/task_e_6862dc5b3a0483318939f693f3543366