### PR TITLE
Add Dockerfile for React client

### DIFF
--- a/README.md
+++ b/README.md
@@ -90,3 +90,17 @@ DATABASE_URL=<postgres connection url>
 `GOOGLE_CLIENT_ID` and `GOOGLE_CLIENT_SECRET` must match your OAuth credentials on the Google Cloud console. `DATABASE_URL` should point to the PostgreSQL instance used by the server.
 
 The `users` table stores OAuth provider information using `provider` and `provider_id` columns. The server queries these fields to locate or create the authenticated user.
+
+## Docker build
+
+A `Dockerfile` is provided under `test-form` to build the React client for production.
+
+```bash
+# Set the API origin when building so login links target the Express server
+docker build \
+  --build-arg REACT_APP_SERVER_URL=http://localhost:5000 \
+  -t intake-form-client -f test-form/Dockerfile test-form
+docker run -p 3000:80 intake-form-client
+```
+
+The container serves the compiled React app via nginx on host port `3000`. Adjust the `REACT_APP_SERVER_URL` build argument if the server runs elsewhere.

--- a/test-form/.dockerignore
+++ b/test-form/.dockerignore
@@ -1,0 +1,7 @@
+/node_modules
+/build
+.env*
+.DS_Store
+npm-debug.log*
+yarn-debug.log*
+yarn-error.log*

--- a/test-form/Dockerfile
+++ b/test-form/Dockerfile
@@ -1,0 +1,18 @@
+# Stage 1: build React app
+FROM node:18 AS builder
+WORKDIR /app
+COPY package*.json ./
+RUN npm ci
+COPY . .
+
+# Configure the API origin for login/logout links
+ARG REACT_APP_SERVER_URL=http://localhost:5000
+ENV REACT_APP_SERVER_URL=${REACT_APP_SERVER_URL}
+
+RUN npm run build
+
+# Stage 2: serve with nginx
+FROM nginx:alpine
+COPY --from=builder /app/build /usr/share/nginx/html
+EXPOSE 3000
+CMD ["nginx", "-g", "daemon off;"]


### PR DESCRIPTION
## Summary
- add multistage Dockerfile to build React app and serve via nginx
- ignore build artifacts in .dockerignore
- document Docker build and run commands in README
- support REACT_APP_SERVER_URL at build time and fix README instructions

## Testing
- `npm test -- -w=0` *(fails: No tests found)*
- `npm run test-server`
- `npm run lint` *(fails: 12 errors)*


------
https://chatgpt.com/codex/tasks/task_e_6868b2d1f3e08331ba5918a536a439b4