### PR TITLE
Cleanup unused code

### DIFF
--- a/test-form/src/components/core/Stepper/Stepper.jsx
+++ b/test-form/src/components/core/Stepper/Stepper.jsx
@@ -35,7 +35,6 @@ export default function Stepper({
         {steps.map((step, index) => {
           const isActive = index === currentStep;
           const isComplete = index < currentStep;
-          const isInactive = !isActive && !isComplete;
 
           let itemClasses = 'jules-stepper-item';
           if (isActive) {

--- a/test-form/src/components/shared/Button/Button.jsx
+++ b/test-form/src/components/shared/Button/Button.jsx
@@ -46,9 +46,6 @@ const Button = ({
     };
     const spinnerSizeClass = spinnerSizeClassMap[size] || '';
 
-    // Determine if there is any visible content other than the spinner
-    const hasOtherContent = Boolean(children || iconLeft || iconRight);
-
     return (
         <button
             type={type}

--- a/test-form/src/components/shared/GroupField/GroupField.jsx
+++ b/test-form/src/components/shared/GroupField/GroupField.jsx
@@ -6,7 +6,6 @@ import CheckboxGroup from '../CheckboxGroup/CheckboxGroup';
 import FileInput from '../FileInput/FileInput';
 import MaskedInput from '../MaskedInput/MaskedInput';
 import AddressAutocomplete from '../AddressAutocomplete';
-import Tooltip from '../Tooltip/Tooltip';
 import Button from '../Button/Button'; // Import the new Button component
 import { evaluateCondition } from '../../../utils/formHelpers';
 


### PR DESCRIPTION
## Summary
- remove unused constant `isInactive` from Stepper
- remove unused constant `hasOtherContent` from Button
- delete unused Tooltip import in GroupField
- run ESLint

## Testing
- `npm run lint` *(fails: Avoid direct Node access etc.)*

------
https://chatgpt.com/codex/tasks/task_e_6868b916f96c8331a0276246d135a02a