### PR TITLE
Use FontAwesome icons

### DIFF
--- a/test-form/package-lock.json
+++ b/test-form/package-lock.json
@@ -8,6 +8,8 @@
       "name": "test-form",
       "version": "0.1.0",
       "dependencies": {
+        "@fortawesome/free-solid-svg-icons": "^6.7.2",
+        "@fortawesome/react-fontawesome": "^0.2.2",
         "@google-cloud/storage": "^7.16.0",
         "@testing-library/dom": "^10.4.0",
         "clamav.js": "^0.12.0",
@@ -2512,6 +2514,53 @@
       "license": "MIT",
       "engines": {
         "node": "^12.22.0 || ^14.17.0 || >=16.0.0"
+      }
+    },
+    "node_modules/@fortawesome/fontawesome-common-types": {
+      "version": "6.7.2",
+      "resolved": "https://registry.npmjs.org/@fortawesome/fontawesome-common-types/-/fontawesome-common-types-6.7.2.tgz",
+      "integrity": "sha512-Zs+YeHUC5fkt7Mg1l6XTniei3k4bwG/yo3iFUtZWd/pMx9g3fdvkSK9E0FOC+++phXOka78uJcYb8JaFkW52Xg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=6"
+      }
+    },
+    "node_modules/@fortawesome/fontawesome-svg-core": {
+      "version": "6.7.2",
+      "resolved": "https://registry.npmjs.org/@fortawesome/fontawesome-svg-core/-/fontawesome-svg-core-6.7.2.tgz",
+      "integrity": "sha512-yxtOBWDrdi5DD5o1pmVdq3WMCvnobT0LU6R8RyyVXPvFRd2o79/0NCuQoCjNTeZz9EzA9xS3JxNWfv54RIHFEA==",
+      "license": "MIT",
+      "peer": true,
+      "dependencies": {
+        "@fortawesome/fontawesome-common-types": "6.7.2"
+      },
+      "engines": {
+        "node": ">=6"
+      }
+    },
+    "node_modules/@fortawesome/free-solid-svg-icons": {
+      "version": "6.7.2",
+      "resolved": "https://registry.npmjs.org/@fortawesome/free-solid-svg-icons/-/free-solid-svg-icons-6.7.2.tgz",
+      "integrity": "sha512-GsBrnOzU8uj0LECDfD5zomZJIjrPhIlWU82AHwa2s40FKH+kcxQaBvBo3Z4TxyZHIyX8XTDxsyA33/Vx9eFuQA==",
+      "license": "(CC-BY-4.0 AND MIT)",
+      "dependencies": {
+        "@fortawesome/fontawesome-common-types": "6.7.2"
+      },
+      "engines": {
+        "node": ">=6"
+      }
+    },
+    "node_modules/@fortawesome/react-fontawesome": {
+      "version": "0.2.2",
+      "resolved": "https://registry.npmjs.org/@fortawesome/react-fontawesome/-/react-fontawesome-0.2.2.tgz",
+      "integrity": "sha512-EnkrprPNqI6SXJl//m29hpaNzOp1bruISWaOiRtkMi/xSvHJlzc2j2JAYS7egxt/EbjSNV/k6Xy0AQI6vB2+1g==",
+      "license": "MIT",
+      "dependencies": {
+        "prop-types": "^15.8.1"
+      },
+      "peerDependencies": {
+        "@fortawesome/fontawesome-svg-core": "~1 || ~6",
+        "react": ">=16.3"
       }
     },
     "node_modules/@google-cloud/paginator": {

--- a/test-form/package.json
+++ b/test-form/package.json
@@ -3,6 +3,8 @@
   "version": "0.1.0",
   "private": true,
   "dependencies": {
+    "@fortawesome/free-solid-svg-icons": "^6.7.2",
+    "@fortawesome/react-fontawesome": "^0.2.2",
     "@google-cloud/storage": "^7.16.0",
     "@testing-library/dom": "^10.4.0",
     "clamav.js": "^0.12.0",

--- a/test-form/src/components/ApplicationCard.jsx
+++ b/test-form/src/components/ApplicationCard.jsx
@@ -1,5 +1,7 @@
 import React from 'react';
 import Button from './shared/Button/Button'; // Import the new Button component
+import { FontAwesomeIcon } from '@fortawesome/react-fontawesome';
+import { faArrowRight, faTrash } from '@fortawesome/free-solid-svg-icons';
 
 export default function ApplicationCard({
   id,
@@ -52,7 +54,7 @@ export default function ApplicationCard({
           variant="primary" // Continue button might be primary in this context
           size="small"
           onClick={() => onContinue && onContinue(id)}
-          iconRight="→"
+          iconRight={<FontAwesomeIcon icon={faArrowRight} aria-hidden="true" />}
         >
           Continue
         </Button>
@@ -60,7 +62,7 @@ export default function ApplicationCard({
           variant="destructive"
           size="small"
           onClick={() => onDelete && onDelete(id)}
-          iconLeft="🗑"
+          iconLeft={<FontAwesomeIcon icon={faTrash} aria-hidden="true" />}
         >
           Delete
         </Button>

--- a/test-form/src/components/core/ReviewStep/ReviewStep.jsx
+++ b/test-form/src/components/core/ReviewStep/ReviewStep.jsx
@@ -1,6 +1,12 @@
 import React, { useState } from 'react';
 import Modal from '../../shared/Modal/Modal'; // Assuming Modal is already refactored
 import Button from '../../shared/Button/Button'; // Import the new Button component
+import { FontAwesomeIcon } from '@fortawesome/react-fontawesome';
+import {
+  faPen,
+  faFileLines,
+  faCheck,
+} from '@fortawesome/free-solid-svg-icons';
 // import styles from './ReviewStep.module.css'; // Removed CSS Module import - likely redundant
 
 function isObject(val) {
@@ -110,8 +116,8 @@ export default function ReviewStep({ steps = [], stepData = {}, onEdit, onSubmit
                   variant="tertiary"
                   size="small"
                   onClick={() => onEdit(idx)}
-                  iconLeft="✎"
-                  style={{marginRight: 'var(--jules-space-sm)'}}
+                  iconLeft={<FontAwesomeIcon icon={faPen} aria-hidden="true" />}
+                  style={{ marginRight: 'var(--jules-space-sm)' }}
                 >
                   Edit
                 </Button>
@@ -119,7 +125,7 @@ export default function ReviewStep({ steps = [], stepData = {}, onEdit, onSubmit
                   variant="tertiary"
                   size="small"
                   onClick={() => handleOpenModal(idx)}
-                  iconLeft="📄"
+                  iconLeft={<FontAwesomeIcon icon={faFileLines} aria-hidden="true" />}
                 >
                   View as JSON
                 </Button>
@@ -135,7 +141,7 @@ export default function ReviewStep({ steps = [], stepData = {}, onEdit, onSubmit
         <Button
           variant="primary"
           onClick={onSubmit}
-          iconRight="✓"
+          iconRight={<FontAwesomeIcon icon={faCheck} aria-hidden="true" />}
           isLoading={isSubmitting} // Pass isSubmitting to isLoading prop
         >
           Submit Application

--- a/test-form/src/components/core/Step/Step.jsx
+++ b/test-form/src/components/core/Step/Step.jsx
@@ -19,6 +19,19 @@ import AddressAutocomplete from '../../shared/AddressAutocomplete';
 import Tooltip from '../../shared/Tooltip/Tooltip';
 import ReactMarkdown from 'react-markdown';
 import Button from '../../shared/Button/Button'; // Import the new Button component
+import { FontAwesomeIcon } from '@fortawesome/react-fontawesome';
+import {
+  faPhone,
+  faEnvelope,
+  faCalendarDays,
+  faCircleXmark,
+  faCircleCheck,
+  faArrowLeft,
+  faArrowRight,
+  faFloppyDisk,
+  faReply,
+  faCheck,
+} from '@fortawesome/free-solid-svg-icons';
 // import styles from './Step.module.css'; // Removed CSS Module import
 
 export default function Step({
@@ -214,8 +227,21 @@ export default function Step({
           value={formData[field.id] || ''}
           onChange={(val) => handleChange(field.id, val)}
           error={error}
-          iconLeft={field.type === 'tel' ? "✆" : undefined} // Example: Phone icon for tel type
-          iconRight={error ? <span className="jules-validation-icon-error">✕</span> : (!error && touched[field.id] && formData[field.id] ? <span className="jules-validation-icon-success">✓</span> : undefined)}
+          iconLeft={field.type === 'tel' ? <FontAwesomeIcon icon={faPhone} aria-hidden="true" /> : undefined}
+          iconRight={
+            error ? (
+              <span className="jules-validation-icon-error">
+                <FontAwesomeIcon icon={faCircleXmark} aria-hidden="true" />
+                <span className="sr-only">Error</span>
+              </span>
+            ) :
+            (!error && touched[field.id] && formData[field.id] ? (
+              <span className="jules-validation-icon-success">
+                <FontAwesomeIcon icon={faCircleCheck} aria-hidden="true" />
+                <span className="sr-only">Valid</span>
+              </span>
+            ) : undefined)
+          }
         />
       );
     }
@@ -245,7 +271,20 @@ export default function Step({
               value={formData[field.id] || ''}
               onChange={(val) => handleChange(field.id, val)}
               error={error}
-              iconRight={error ? <span className="jules-validation-icon-error">✕</span> : (!error && touched[field.id] && formData[field.id] ? <span className="jules-validation-icon-success">✓</span> : undefined)}
+              iconRight={
+                error ? (
+                  <span className="jules-validation-icon-error">
+                    <FontAwesomeIcon icon={faCircleXmark} aria-hidden="true" />
+                    <span className="sr-only">Error</span>
+                  </span>
+                ) :
+                (!error && touched[field.id] && formData[field.id] ? (
+                  <span className="jules-validation-icon-success">
+                    <FontAwesomeIcon icon={faCircleCheck} aria-hidden="true" />
+                    <span className="sr-only">Valid</span>
+                  </span>
+                ) : undefined)
+              }
             />
           );
         }
@@ -357,8 +396,21 @@ export default function Step({
             value={formData[field.id] || ''}
             onChange={(e) => handleChange(field.id, e.target.value)}
             error={error}
-            iconLeft={field.type === 'email' ? "@" : undefined} // Example: Email icon
-            iconRight={error ? <span className="jules-validation-icon-error">✕</span> : (!error && touched[field.id] && formData[field.id] ? <span className="jules-validation-icon-success">✓</span> : undefined)}
+            iconLeft={field.type === 'email' ? <FontAwesomeIcon icon={faEnvelope} aria-hidden="true" /> : undefined}
+            iconRight={
+              error ? (
+                <span className="jules-validation-icon-error">
+                  <FontAwesomeIcon icon={faCircleXmark} aria-hidden="true" />
+                  <span className="sr-only">Error</span>
+                </span>
+              ) :
+              (!error && touched[field.id] && formData[field.id] ? (
+                <span className="jules-validation-icon-success">
+                  <FontAwesomeIcon icon={faCircleCheck} aria-hidden="true" />
+                  <span className="sr-only">Valid</span>
+                </span>
+              ) : undefined)
+            }
             // Hint prop can be added if field.description exists
           />
         );
@@ -478,8 +530,21 @@ export default function Step({
             value={formData[field.id] || ''}
             onChange={(e) => handleChange(field.id, e.target.value)}
             error={error}
-            iconLeft={"📅"} // Example: Calendar icon for date
-            iconRight={error ? <span className="jules-validation-icon-error">✕</span> : (!error && touched[field.id] && formData[field.id] ? <span className="jules-validation-icon-success">✓</span> : undefined)}
+            iconLeft={<FontAwesomeIcon icon={faCalendarDays} aria-hidden="true" />}
+            iconRight={
+              error ? (
+                <span className="jules-validation-icon-error">
+                  <FontAwesomeIcon icon={faCircleXmark} aria-hidden="true" />
+                  <span className="sr-only">Error</span>
+                </span>
+              ) :
+              (!error && touched[field.id] && formData[field.id] ? (
+                <span className="jules-validation-icon-success">
+                  <FontAwesomeIcon icon={faCircleCheck} aria-hidden="true" />
+                  <span className="sr-only">Valid</span>
+                </span>
+              ) : undefined)
+            }
           />
         );
       case 'file':
@@ -528,7 +593,20 @@ export default function Step({
               onChange={(val) => handleChange(field.id, val)}
               error={error}
               // Icons for MaskedInput (like SSN) generally not needed unless for validation
-              iconRight={error ? <span className="jules-validation-icon-error">✕</span> : (!error && touched[field.id] && formData[field.id] ? <span className="jules-validation-icon-success">✓</span> : undefined)}
+              iconRight={
+                error ? (
+                  <span className="jules-validation-icon-error">
+                    <FontAwesomeIcon icon={faCircleXmark} aria-hidden="true" />
+                    <span className="sr-only">Error</span>
+                  </span>
+                ) :
+                (!error && touched[field.id] && formData[field.id] ? (
+                  <span className="jules-validation-icon-success">
+                    <FontAwesomeIcon icon={faCircleCheck} aria-hidden="true" />
+                    <span className="sr-only">Valid</span>
+                  </span>
+                ) : undefined)
+              }
             />
           );
         }
@@ -543,7 +621,20 @@ export default function Step({
               value={formData[field.id] || ''}
               onChange={(e) => handleChange(field.id, e.target.value)}
               error={error}
-              iconRight={error ? <span className="jules-validation-icon-error">✕</span> : (!error && touched[field.id] && formData[field.id] ? <span className="jules-validation-icon-success">✓</span> : undefined)}
+              iconRight={
+                error ? (
+                  <span className="jules-validation-icon-error">
+                    <FontAwesomeIcon icon={faCircleXmark} aria-hidden="true" />
+                    <span className="sr-only">Error</span>
+                  </span>
+                ) :
+                (!error && touched[field.id] && formData[field.id] ? (
+                  <span className="jules-validation-icon-success">
+                    <FontAwesomeIcon icon={faCircleCheck} aria-hidden="true" />
+                    <span className="sr-only">Valid</span>
+                  </span>
+                ) : undefined)
+              }
             />
         );
     }
@@ -643,7 +734,7 @@ export default function Step({
             size="small"
             className="jules-step-back-to-review"
             onClick={handleBackToReviewClick}
-            iconLeft="↩"
+            iconLeft={<FontAwesomeIcon icon={faReply} aria-hidden="true" />}
           >
             Back to Review step
           </Button>
@@ -742,25 +833,41 @@ export default function Step({
       })}
       <div className="jules-step-navigation">
         {!isFirst && (
-          <Button variant="secondary" onClick={handleBackClick} iconLeft="←">
+          <Button
+            variant="secondary"
+            onClick={handleBackClick}
+            iconLeft={<FontAwesomeIcon icon={faArrowLeft} aria-hidden="true" />}
+          >
             Back
           </Button>
         )}
         <Button
           variant="secondary"
           onClick={handleSaveDraftClick}
-          iconLeft="💾"
+          iconLeft={<FontAwesomeIcon icon={faFloppyDisk} aria-hidden="true" />}
           isLoading={isSavingDraft}
         >
           Save Draft
         </Button>
         {!isLast && (
-          <Button variant="primary" onClick={handleNextClick} iconRight="→">
+          <Button
+            variant="primary"
+            onClick={handleNextClick}
+            iconRight={<FontAwesomeIcon icon={faArrowRight} aria-hidden="true" />}
+          >
             Next
           </Button>
         )}
         {/* Assuming onNext handles final submission if isLast is true, or a dedicated submit handler would be passed. */}
-        {isLast && <Button variant="primary" onClick={handleNextClick} iconRight="✓">Submit</Button>}
+        {isLast && (
+          <Button
+            variant="primary"
+            onClick={handleNextClick}
+            iconRight={<FontAwesomeIcon icon={faCheck} aria-hidden="true" />}
+          >
+            Submit
+          </Button>
+        )}
       </div>
     </div>
   );

--- a/test-form/src/components/shared/GroupField/GroupField.jsx
+++ b/test-form/src/components/shared/GroupField/GroupField.jsx
@@ -7,6 +7,13 @@ import FileInput from '../FileInput/FileInput';
 import MaskedInput from '../MaskedInput/MaskedInput';
 import AddressAutocomplete from '../AddressAutocomplete';
 import Button from '../Button/Button'; // Import the new Button component
+import { FontAwesomeIcon } from '@fortawesome/react-fontawesome';
+import {
+  faPen,
+  faTrash,
+  faPlus,
+  faCheck,
+} from '@fortawesome/free-solid-svg-icons';
 import { evaluateCondition } from '../../../utils/formHelpers';
 
 export default function GroupField({ field, value = [], onChange, fullData = {} }) {
@@ -329,8 +336,22 @@ export default function GroupField({ field, value = [], onChange, fullData = {} 
                   </td>
                 ))}
                 <td className="jules-groupfield-actions">
-                  <Button variant="tertiary" size="small" onClick={() => handleEdit(idx)} iconLeft="✎">Edit</Button>
-                  <Button variant="destructive" size="small" onClick={() => handleDelete(idx)} iconLeft="🗑">Delete</Button>
+                  <Button
+                    variant="tertiary"
+                    size="small"
+                    onClick={() => handleEdit(idx)}
+                    iconLeft={<FontAwesomeIcon icon={faPen} aria-hidden="true" />}
+                  >
+                    Edit
+                  </Button>
+                  <Button
+                    variant="destructive"
+                    size="small"
+                    onClick={() => handleDelete(idx)}
+                    iconLeft={<FontAwesomeIcon icon={faTrash} aria-hidden="true" />}
+                  >
+                    Delete
+                  </Button>
                 </td>
               </tr>
             ))}
@@ -341,8 +362,8 @@ export default function GroupField({ field, value = [], onChange, fullData = {} 
         <Button
           variant="secondary"
           onClick={() => { setShowForm(true); setEditingIndex(null); setCurrentEntry({}); }}
-          iconLeft="＋"
-          style={{marginTop: entries.length > 0 ? 'var(--jules-space-md)' : '0'}}
+          iconLeft={<FontAwesomeIcon icon={faPlus} aria-hidden="true" />}
+          style={{ marginTop: entries.length > 0 ? 'var(--jules-space-md)' : '0' }}
         >
           Add {field.label}
         </Button>
@@ -352,7 +373,13 @@ export default function GroupField({ field, value = [], onChange, fullData = {} 
           <h3>{editingIndex !== null ? `Edit ${field.label}` : `Add New ${field.label}`}</h3>
           {field.fields.map(renderField)}
           <div className="jules-form-actions">
-            <Button variant="primary" onClick={handleSave} iconLeft="✓">Save</Button>
+            <Button
+              variant="primary"
+              onClick={handleSave}
+              iconLeft={<FontAwesomeIcon icon={faCheck} aria-hidden="true" />}
+            >
+              Save
+            </Button>
             <Button variant="secondary" onClick={handleCancel}>Cancel</Button>
           </div>
         </div>


### PR DESCRIPTION
## Summary
- replace text icons in Step and ReviewStep
- update ApplicationCard and GroupField to use FontAwesome icons
- add FontAwesome dependencies

## Testing
- `CI=true npm test --silent`

------
https://chatgpt.com/codex/tasks/task_e_68693d117f708331b2b4509bab7314e8