### PR TITLE
Add ESLint and Prettier setup

### DIFF
--- a/test-form/.eslintrc.json
+++ b/test-form/.eslintrc.json
@@ -1,0 +1,7 @@
+{
+  "extends": [
+    "react-app",
+    "react-app/jest",
+    "eslint:recommended"
+  ]
+}

--- a/test-form/.prettierrc
+++ b/test-form/.prettierrc
@@ -1,0 +1,4 @@
+{
+  "singleQuote": true,
+  "trailingComma": "all"
+}

--- a/test-form/package-lock.json
+++ b/test-form/package-lock.json
@@ -34,8 +34,10 @@
         "@testing-library/react": "^16.3.0",
         "@testing-library/user-event": "^14.6.1",
         "concurrently": "^9.1.2",
+        "eslint": "^8.57.0",
         "jest": "^27.5.1",
         "jest-axe": "^10.0.0",
+        "prettier": "^2.8.8",
         "supertest": "^6.3.3"
       }
     },
@@ -15831,6 +15833,22 @@
       "license": "MIT",
       "engines": {
         "node": ">= 0.8.0"
+      }
+    },
+    "node_modules/prettier": {
+      "version": "2.8.8",
+      "resolved": "https://registry.npmjs.org/prettier/-/prettier-2.8.8.tgz",
+      "integrity": "sha512-tdN8qQGvNjw4CHbY+XXk0JgCXn9QiF21a55rBe5LJAU+kDyC4WQn4+awm2Xfk2lQMk5fKup9XgzTZtGkjBdP9Q==",
+      "dev": true,
+      "license": "MIT",
+      "bin": {
+        "prettier": "bin-prettier.js"
+      },
+      "engines": {
+        "node": ">=10.13.0"
+      },
+      "funding": {
+        "url": "https://github.com/prettier/prettier?sponsor=1"
       }
     },
     "node_modules/pretty-bytes": {

--- a/test-form/package.json
+++ b/test-form/package.json
@@ -31,13 +31,9 @@
     "build": "react-scripts build",
     "test": "react-scripts test",
     "eject": "react-scripts eject",
-    "test-server": "jest --config server/jest.config.js"
-  },
-  "eslintConfig": {
-    "extends": [
-      "react-app",
-      "react-app/jest"
-    ]
+    "test-server": "jest --config server/jest.config.js",
+    "lint": "eslint \"src/**/*.{js,jsx}\"",
+    "format": "prettier --write \"src/**/*.{js,jsx,json,css,md}\""
   },
   "browserslist": {
     "production": [
@@ -59,6 +55,8 @@
     "concurrently": "^9.1.2",
     "jest-axe": "^10.0.0",
     "jest": "^27.5.1",
-    "supertest": "^6.3.3"
+    "supertest": "^6.3.3",
+    "eslint": "^8.57.0",
+    "prettier": "^2.8.8"
   }
 }


### PR DESCRIPTION
## Summary
- install `eslint` and `prettier` in test-form package
- add ESLint and Prettier config files
- provide lint and format npm scripts

## Testing
- `CI=true npm test -- --watchAll=false`

------
https://chatgpt.com/codex/tasks/task_e_6868a89c1dc0833190f7a785bd57742e