### PR TITLE
Add prefers-reduced-motion support

### DIFF
--- a/test-form/src/jules_misc.css
+++ b/test-form/src/jules_misc.css
@@ -1,5 +1,14 @@
 @import './jules_tokens.css';
 
+/* Disable transitions when the user prefers reduced motion */
+@media (prefers-reduced-motion: reduce) {
+  :root {
+    --jules-transition-duration-fast: 0ms;
+    --jules-transition-duration-base: 0ms;
+    --jules-transition-duration-slow: 0ms;
+  }
+}
+
 /* --- Tooltips --- */
 .jules-tooltip-wrapper {
   display: inline-flex; /* Align icon with text nicely */


### PR DESCRIPTION
## Summary
- add a global rule disabling transition durations under `prefers-reduced-motion`

## Testing
- `npm test --silent`

------
https://chatgpt.com/codex/tasks/task_e_686984a12ee483319be77fb7c541ebef