### PR TITLE
Move application storage to postgres

### DIFF
--- a/test-form/server/db/schema.sql
+++ b/test-form/server/db/schema.sql
@@ -23,3 +23,22 @@ ALTER TABLE "session" ADD CONSTRAINT "session_pkey" PRIMARY KEY ("sid") NOT DEFE
 
 CREATE INDEX "IDX_session_expire" ON "session" ("expire");
 
+CREATE TABLE applications (
+  id UUID PRIMARY KEY DEFAULT gen_random_uuid(),
+  user_id UUID REFERENCES users(id),
+  service_key TEXT NOT NULL,
+  status TEXT NOT NULL,
+  current_step INTEGER NOT NULL DEFAULT 0,
+  step_data JSONB NOT NULL DEFAULT '{}',
+  all_data JSONB NOT NULL DEFAULT '{}',
+  created_at TIMESTAMP WITH TIME ZONE DEFAULT NOW(),
+  updated_at TIMESTAMP WITH TIME ZONE DEFAULT NOW()
+);
+
+CREATE TABLE application_files (
+  id UUID PRIMARY KEY DEFAULT gen_random_uuid(),
+  application_id UUID REFERENCES applications(id) ON DELETE CASCADE,
+  file_path TEXT NOT NULL,
+  uploaded_at TIMESTAMP WITH TIME ZONE DEFAULT NOW()
+);
+

--- a/test-form/server/index.js
+++ b/test-form/server/index.js
@@ -229,53 +229,90 @@ app.get('/api/places/details/:id', async (req, res) => {
 });
 
 // ------- Application Storage Helpers -------
-function loadApplications() {
-  try {
-    const raw = fs.readFileSync(path.join(__dirname, 'data', 'applications.json'));
-    return JSON.parse(raw);
-  } catch {
-    return [];
-  }
+async function getApplications() {
+  const res = await pool.query('SELECT * FROM applications ORDER BY updated_at DESC');
+  return res.rows;
 }
 
-function saveApplications(apps) {
-  const file = path.join(__dirname, 'data', 'applications.json');
-  fs.mkdirSync(path.dirname(file), { recursive: true });
-  fs.writeFileSync(file, JSON.stringify(apps, null, 2));
+async function getApplication(id) {
+  const res = await pool.query('SELECT * FROM applications WHERE id = $1', [id]);
+  return res.rows[0];
+}
+
+async function upsertApplication(id, data) {
+  const {
+    userId = null,
+    serviceKey = 'childcare',
+    status = 'draft',
+    currentStep = 0,
+    stepData = {},
+    allData = {},
+  } = data;
+  await pool.query(
+    `INSERT INTO applications (id, user_id, service_key, status, current_step, step_data, all_data)
+     VALUES ($1,$2,$3,$4,$5,$6,$7)
+     ON CONFLICT (id) DO UPDATE SET
+       user_id = EXCLUDED.user_id,
+       service_key = EXCLUDED.service_key,
+       status = EXCLUDED.status,
+       current_step = EXCLUDED.current_step,
+       step_data = EXCLUDED.step_data,
+       all_data = EXCLUDED.all_data,
+       updated_at = NOW()`,
+    [id, userId, serviceKey, status, currentStep, stepData, allData]
+  );
 }
 
 // --- Application API ---
-app.post('/api/applications/:appId', (req, res) => {
-  const apps = loadApplications();
-  const idx = apps.findIndex((a) => a.id === req.params.appId);
-  const record = { id: req.params.appId, ...req.body, updatedAt: new Date().toISOString() };
-  if (idx !== -1) {
-    apps[idx] = { ...apps[idx], ...record };
-  } else {
-    apps.push(record);
+app.post('/api/applications/:appId', async (req, res) => {
+  try {
+    await upsertApplication(req.params.appId, req.body);
+    res.json({ status: 'ok' });
+  } catch (err) {
+    console.error(err);
+    res.status(500).json({ error: 'Failed to save application' });
   }
-  saveApplications(apps);
-  res.json({ status: 'ok' });
 });
 
-app.get('/api/applications', (req, res) => {
-  res.json(loadApplications());
+app.get('/api/applications', async (req, res) => {
+  try {
+    const apps = await getApplications();
+    res.json(apps);
+  } catch (err) {
+    console.error(err);
+    res.status(500).json({ error: 'Failed to load applications' });
+  }
 });
 
-app.get('/api/applications/:appId', (req, res) => {
-  const appData = loadApplications().find((a) => a.id === req.params.appId);
-  if (!appData) return res.status(404).json({ error: 'Not found' });
-  res.json(appData);
+app.get('/api/applications/:appId', async (req, res) => {
+  try {
+    const appData = await getApplication(req.params.appId);
+    if (!appData) return res.status(404).json({ error: 'Not found' });
+    res.json(appData);
+  } catch (err) {
+    console.error(err);
+    res.status(500).json({ error: 'Failed to load application' });
+  }
+});
+
+app.delete('/api/applications/:appId', async (req, res) => {
+  try {
+    await pool.query('DELETE FROM applications WHERE id = $1', [req.params.appId]);
+    res.json({ status: 'ok' });
+  } catch (err) {
+    console.error(err);
+    res.status(500).json({ error: 'Failed to delete application' });
+  }
 });
 
 // --- Case Management UI ---
-app.get('/cases', (req, res) => {
-  const apps = loadApplications();
+app.get('/cases', async (req, res) => {
+  const apps = await getApplications();
   res.render('applications', { apps });
 });
 
-app.get('/cases/:appId', (req, res) => {
-  const appData = loadApplications().find((a) => a.id === req.params.appId);
+app.get('/cases/:appId', async (req, res) => {
+  const appData = await getApplication(req.params.appId);
   if (!appData) return res.status(404).send('Application not found');
   res.render('application', { app: appData });
 });

--- a/test-form/src/components/core/FormRenderer/FormRenderer.test.jsx
+++ b/test-form/src/components/core/FormRenderer/FormRenderer.test.jsx
@@ -14,9 +14,17 @@ beforeAll(() => {
 });
 
 beforeEach(() => {
-  global.fetch = jest.fn(() =>
-    Promise.resolve({ ok: true, json: () => Promise.resolve(formSpec) })
-  );
+  global.fetch = jest.fn((url) => {
+    if (url.startsWith('/api/applications/')) {
+      const spec = require('../../../data/childcare_form.json');
+      const reviewIndex = spec.form.steps.findIndex((s) => s.id === 'review');
+      return Promise.resolve({
+        ok: true,
+        json: () => Promise.resolve({ id: '1', current_step: reviewIndex }),
+      });
+    }
+    return Promise.resolve({ ok: true, json: () => Promise.resolve(formSpec) });
+  });
 });
 
 test('renders form title', async () => {
@@ -27,12 +35,6 @@ test('renders form title', async () => {
 });
 
 test('renders review step when currentStep is review', async () => {
-  const spec = require('../../../data/childcare_form.json');
-  const reviewIndex = spec.form.steps.findIndex((s) => s.id === 'review');
-  localStorage.setItem(
-    'childcareApplications',
-    JSON.stringify([{ id: '1', currentStep: reviewIndex }])
-  );
   render(<FormRenderer applicationId="1" />);
   expect(await screen.findByRole('heading', { name: /review & submit/i })).toBeInTheDocument();
 });

--- a/test-form/src/components/core/Step/Step.jsx
+++ b/test-form/src/components/core/Step/Step.jsx
@@ -624,14 +624,13 @@ export default function Step({
     onBackToReview && onBackToReview(cleaned);
   };
 
-  const handleSaveDraftClick = () => {
+  const handleSaveDraftClick = async () => {
     setIsSavingDraft(true);
-    // Current onSaveDraft is synchronous (localStorage).
-    // If it were async, it would be:
-    // try { await onSaveDraft(formData); } catch(e) { ... } finally { setIsSavingDraft(false); }
-    onSaveDraft && onSaveDraft(formData);
-    // For synchronous, reset immediately or after a very short timeout for visual feedback
-    setTimeout(() => setIsSavingDraft(false), 200); // Brief visual feedback
+    try {
+      await onSaveDraft?.(formData);
+    } finally {
+      setIsSavingDraft(false);
+    }
   };
 
   return (

--- a/test-form/src/pages/Dashboard.jsx
+++ b/test-form/src/pages/Dashboard.jsx
@@ -1,5 +1,5 @@
 import React, { useState, useEffect } from 'react';
-import { loadApplications, saveApplications, deleteApplication } from '../utils/appStorage';
+import { loadApplications, upsertApplication, deleteApplication } from '../utils/appStorage';
 import ServiceCard from '../components/ServiceCard';
 import ApplicationCard from '../components/ApplicationCard';
 
@@ -7,14 +7,13 @@ export default function Dashboard({ onStart }) {
   const [apps, setApps] = useState([]);
 
   useEffect(() => {
-    setApps(loadApplications());
+    loadApplications().then(setApps);
   }, []);
 
-  const createNew = (serviceKey) => {
+  const createNew = async (serviceKey) => {
     const id = Date.now().toString();
     const isDycd = serviceKey === 'dycd';
-    const newApp = {
-      id,
+    await upsertApplication(id, {
       serviceKey,
       stepData: {},
       allData: {},
@@ -25,10 +24,9 @@ export default function Dashboard({ onStart }) {
       interactionName: isDycd
         ? 'Youth Services Intake'
         : 'Child Care Assistance Application',
-      updatedAt: new Date().toISOString(),
-    };
-    const updated = [...apps, newApp];
-    saveApplications(updated);
+      status: 'draft',
+    });
+    const updated = await loadApplications();
     setApps(updated);
     onStart && onStart(serviceKey, id);
   };
@@ -39,8 +37,8 @@ export default function Dashboard({ onStart }) {
     onStart && onStart(key, id);
   };
 
-  const handleDelete = (id) => {
-    deleteApplication(id);
+  const handleDelete = async (id) => {
+    await deleteApplication(id);
     setApps((prev) => prev.filter((a) => a.id !== id));
   };
 

--- a/test-form/src/utils/appStorage.js
+++ b/test-form/src/utils/appStorage.js
@@ -1,32 +1,31 @@
-export function loadApplications() {
+export async function loadApplications() {
   try {
-    const raw = localStorage.getItem('childcareApplications');
-    return raw ? JSON.parse(raw) : [];
+    const res = await fetch('/api/applications');
+    if (!res.ok) throw new Error('Failed to load applications');
+    return await res.json();
   } catch {
     return [];
   }
 }
 
-export function saveApplications(apps) {
-  localStorage.setItem('childcareApplications', JSON.stringify(apps));
-}
-
-export function getApplication(id) {
-  return loadApplications().find((a) => a.id === id);
-}
-
-export function upsertApplication(id, data) {
-  const apps = loadApplications();
-  const idx = apps.findIndex((a) => a.id === id);
-  if (idx !== -1) {
-    apps[idx] = { ...apps[idx], ...data, id };
-  } else {
-    apps.push({ id, ...data });
+export async function getApplication(id) {
+  try {
+    const res = await fetch(`/api/applications/${id}`);
+    if (!res.ok) return null;
+    return await res.json();
+  } catch {
+    return null;
   }
-  saveApplications(apps);
 }
 
-export function deleteApplication(id) {
-  const updated = loadApplications().filter((a) => a.id !== id);
-  saveApplications(updated);
+export async function upsertApplication(id, data) {
+  await fetch(`/api/applications/${id}`, {
+    method: 'POST',
+    headers: { 'Content-Type': 'application/json' },
+    body: JSON.stringify(data),
+  });
+}
+
+export async function deleteApplication(id) {
+  await fetch(`/api/applications/${id}`, { method: 'DELETE' });
 }


### PR DESCRIPTION
## Summary
- add `applications` and `application_files` tables
- switch server to read/write from Postgres instead of JSON files
- update dashboard and form renderer to fetch/submit data via the API
- replace `appStorage` localStorage helpers with API based versions
- update tests for new API behaviour

## Testing
- `npm test --silent`

------
https://chatgpt.com/codex/tasks/task_e_686342ab9ac883318274fa32812964c4