### PR TITLE
Fix login/logout links to use server URL

### DIFF
--- a/README.md
+++ b/README.md
@@ -48,8 +48,14 @@ GOOGLE_CLIENT_SECRET=<google oauth client secret>
 `GOOGLE_API_KEY` is required for the backend to make Google Places API requests. `SESSION_SECRET` secures Express sessions. `DATABASE_URL` points to your PostgreSQL database. The Google OAuth credentials are needed for authentication.
 
 The React app optionally reads `REACT_APP_SERVER_URL` to determine the Express
-server origin when building login links. It defaults to
-`http://localhost:5000` if not set.
+server origin when building login and logout links. Create a `.env` file in the
+`test-form` directory to override the default:
+
+```bash
+REACT_APP_SERVER_URL=http://localhost:5000
+```
+
+If not provided, the value defaults to `http://localhost:5000`.
 
 ## Database setup
 

--- a/test-form/src/App.js
+++ b/test-form/src/App.js
@@ -71,7 +71,7 @@ function App() {
               {userMenuOpen && (
                 <div className="dropdown">
                   <Link to="/profile" onClick={() => setUserMenuOpen(false)}>Profile</Link>
-                  <a href="/auth/logout">Logout</a>
+                  <a href={`${server}/auth/logout`}>Logout</a>
                 </div>
               )}
             </div>


### PR DESCRIPTION
## Summary
- fix auth links to use `REACT_APP_SERVER_URL` value for login/logout
- document `REACT_APP_SERVER_URL` configuration in README

## Testing
- `npm test --silent`

------
https://chatgpt.com/codex/tasks/task_e_68630f65b60c8331b94a4262b7c67785