### PR TITLE
Add env example template

### DIFF
--- a/README.md
+++ b/README.md
@@ -35,7 +35,7 @@ Selecting an application opens a page with each step's data shown in its own tab
 ## Environment requirements
 
 - **Node.js**: version 18 or later is recommended.
-- **Environment variables**: create a `.env` file inside the `test-form/server` directory with the following keys:
+- **Environment variables**: copy `test-form/.env.example` to `test-form/.env` and `test-form/server/.env`, then update the following keys:
 
 ```
 GOOGLE_API_KEY=<your Places API key>
@@ -53,9 +53,7 @@ CLAMAV_PORT=3310
 
 Uploads are scanned using [ClamAV](https://www.clamav.net/). Install and run `clamd` locally and adjust `CLAMAV_HOST` and `CLAMAV_PORT` if needed. Infected files are moved to `test-form/server/quarantine`.
 
-The React app optionally reads `REACT_APP_SERVER_URL` to determine the Express
-server origin when building login and logout links. Create a `.env` file in the
-`test-form` directory to override the default:
+The React app optionally reads `REACT_APP_SERVER_URL` to determine the Express server origin when building login and logout links. Copy `test-form/.env.example` to `test-form/.env` and edit it to override the default:
 
 ```bash
 REACT_APP_SERVER_URL=http://localhost:5000

--- a/test-form/.env.example
+++ b/test-form/.env.example
@@ -1,0 +1,15 @@
+# Sample environment configuration
+
+# Server settings
+GOOGLE_API_KEY=your-google-api-key
+SESSION_SECRET=change-me
+DATABASE_URL=postgres://localhost:5432/intake_form
+GOOGLE_CLIENT_ID=your-google-client-id
+GOOGLE_CLIENT_SECRET=your-google-client-secret
+FILE_STORAGE=local
+GCP_BUCKET=your-bucket
+CLAMAV_HOST=127.0.0.1
+CLAMAV_PORT=3310
+
+# React settings
+REACT_APP_SERVER_URL=http://localhost:5000


### PR DESCRIPTION
## Summary
- provide a .env.example in `test-form`
- explain copying this example in README

## Testing
- `npm test --silent`

------
https://chatgpt.com/codex/tasks/task_e_6868a36ebb8083319fb83f3bb6d79a7f