### PR TITLE
Improve Stepper accessibility

### DIFF
--- a/test-form/src/components/core/Stepper/Stepper.jsx
+++ b/test-form/src/components/core/Stepper/Stepper.jsx
@@ -12,11 +12,11 @@ export default function Stepper({
   const isHorizontal = orientation === 'horizontal';
 
   const containerClass = `jules-stepper ${isHorizontal ? 'jules-stepper-horizontal' : 'jules-stepper-vertical'}`;
-  // The <ul> itself might not need a specific class if .jules-stepper directly styles its child ul or if the items are direct children.
+  // The list itself might not need a specific class if .jules-stepper directly styles its child ol or if the items are direct children.
   // Assuming .jules-stepper is the ul, or it directly styles the ul.
-  // For now, let's assume the containerClass is applied to the <aside> and the <ul> is part of its structure.
-  // jules_stepper.css was designed with .jules-stepper as the main list (ul) container.
-  // So, the <aside> might be a wrapper, and the <ul> inside gets the .jules-stepper classes.
+  // For now, let's assume the containerClass is applied to the <aside> and the <ol> is part of its structure.
+  // jules_stepper.css was designed with .jules-stepper as the main list container.
+  // So, the <aside> might be a wrapper, and the <ol> inside gets the .jules-stepper classes.
 
   const handleClick = (idx) => {
     if (idx === currentStep) return;
@@ -24,8 +24,20 @@ export default function Stepper({
     onStepChange && onStepChange(idx);
   };
 
+  const handleKeyDown = (e, idx) => {
+    if (e.key === 'ArrowRight' || e.key === 'ArrowDown') {
+      e.preventDefault();
+      const next = Math.min(idx + 1, steps.length - 1);
+      if (next !== idx) handleClick(next);
+    } else if (e.key === 'ArrowLeft' || e.key === 'ArrowUp') {
+      e.preventDefault();
+      const prev = Math.max(idx - 1, 0);
+      if (prev !== idx) handleClick(prev);
+    }
+  };
+
   return (
-    // The <aside> can be a generic container; the <ul> inside will be the actual stepper component
+    // The <aside> can be a generic container; the <ol> inside will be the actual stepper component
     <aside
       className={
         isHorizontal
@@ -41,7 +53,8 @@ export default function Stepper({
       >
         Step {currentStep + 1} of {steps.length}
       </div>
-      <ul className={containerClass}> {/* Applied jules-stepper and orientation class to UL */}
+      <nav aria-label="Stepper Navigation">
+        <ol className={containerClass} aria-orientation={orientation}> {/* Applied jules-stepper and orientation class to OL */}
         {steps.map((step, index) => {
           const isActive = index === currentStep;
           const isComplete = index < currentStep;
@@ -75,6 +88,7 @@ export default function Stepper({
               key={step.id}
               className={itemClasses}
               onClick={() => handleClick(index)}
+              onKeyDown={(e) => handleKeyDown(e, index)}
               aria-current={isActive ? 'step' : undefined}
               aria-disabled={isDisabled ? 'true' : undefined}
               role="button"
@@ -90,7 +104,8 @@ export default function Stepper({
             </li>
           );
         })}
-      </ul>
+        </ol>
+      </nav>
       {requiredDocs.length > 0 && (
         <div className="jules-stepper-required-docs">
           {/* The h5 should pick up styles from jules_base.css or could be jules-text-color-headings */}

--- a/test-form/src/components/core/Stepper/Stepper.test.jsx
+++ b/test-form/src/components/core/Stepper/Stepper.test.jsx
@@ -44,3 +44,30 @@ test('step buttons expose correct aria attributes', () => {
   expect(buttons[1]).toHaveAttribute('aria-disabled', 'true');
   expect(buttons[1]).not.toHaveAttribute('aria-current');
 });
+
+test('sets aria-orientation on the list', () => {
+  const steps = [
+    { id: 'one', title: 'One' },
+    { id: 'two', title: 'Two' },
+  ];
+  render(<Stepper steps={steps} currentStep={0} orientation="horizontal" />);
+  const list = screen.getByRole('list');
+  expect(list).toHaveAttribute('aria-orientation', 'horizontal');
+});
+
+test('allows arrow key navigation', async () => {
+  const user = userEvent.setup();
+  const onStepChange = jest.fn();
+  const steps = [
+    { id: 'one', title: 'One' },
+    { id: 'two', title: 'Two' },
+    { id: 'three', title: 'Three' },
+  ];
+  render(
+    <Stepper steps={steps} currentStep={1} onStepChange={onStepChange} />
+  );
+  const buttons = screen.getAllByRole('button');
+  buttons[1].focus();
+  await user.keyboard('{ArrowRight}');
+  expect(onStepChange).toHaveBeenCalledWith(2);
+});


### PR DESCRIPTION
## Summary
- convert Stepper list to `<nav>` with an `<ol>` and aria orientation
- add keyboard arrow navigation between steps
- test keyboard navigation and aria-orientation

## Testing
- `npx react-scripts test src/components/core/Stepper/Stepper.test.jsx --watchAll=false`

------
https://chatgpt.com/codex/tasks/task_e_6869803b3bbc8331b4156d4752ecb60c