### PR TITLE
Improve HelpChat UX

### DIFF
--- a/README.md
+++ b/README.md
@@ -97,6 +97,10 @@ Form pages include a "Need Help?" button that opens a small chat window. Message
 
 The chat endpoint now sends the current step's field info and any validation errors to the AI service. Replies include up to three suggested follow-up questions shown as clickable chips.
 
+The Help Chat window uses the `jules_` design system. Messages now appear in modern
+speech bubbles with clear distinction between user and assistant responses and
+accessible colors.
+
 Chat conversations are ephemeral and are **not** stored on the server. Responses may be inaccurate, so do not share personal or sensitive information.
 
 ## Docker build

--- a/test-form/src/jules_misc.css
+++ b/test-form/src/jules_misc.css
@@ -599,30 +599,46 @@
 }
 
 .jules-helpchat-disclaimer {
-  font-size: var(--jules-font-size-sm);
+  font-size: var(--jules-font-size-xs);
   color: var(--jules-text-color-muted);
+  text-align: center;
 }
 
 .jules-helpchat-conversation {
   border: var(--jules-border-width-sm) solid var(--jules-border-color);
-  border-radius: var(--jules-border-radius-md);
+  border-radius: var(--jules-border-radius-lg);
   padding: var(--jules-space-md);
+  background-color: var(--jules-neutral-white);
+  box-shadow: var(--jules-shadow-sm);
   max-height: 300px;
   overflow-y: auto;
+  display: flex;
+  flex-direction: column;
+  gap: var(--jules-space-sm);
 }
 
 .jules-helpchat-message {
-  margin-bottom: var(--jules-space-sm);
+  margin-bottom: var(--jules-space-xs);
+  max-width: 80%;
+  padding: var(--jules-space-xs) var(--jules-space-sm);
+  border-radius: var(--jules-border-radius-lg);
+  box-shadow: var(--jules-shadow-xs);
+  white-space: pre-line;
+  word-wrap: break-word;
 }
 
 .jules-helpchat-user {
-  text-align: right;
-  color: var(--jules-text-color-body);
+  align-self: flex-end;
+  text-align: left;
+  background-color: var(--jules-primary-blue-500);
+  color: var(--jules-text-color-on-primary);
 }
 
 .jules-helpchat-assistant {
+  align-self: flex-start;
   text-align: left;
-  color: var(--jules-text-color-muted);
+  background-color: var(--jules-neutral-gray-200);
+  color: var(--jules-text-color-body);
 }
 
 .jules-helpchat-input-row {
@@ -648,13 +664,16 @@
   background-color: var(--jules-primary-blue-50);
   border: var(--jules-border-width-sm) solid var(--jules-primary-blue-300);
   border-radius: var(--jules-border-radius-xl);
-  padding: 2px 10px;
+  padding: 2px 12px;
   font-size: var(--jules-font-size-sm);
   color: var(--jules-primary-blue-700);
   cursor: pointer;
+  box-shadow: var(--jules-shadow-xs);
   transition: background-color var(--jules-transition-duration-fast)
       var(--jules-transition-timing-function),
     border-color var(--jules-transition-duration-fast)
+      var(--jules-transition-timing-function),
+    box-shadow var(--jules-transition-duration-fast)
       var(--jules-transition-timing-function);
 }
 
@@ -662,6 +681,7 @@
   background-color: var(--jules-primary-blue-100);
   border-color: var(--jules-primary-blue-500);
   color: var(--jules-primary-blue-900);
+  box-shadow: var(--jules-shadow-sm);
 }
 
 .jules-helpchat-chip:focus-visible {


### PR DESCRIPTION
## Summary
- restyle HelpChat with message bubbles using the jules theme
- document the polished Help Chat look in README

## Testing
- `npm install --silent` *(fails: react-scripts not found)*
- `npm test --silent` *(fails: react-scripts not found)*

------
https://chatgpt.com/codex/tasks/task_e_6869aa8837f883319c5b9016a85549f2