### PR TITLE
Fix Dashboard link navigation

### DIFF
--- a/test-form/src/App.js
+++ b/test-form/src/App.js
@@ -48,12 +48,12 @@ function App() {
         </div>
 
         <nav className={`right ${menuOpen ? "open" : ""}`}>
-          <a
-            href="#dashboard"
+          <Link
+            to="/"
             onClick={() => setPage('dashboard')}
           >
             Dashboard
-          </a>
+          </Link>
           {!user && (
             <a href="/auth/google">Login</a>
           )}


### PR DESCRIPTION
## Summary
- update dashboard link to go to the root route

## Testing
- `npm test --silent`

------
https://chatgpt.com/codex/tasks/task_e_686308eb34c083318e6e51d1c405f5c6