### PR TITLE
Update FormPage spec path handling

### DIFF
--- a/test-form/src/pages/FormPage.jsx
+++ b/test-form/src/pages/FormPage.jsx
@@ -1,9 +1,13 @@
 import React from 'react';
 import FormRenderer from '../components/core/FormRenderer/FormRenderer';
-import DycdFormRenderer from '../components/core/FormRenderer/DycdFormRenderer';
+
 export default function FormPage({ applicationId, service = 'childcare', onExit }) {
-  if (service === 'dycd') {
-    return <DycdFormRenderer applicationId={applicationId} onExit={onExit} />;
-  }
-  return <FormRenderer applicationId={applicationId} onExit={onExit} />;
+  const path = service === 'dycd' ? '/data/dycd_form.json' : '/data/childcare_form.json';
+  return (
+    <FormRenderer
+      applicationId={applicationId}
+      onExit={onExit}
+      formSpecPath={path}
+    />
+  );
 }

--- a/test-form/src/pages/FormPage.test.jsx
+++ b/test-form/src/pages/FormPage.test.jsx
@@ -1,16 +1,22 @@
 import React from 'react';
 import { render, screen } from '@testing-library/react';
 import FormPage from './FormPage';
+import FormRenderer from '../components/core/FormRenderer/FormRenderer';
 
-jest.mock('../components/core/FormRenderer/FormRenderer', () => () => <div>Default Form</div>);
-jest.mock('../components/core/FormRenderer/DycdFormRenderer', () => () => <div>DYCD Form</div>);
+jest.mock('../components/core/FormRenderer/FormRenderer', () => jest.fn(() => <div>Rendered</div>));
 
-test('renders DYCD renderer when service is dycd', () => {
-  render(<FormPage service="dycd" />);
-  expect(screen.getByText('DYCD Form')).toBeInTheDocument();
+beforeEach(() => {
+  FormRenderer.mockClear();
 });
 
-test('renders default renderer when service is childcare', () => {
+test('passes DYCD form path when service is dycd', () => {
+  render(<FormPage service="dycd" />);
+  expect(FormRenderer.mock.calls[0][0].formSpecPath).toBe('/data/dycd_form.json');
+});
+
+test('passes childcare form path when service is childcare', () => {
   render(<FormPage service="childcare" />);
-  expect(screen.getByText('Default Form')).toBeInTheDocument();
+  expect(FormRenderer.mock.calls[0][0].formSpecPath).toBe(
+    '/data/childcare_form.json',
+  );
 });


### PR DESCRIPTION
## Summary
- remove unused DycdFormRenderer from `FormPage`
- choose spec path based on service prop and pass to `FormRenderer`
- update FormPage tests to verify passed spec path

## Testing
- `CI=true npm test --silent -- src/pages/FormPage.test.jsx`
- `CI=true npm test --silent`

------
https://chatgpt.com/codex/tasks/task_e_6869ea3083f88331b241812e7633b947