### PR TITLE
Switch to crypto.randomUUID for new app IDs

### DIFF
--- a/test-form/src/pages/Dashboard.jsx
+++ b/test-form/src/pages/Dashboard.jsx
@@ -11,7 +11,7 @@ export default function Dashboard({ onStart }) {
   }, []);
 
   const createNew = async (serviceKey) => {
-    const id = Date.now().toString();
+    const id = crypto.randomUUID();
     const isDycd = serviceKey === 'dycd';
     await upsertApplication(id, {
       serviceKey,

--- a/test-form/src/setupTests.js
+++ b/test-form/src/setupTests.js
@@ -9,3 +9,10 @@ expect.extend(toHaveNoViolations);
 
 // jsdom does not implement scrollTo; provide a stub for tests that call it
 window.scrollTo = () => {};
+
+// Provide crypto.randomUUID for tests (jsdom may not implement it)
+if (!global.crypto) {
+  global.crypto = { randomUUID: () => 'test-id' };
+} else if (!global.crypto.randomUUID) {
+  global.crypto.randomUUID = () => 'test-id';
+}


### PR DESCRIPTION
## Summary
- use `crypto.randomUUID()` when creating new applications
- mock `crypto.randomUUID` in test setup so Jest has the API

## Testing
- `npm install`
- `CI=true npm test -- --watchAll=false` *(fails: Jest execution didn't complete in this environment)*

------
https://chatgpt.com/codex/tasks/task_e_686348e557708331907d76b9d0f6b9ba