### PR TITLE
Add ClamAV virus scanning for uploads

### DIFF
--- a/README.md
+++ b/README.md
@@ -45,9 +45,13 @@ GOOGLE_CLIENT_ID=<google oauth client id>
 GOOGLE_CLIENT_SECRET=<google oauth client secret>
 FILE_STORAGE=local # or 'gcp'
 GCP_BUCKET=<gcs bucket name when using gcp>
+CLAMAV_HOST=127.0.0.1
+CLAMAV_PORT=3310
 ```
 
 `GOOGLE_API_KEY` is required for the backend to make Google Places API requests. `SESSION_SECRET` secures Express sessions. `DATABASE_URL` points to your PostgreSQL database. The Google OAuth credentials are needed for authentication. Set `FILE_STORAGE` to `gcp` to store uploads in the bucket specified by `GCP_BUCKET`; otherwise files are kept on disk under `server/uploads`.
+
+Uploads are scanned using [ClamAV](https://www.clamav.net/). Install and run `clamd` locally and adjust `CLAMAV_HOST` and `CLAMAV_PORT` if needed. Infected files are moved to `test-form/server/quarantine`.
 
 The React app optionally reads `REACT_APP_SERVER_URL` to determine the Express
 server origin when building login and logout links. Create a `.env` file in the

--- a/test-form/package-lock.json
+++ b/test-form/package-lock.json
@@ -10,6 +10,7 @@
       "dependencies": {
         "@google-cloud/storage": "^7.16.0",
         "@testing-library/dom": "^10.4.0",
+        "clamav.js": "^0.12.0",
         "connect-pg-simple": "^10.0.0",
         "dotenv": "^16.3.1",
         "express": "^4.18.2",
@@ -5975,6 +5976,12 @@
       "version": "1.4.3",
       "resolved": "https://registry.npmjs.org/cjs-module-lexer/-/cjs-module-lexer-1.4.3.tgz",
       "integrity": "sha512-9z8TZaGM1pfswYeXrUpzPrkx8UnWYdhJclsiYMm6x/w5+nN+8Tf/LnAgfLGQCm59qAOxU8WwHEq2vNwF6i4j+Q==",
+      "license": "MIT"
+    },
+    "node_modules/clamav.js": {
+      "version": "0.12.0",
+      "resolved": "https://registry.npmjs.org/clamav.js/-/clamav.js-0.12.0.tgz",
+      "integrity": "sha512-IoPwy6rzivi9PGtRR9GvnXmfCLbMi+WX46j5S/SFG3tniIqesxq6976su7jGmhSu8FLp8TUC/ZE604KxELacWg==",
       "license": "MIT"
     },
     "node_modules/clean-css": {

--- a/test-form/package.json
+++ b/test-form/package.json
@@ -21,7 +21,8 @@
     "react-router-dom": "^6.23.0",
     "react-scripts": "5.0.1",
     "remark-gfm": "^4.0.1",
-    "web-vitals": "^2.1.4"
+    "web-vitals": "^2.1.4",
+    "clamav.js": "^0.12.0"
   },
   "scripts": {
     "start": "react-scripts start",

--- a/test-form/server/index.js
+++ b/test-form/server/index.js
@@ -132,6 +132,9 @@ app.post('/api/applications/:appId/upload', upload, async (req, res) => {
     res.json({ paths });
   } catch (err) {
     console.error(err);
+    if (err.code === 'VIRUS_DETECTED') {
+      return res.status(400).json({ error: 'Malicious file detected' });
+    }
     res.status(500).json({ error: 'Failed to store files' });
   }
 });

--- a/test-form/server/storage/gcpStorage.js
+++ b/test-form/server/storage/gcpStorage.js
@@ -1,10 +1,14 @@
 const multer = require('multer');
 const { Storage } = require('@google-cloud/storage');
+const fs = require('fs');
+const path = require('path');
+const { scanBuffer } = require('../virusScanner');
 
 class GCPStorageStrategy {
   constructor(bucketName) {
     if (!bucketName) throw new Error('GCP bucket name is required');
     this.bucket = new Storage().bucket(bucketName);
+    this.quarantineDir = path.join(__dirname, '..', 'quarantine');
   }
 
   multerMiddleware() {
@@ -12,11 +16,18 @@ class GCPStorageStrategy {
   }
 
   async saveFiles(appId, files) {
-    const uploads = files.map(file => {
-      const destination = `${appId}/${Date.now()}-${file.originalname}`;
-      return this.bucket.file(destination)
-        .save(file.buffer)
-        .then(() => `https://storage.googleapis.com/${this.bucket.name}/${destination}`);
+    const uploads = files.map(async file => {
+      try {
+        await scanBuffer(file.buffer);
+        const destination = `${appId}/${Date.now()}-${file.originalname}`;
+        await this.bucket.file(destination).save(file.buffer);
+        return `https://storage.googleapis.com/${this.bucket.name}/${destination}`;
+      } catch (err) {
+        fs.mkdirSync(this.quarantineDir, { recursive: true });
+        const qpath = path.join(this.quarantineDir, `${Date.now()}-${file.originalname}`);
+        fs.writeFileSync(qpath, file.buffer);
+        throw err;
+      }
     });
     return Promise.all(uploads);
   }

--- a/test-form/server/storage/localStorage.js
+++ b/test-form/server/storage/localStorage.js
@@ -1,29 +1,36 @@
 const multer = require('multer');
 const fs = require('fs');
 const path = require('path');
+const { scanBuffer } = require('../virusScanner');
 
 class LocalStorageStrategy {
   constructor(baseDir) {
     this.baseDir = baseDir;
+    this.quarantineDir = path.join(path.dirname(baseDir), 'quarantine');
   }
 
   multerMiddleware() {
-    return multer({
-      storage: multer.diskStorage({
-        destination: (req, file, cb) => {
-          const dir = path.join(this.baseDir, req.params.appId);
-          fs.mkdirSync(dir, { recursive: true });
-          cb(null, dir);
-        },
-        filename: (req, file, cb) => {
-          cb(null, Date.now() + '-' + file.originalname);
-        }
-      })
-    }).array('files');
+    return multer({ storage: multer.memoryStorage() }).array('files');
   }
 
   async saveFiles(appId, files) {
-    return files.map(f => `/uploads/${appId}/${f.filename}`);
+    const dir = path.join(this.baseDir, appId);
+    fs.mkdirSync(dir, { recursive: true });
+    const paths = [];
+    for (const file of files) {
+      try {
+        await scanBuffer(file.buffer);
+        const filename = `${Date.now()}-${file.originalname}`;
+        fs.writeFileSync(path.join(dir, filename), file.buffer);
+        paths.push(`/uploads/${appId}/${filename}`);
+      } catch (err) {
+        fs.mkdirSync(this.quarantineDir, { recursive: true });
+        const qpath = path.join(this.quarantineDir, `${Date.now()}-${file.originalname}`);
+        fs.writeFileSync(qpath, file.buffer);
+        throw err;
+      }
+    }
+    return paths;
   }
 }
 

--- a/test-form/server/virusScanner.js
+++ b/test-form/server/virusScanner.js
@@ -1,0 +1,25 @@
+const clamav = require('clamav.js');
+const { Readable } = require('stream');
+
+const HOST = process.env.CLAMAV_HOST || '127.0.0.1';
+const PORT = parseInt(process.env.CLAMAV_PORT, 10) || 3310;
+
+function scanBuffer(buffer) {
+  return new Promise((resolve, reject) => {
+    clamav.ping(PORT, HOST, 1000, pingErr => {
+      if (pingErr) return reject(pingErr);
+      const stream = Readable.from(buffer);
+      clamav.createScanner(PORT, HOST).scan(stream, (err, _object, malicious) => {
+        if (err) return reject(err);
+        if (malicious) {
+          const error = new Error('Malicious file detected');
+          error.code = 'VIRUS_DETECTED';
+          return reject(error);
+        }
+        resolve();
+      });
+    });
+  });
+}
+
+module.exports = { scanBuffer };

--- a/test-form/src/components/shared/FileInput/FileInput.jsx
+++ b/test-form/src/components/shared/FileInput/FileInput.jsx
@@ -19,6 +19,7 @@ export default function FileInput({
 }) {
   const [dragOver, setDragOver] = useState(false);
   const [fileNames, setFileNames] = useState([]);
+  const [uploadError, setUploadError] = useState('');
   const dragCounter = useRef(0);
   const inputRef = useRef(null);
 
@@ -30,6 +31,7 @@ export default function FileInput({
     if (!onChange || filesArray.length === 0) return;
 
     setFileNames(filesArray.map((f) => f.name));
+    setUploadError('');
 
     if (applicationId) {
       const form = new FormData();
@@ -46,10 +48,10 @@ export default function FileInput({
           return;
         }
         console.error('Upload failed', data);
-        // Potentially set an error state here to display to the user
+        setUploadError(data.error || 'Upload failed');
       } catch (err) {
         console.error('Upload error', err);
-        // Potentially set an error state here
+        setUploadError('Upload failed');
       }
     } else {
       // If no applicationId, pass the FileList/File object directly
@@ -173,6 +175,7 @@ export default function FileInput({
         <p className="jules-input-hint">{hint}</p>
       )}
       {error && <div className="jules-alert jules-alert-error jules-input-error-message">{error}</div>}
+      {uploadError && <div className="jules-alert jules-alert-error">{uploadError}</div>}
     </div>
   );
 }


### PR DESCRIPTION
## Summary
- add clamav.js dependency
- implement virus scanning helper and integrate in storage layers
- quarantine malicious files and expose error in API
- show upload error in FileInput component
- document ClamAV setup in README

## Testing
- `npm test --silent -- --watchAll=false`

------
https://chatgpt.com/codex/tasks/task_e_686838ccfe9c8331b08d4d3d2ab2ace4