### PR TITLE
Enable dark mode theme toggling

### DIFF
--- a/JULES_THEME_GUIDE.md
+++ b/JULES_THEME_GUIDE.md
@@ -84,3 +84,24 @@ A consistent spacing scale (e.g., 4px/8px base increments) is used for padding a
     *   Completed steps are marked (e.g., green checkmark).
 
 This theme aims to provide a highly usable, accessible, and visually appealing interface for users interacting with MyCity Services forms.
+
+## Theme Switching
+
+The design tokens support both light and dark themes. By default the light theme values are applied from the `:root` selector in `jules_tokens.css`. A `[data-theme='dark']` block overrides key color variables for dark mode.
+
+Set the desired theme on the root HTML element:
+
+```html
+<html data-theme="dark">
+```
+
+In React you can toggle this attribute dynamically:
+
+```js
+const toggle = () => {
+  const current = document.documentElement.getAttribute('data-theme');
+  document.documentElement.setAttribute('data-theme', current === 'dark' ? 'light' : 'dark');
+};
+```
+
+The sample `App.js` includes a button that switches between light and dark modes at runtime.

--- a/test-form/src/App.js
+++ b/test-form/src/App.js
@@ -1,4 +1,4 @@
-import { useState, useContext } from "react";
+import { useState, useContext, useEffect } from "react";
 import { Link, Routes, Route } from 'react-router-dom';
 import { AuthContext } from './context/AuthContext';
 import Profile from './pages/Profile';
@@ -25,8 +25,17 @@ function App() {
   const [page, setPage] = useState('dashboard');
   const [currentId, setCurrentId] = useState(null);
   const [currentService, setCurrentService] = useState('childcare');
+  const [theme, setTheme] = useState('light');
   const { user } = useContext(AuthContext);
   const server = process.env.REACT_APP_SERVER_URL || '';
+
+  useEffect(() => {
+    document.documentElement.setAttribute('data-theme', theme);
+  }, [theme]);
+
+  const toggleTheme = () => {
+    setTheme(theme === 'light' ? 'dark' : 'light');
+  };
 
   const startApplication = (serviceKey, id) => {
     setCurrentService(serviceKey);
@@ -83,6 +92,9 @@ function App() {
               )}
             </div>
           )}
+          <button type="button" onClick={toggleTheme} className="theme-toggle">
+            {theme === 'light' ? 'Dark Mode' : 'Light Mode'}
+          </button>
         </nav>
       </header>
 

--- a/test-form/src/jules_tokens.css
+++ b/test-form/src/jules_tokens.css
@@ -133,3 +133,24 @@
   --jules-z-index-popover: 1060;
   --jules-z-index-tooltip: 1070;
 }
+[data-theme='dark'] {
+  --jules-neutral-white: #000000;
+  --jules-neutral-gray-50: #1a1a1a;
+  --jules-neutral-gray-100: #222222;
+  --jules-neutral-gray-200: #2c2c2c;
+  --jules-neutral-gray-300: #444444;
+  --jules-neutral-gray-400: #555555;
+  --jules-neutral-gray-500: #888888;
+  --jules-neutral-gray-600: #aaaaaa;
+  --jules-neutral-gray-700: #cccccc;
+  --jules-neutral-gray-800: #dddddd;
+  --jules-neutral-gray-900: #ffffff;
+
+  --jules-text-color-body: var(--jules-neutral-gray-800);
+  --jules-text-color-headings: var(--jules-neutral-gray-900);
+  --jules-text-color-muted: var(--jules-neutral-gray-600);
+  --jules-text-color-link: var(--jules-primary-blue-300);
+  --jules-text-color-link-hover: var(--jules-primary-blue-50);
+  --jules-border-color: var(--jules-neutral-gray-300);
+  --jules-focus-ring-color: var(--jules-primary-blue-700);
+}


### PR DESCRIPTION
## Summary
- add `[data-theme='dark']` overrides to `jules_tokens.css`
- document theme switching in `JULES_THEME_GUIDE.md`
- update `App.js` with runtime dark mode toggle

## Testing
- `npx react-scripts test --watchAll=false --passWithNoTests --silent`

------
https://chatgpt.com/codex/tasks/task_e_68696336b380833199c75eb481f74e0d