### PR TITLE
Fix onChange value handling

### DIFF
--- a/test-form/src/components/core/Step/Step.jsx
+++ b/test-form/src/components/core/Step/Step.jsx
@@ -375,7 +375,14 @@ export default function Step({
           />
         );
       default:
-        return <Component {...commonProps} onChange={(e) => handleValueChange(e.target.value)} />;
+        return (
+          <Component
+            {...commonProps}
+            onChange={(val) =>
+              handleValueChange(val && val.target ? val.target.value : val)
+            }
+          />
+        );
     }
   };
 


### PR DESCRIPTION
## Summary
- handle `onChange` values that may not be events in `Step` component

## Testing
- `CI=true npx react-scripts test --watchAll=false --passWithNoTests --silent`


------
https://chatgpt.com/codex/tasks/task_e_68695af6f7388331beb0dba06f5ea7a4