### PR TITLE
Replace red hex colors with tokens

### DIFF
--- a/test-form/src/jules_button.css
+++ b/test-form/src/jules_button.css
@@ -107,13 +107,13 @@
   border-color: var(--jules-error-red-500);
 }
 .jules-button-danger:hover {
-  background-color: #c92a2a; /* Darker red, if not in tokens, use a calculated value or add to tokens */
-  border-color: #c92a2a;
+  background-color: var(--jules-error-red-700); /* Darker red */
+  border-color: var(--jules-error-red-700);
   box-shadow: var(--jules-shadow-md);
 }
 .jules-button-danger:active {
-  background-color: #a61e1e; /* Even darker red */
-  border-color: #a61e1e;
+  background-color: var(--jules-error-red-900); /* Even darker red */
+  border-color: var(--jules-error-red-900);
 }
 
 /* Secondary Destructive Button */
@@ -124,14 +124,14 @@
 }
 .jules-button-danger-secondary:hover {
   background-color: var(--jules-primary-blue-50); /* error red light, e.g. --jules-error-red-50 */
-  border-color: #c92a2a;
-  color: #c92a2a;
+  border-color: var(--jules-error-red-700);
+  color: var(--jules-error-red-700);
   box-shadow: var(--jules-shadow-md);
 }
 .jules-button-danger-secondary:active {
   background-color: var(--jules-primary-blue-50); /* --jules-error-red-100 */
-  border-color: #a61e1e;
-  color: #a61e1e;
+  border-color: var(--jules-error-red-900);
+  color: var(--jules-error-red-900);
 }
 
 

--- a/test-form/src/jules_tokens.css
+++ b/test-form/src/jules_tokens.css
@@ -32,6 +32,8 @@
   --jules-success-green-500: #2f9e44;
   --jules-warning-yellow-500: #fcc419;
   --jules-error-red-500: #e03131;
+  --jules-error-red-700: #c92a2a;
+  --jules-error-red-900: #a61e1e;
   --jules-info-blue-500: var(--jules-primary-blue-500);
 
   /* Colors - Text */


### PR DESCRIPTION
## Summary
- add new red color shades to design tokens
- use the new tokens in button danger styles

## Testing
- `CI=true npm test --silent -- --watchAll=false`

------
https://chatgpt.com/codex/tasks/task_e_68694e71c5588331be3a4d715a6340c9