### PR TITLE
Improve stepper accessibility

### DIFF
--- a/test-form/src/components/core/Stepper/Stepper.jsx
+++ b/test-form/src/components/core/Stepper/Stepper.jsx
@@ -26,15 +26,28 @@ export default function Stepper({
 
   return (
     // The <aside> can be a generic container; the <ul> inside will be the actual stepper component
-    <aside className={isHorizontal ? 'jules-stepper-container-horizontal' : 'jules-stepper-container-vertical'}>
-      <h4>Steps</h4> {/* This h4 might need jules styling or be removed if stepper design incorporates title */}
-      <div className="jules-stepper-progress">
+    <aside
+      className={
+        isHorizontal
+          ? 'jules-stepper-container-horizontal'
+          : 'jules-stepper-container-vertical'
+      }
+    >
+      <h4>Steps</h4>{' '}
+      {/* This h4 might need jules styling or be removed if stepper design incorporates title */}
+      <div
+        className="jules-stepper-progress"
+        aria-label={`Step ${currentStep + 1} of ${steps.length}`}
+      >
         Step {currentStep + 1} of {steps.length}
       </div>
       <ul className={containerClass}> {/* Applied jules-stepper and orientation class to UL */}
         {steps.map((step, index) => {
           const isActive = index === currentStep;
           const isComplete = index < currentStep;
+
+          const isDisabled =
+            canNavigate && !canNavigate(index, true) && index !== currentStep;
 
           let itemClasses = 'jules-stepper-item';
           if (isActive) {
@@ -63,10 +76,14 @@ export default function Stepper({
               className={itemClasses}
               onClick={() => handleClick(index)}
               aria-current={isActive ? 'step' : undefined}
+              aria-disabled={isDisabled ? 'true' : undefined}
+              role="button"
+              tabIndex={isDisabled ? -1 : 0}
             >
               <div className="jules-stepper-item-content">
                 <span className="jules-stepper-icon">
-                  {isComplete ? '✓' : isActive ? '▶' : (index + 1)} {/* Display number for inactive steps */}
+                  {isComplete ? '✓' : isActive ? '▶' : index + 1}{' '}
+                  {/* Display number for inactive steps */}
                 </span>
                 <span className="jules-stepper-label">{step.title}</span>
               </div>

--- a/test-form/src/components/core/Stepper/Stepper.test.jsx
+++ b/test-form/src/components/core/Stepper/Stepper.test.jsx
@@ -18,3 +18,29 @@ test('calls onStepChange when step clicked', async () => {
   await user.click(screen.getByText('Two'));
   expect(onStepChange).toHaveBeenCalledWith(1);
 });
+
+test('renders accessible progress label', () => {
+  const steps = [
+    { id: 'one', title: 'One' },
+    { id: 'two', title: 'Two' },
+  ];
+  render(<Stepper steps={steps} currentStep={0} />);
+  const progress = screen.getByText('Step 1 of 2');
+  expect(progress).toHaveAttribute('aria-label', 'Step 1 of 2');
+});
+
+test('step buttons expose correct aria attributes', () => {
+  const steps = [
+    { id: 'one', title: 'One' },
+    { id: 'two', title: 'Two' },
+  ];
+  const canNavigate = (index) => index <= 0;
+  render(
+    <Stepper steps={steps} currentStep={0} canNavigate={canNavigate} />
+  );
+  const buttons = screen.getAllByRole('button');
+  expect(buttons[0]).toHaveAttribute('aria-current', 'step');
+  expect(buttons[0]).not.toHaveAttribute('aria-disabled');
+  expect(buttons[1]).toHaveAttribute('aria-disabled', 'true');
+  expect(buttons[1]).not.toHaveAttribute('aria-current');
+});


### PR DESCRIPTION
## Summary
- add `aria-label` for step progress
- mark step buttons with `aria-current` and `aria-disabled`
- verify accessibility attributes in tests

## Testing
- `CI=true npm test -- --watchAll=false`

------
https://chatgpt.com/codex/tasks/task_e_686956d9da5c83319c78534e9f9394df