### PR TITLE
Add toast notifications

### DIFF
--- a/test-form/src/components/core/FormRenderer/DycdFormRenderer.jsx
+++ b/test-form/src/components/core/FormRenderer/DycdFormRenderer.jsx
@@ -1,4 +1,5 @@
 import React, { useState, useEffect } from 'react';
+import { useToast } from '../../../context/ToastContext';
 import Step from '../Step/Step';
 import Stepper from '../Stepper/Stepper';
 import ReviewStep from '../ReviewStep/ReviewStep';
@@ -7,6 +8,7 @@ import { validateStep } from '../../../utils/formHelpers';
 import { getApplication, upsertApplication } from '../../../utils/appStorage';
 
 export default function DycdFormRenderer({ applicationId, onExit }) {
+  const { showToast } = useToast();
   const { form } = formSpec;
   const steps = form.steps || [];
   const [currentStep, setCurrentStep] = useState(0);
@@ -74,6 +76,7 @@ export default function DycdFormRenderer({ applicationId, onExit }) {
       currentStep,
       status: 'draft',
     });
+    showToast({ message: 'Draft saved', variant: 'success' });
     onExit && onExit();
   };
 

--- a/test-form/src/components/core/FormRenderer/FormRenderer.jsx
+++ b/test-form/src/components/core/FormRenderer/FormRenderer.jsx
@@ -1,4 +1,5 @@
 import React, { useState, useEffect, useRef } from 'react';
+import { useToast } from '../../../context/ToastContext';
 import Step from '../Step/Step';
 import Stepper from '../Stepper/Stepper';
 import ReviewStep from '../ReviewStep/ReviewStep';
@@ -7,6 +8,7 @@ import { validateStep } from '../../../utils/formHelpers';
 import { getApplication, upsertApplication } from '../../../utils/appStorage';
 
 export default function FormRenderer({ applicationId, onExit }) {
+  const { showToast } = useToast();
   const [formSpec, setFormSpec] = useState(null);
   const [isLoading, setIsLoading] = useState(true);
   const [error, setError] = useState(null);
@@ -124,6 +126,7 @@ export default function FormRenderer({ applicationId, onExit }) {
         currentStep,
         status: 'draft',
       });
+      showToast({ message: 'Draft saved', variant: 'success' });
     }
     setErrorSummary([]);
     onExit && onExit();

--- a/test-form/src/components/shared/Toast/Toast.jsx
+++ b/test-form/src/components/shared/Toast/Toast.jsx
@@ -1,0 +1,10 @@
+import React from 'react';
+
+export default function Toast({ message, variant = 'info' }) {
+  const classes = ['jules-toast', `jules-toast-${variant}`].join(' ');
+  return (
+    <div className={classes} role="status">
+      {message}
+    </div>
+  );
+}

--- a/test-form/src/components/shared/Toast/Toast.test.jsx
+++ b/test-form/src/components/shared/Toast/Toast.test.jsx
@@ -1,0 +1,30 @@
+import React from 'react';
+import { render, screen } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import '@testing-library/jest-dom';
+import { ToastProvider, useToast } from '../../../context/ToastContext';
+
+function Demo() {
+  const { showToast } = useToast();
+  return (
+    <button
+      onClick={() =>
+        showToast({ message: 'Saved', variant: 'success', duration: 1000 })
+      }
+    >
+      Trigger
+    </button>
+  );
+}
+
+test('renders toast when triggered', async () => {
+  const user = userEvent.setup();
+  render(
+    <ToastProvider>
+      <Demo />
+    </ToastProvider>
+  );
+  await user.click(screen.getByRole('button', { name: /trigger/i }));
+  const toast = await screen.findByRole('status');
+  expect(toast).toHaveTextContent('Saved');
+});

--- a/test-form/src/components/shared/Toast/index.js
+++ b/test-form/src/components/shared/Toast/index.js
@@ -1,0 +1,1 @@
+export { default } from './Toast';

--- a/test-form/src/context/ToastContext.jsx
+++ b/test-form/src/context/ToastContext.jsx
@@ -1,0 +1,29 @@
+import React, { createContext, useCallback, useContext, useState } from 'react';
+import Toast from '../components/shared/Toast';
+
+export const ToastContext = createContext({ showToast: () => {} });
+
+export function ToastProvider({ children }) {
+  const [toasts, setToasts] = useState([]);
+
+  const showToast = useCallback(({ message, variant = 'info', duration = 3000 }) => {
+    const id = crypto.randomUUID();
+    setToasts((prev) => [...prev, { id, message, variant }]);
+    setTimeout(() => {
+      setToasts((prev) => prev.filter((t) => t.id !== id));
+    }, duration);
+  }, []);
+
+  return (
+    <ToastContext.Provider value={{ showToast }}>
+      {children}
+      <div className="jules-toast-container" aria-live="polite" aria-atomic="true">
+        {toasts.map((t) => (
+          <Toast key={t.id} message={t.message} variant={t.variant} />
+        ))}
+      </div>
+    </ToastContext.Provider>
+  );
+}
+
+export const useToast = () => useContext(ToastContext);

--- a/test-form/src/index.js
+++ b/test-form/src/index.js
@@ -5,13 +5,16 @@ import './index.css';
 import App from './App';
 import reportWebVitals from './reportWebVitals';
 import { AuthProvider } from './context/AuthContext';
+import { ToastProvider } from './context/ToastContext';
 
 const root = ReactDOM.createRoot(document.getElementById('root'));
 root.render(
   <React.StrictMode>
     <BrowserRouter>
       <AuthProvider>
-        <App />
+        <ToastProvider>
+          <App />
+        </ToastProvider>
       </AuthProvider>
     </BrowserRouter>
   </React.StrictMode>

--- a/test-form/src/jules_misc.css
+++ b/test-form/src/jules_misc.css
@@ -507,3 +507,35 @@
 .jules-card-header .jules-card-title {
     margin-bottom: var(--jules-space-xxs); /* Reduce bottom margin if interaction name is below it */
 }
+
+/* --- Toasts --- */
+.jules-toast-container {
+  position: fixed;
+  top: var(--jules-space-lg);
+  right: var(--jules-space-lg);
+  display: flex;
+  flex-direction: column;
+  gap: var(--jules-space-sm);
+  z-index: 1100;
+}
+
+.jules-toast {
+  background-color: var(--jules-neutral-white);
+  border: var(--jules-border-width-sm) solid var(--jules-border-color);
+  border-radius: var(--jules-border-radius-md);
+  box-shadow: var(--jules-shadow-lg);
+  padding: var(--jules-space-md) var(--jules-space-lg);
+  min-width: 200px;
+}
+
+.jules-toast-success {
+  border-color: var(--jules-success-green-500);
+}
+
+.jules-toast-error {
+  border-color: var(--jules-error-red-500);
+}
+
+.jules-toast-info {
+  border-color: var(--jules-primary-blue-500);
+}


### PR DESCRIPTION
## Summary
- add a reusable Toast component
- implement ToastContext for showing notifications
- wire toast provider in the app
- trigger toast on Save Draft actions
- style toast elements in jules_misc.css
- test toast behavior

## Testing
- `npm install`
- `npm test --silent --no-color`

------
https://chatgpt.com/codex/tasks/task_e_68697cca781c833192ab26fd75f55222