### PR TITLE
Add login redirect route and update link

### DIFF
--- a/test-form/server/index.js
+++ b/test-form/server/index.js
@@ -74,6 +74,8 @@ passport.deserializeUser(async (id, done) => {
 
 app.get('/auth/google', passport.authenticate('google', { scope: ['profile', 'email'] }));
 
+app.get('/auth/login', (req, res) => res.redirect('/auth/google'));
+
 app.get('/auth/google/callback',
   passport.authenticate('google', { failureRedirect: '/' }),
   (req, res) => {

--- a/test-form/src/App.js
+++ b/test-form/src/App.js
@@ -55,7 +55,7 @@ function App() {
             Dashboard
           </Link>
           {!user && (
-            <a href="/auth/google">Login</a>
+            <a href="/auth/login">Login</a>
           )}
           {user && (
             <div className="user-menu">


### PR DESCRIPTION
## Summary
- add `/auth/login` route that redirects to Google auth
- change login button to use new `/auth/login` endpoint

## Testing
- `CI=true npm test --silent -- --watchAll=false` *(fails: Unable to find an accessible element in FormRenderer.test.jsx)*

------
https://chatgpt.com/codex/tasks/task_e_686309a222688331bae41fda18a15efd