### PR TITLE
Update tests for unified FormRenderer

### DIFF
--- a/test-form/src/__tests__/ChildcareFormNavigation.test.js
+++ b/test-form/src/__tests__/ChildcareFormNavigation.test.js
@@ -3,6 +3,8 @@ import userEvent from '@testing-library/user-event';
 import FormRenderer from '../components/core/FormRenderer/FormRenderer';
 import formSpec from '../../public/data/childcare_form.json';
 
+const formSpecPath = '/data/childcare_form.json';
+
 // Mock markdown rendering used in InfoSection/Step components
 jest.mock('react-markdown', () => ({ children }) => <div>{children}</div>);
 jest.mock('remark-gfm', () => ({}));
@@ -12,23 +14,26 @@ beforeAll(() => {
 });
 
 beforeEach(() => {
-  global.fetch = jest.fn(() =>
-    Promise.resolve({ ok: true, json: () => Promise.resolve(formSpec) })
-  );
+  global.fetch = jest.fn((url) => {
+    if (url === formSpecPath) {
+      return Promise.resolve({ ok: true, json: () => Promise.resolve(formSpec) });
+    }
+    return Promise.reject(new Error(`Unexpected fetch URL: ${url}`));
+  });
 });
 
 describe('Childcare form navigation', () => {
   const steps = formSpec.form.steps || [];
 
   test('renders first step by default', async () => {
-    render(<FormRenderer />);
+    render(<FormRenderer formSpecPath={formSpecPath} />);
     const heading = await screen.findByRole('heading', { level: 2, name: steps[0].title });
     expect(heading).toBeInTheDocument();
   });
 
   test('navigates to second step', async () => {
       const user = userEvent.setup();
-      render(<FormRenderer />);
+      render(<FormRenderer formSpecPath={formSpecPath} />);
       const btn = await screen.findByRole('button', { name: /next/i });
       await user.click(btn);
       expect(

--- a/test-form/src/components/core/FormRenderer/FormRenderer.test.jsx
+++ b/test-form/src/components/core/FormRenderer/FormRenderer.test.jsx
@@ -3,6 +3,8 @@ import { render, screen } from '@testing-library/react';
 import FormRenderer from './FormRenderer';
 import formSpec from '../../../../public/data/childcare_form.json';
 
+const formSpecPath = '/data/childcare_form.json';
+
 jest.mock('react-markdown', () => ({ children }) => <div>{children}</div>);
 
 beforeAll(() => {
@@ -23,18 +25,21 @@ beforeEach(() => {
         json: () => Promise.resolve({ id: '1', current_step: reviewIndex }),
       });
     }
-    return Promise.resolve({ ok: true, json: () => Promise.resolve(formSpec) });
+    if (url === formSpecPath) {
+      return Promise.resolve({ ok: true, json: () => Promise.resolve(formSpec) });
+    }
+    return Promise.reject(new Error(`Unexpected fetch URL: ${url}`));
   });
 });
 
 test('renders form title', async () => {
-  render(<FormRenderer />);
+  render(<FormRenderer formSpecPath={formSpecPath} />);
   expect(
     await screen.findByRole('heading', { level: 1, name: /Childcare Voucher Application/i })
   ).toBeInTheDocument();
 });
 
 test('renders review step when currentStep is review', async () => {
-  render(<FormRenderer applicationId="1" />);
+  render(<FormRenderer applicationId="1" formSpecPath={formSpecPath} />);
   expect(await screen.findByRole('heading', { name: /review & submit/i })).toBeInTheDocument();
 });

--- a/test-form/src/pages/FormPage.test.jsx
+++ b/test-form/src/pages/FormPage.test.jsx
@@ -1,5 +1,5 @@
 import React from 'react';
-import { render, screen } from '@testing-library/react';
+import { render } from '@testing-library/react';
 import FormPage from './FormPage';
 import FormRenderer from '../components/core/FormRenderer/FormRenderer';
 
@@ -9,14 +9,18 @@ beforeEach(() => {
   FormRenderer.mockClear();
 });
 
-test('passes DYCD form path when service is dycd', () => {
+test('uses FormRenderer for dycd service', () => {
   render(<FormPage service="dycd" />);
-  expect(FormRenderer.mock.calls[0][0].formSpecPath).toBe('/data/dycd_form.json');
+  expect(FormRenderer).toHaveBeenCalledWith(
+    expect.objectContaining({ formSpecPath: '/data/dycd_form.json' }),
+    undefined,
+  );
 });
 
-test('passes childcare form path when service is childcare', () => {
+test('uses FormRenderer for childcare service', () => {
   render(<FormPage service="childcare" />);
-  expect(FormRenderer.mock.calls[0][0].formSpecPath).toBe(
-    '/data/childcare_form.json',
+  expect(FormRenderer).toHaveBeenCalledWith(
+    expect.objectContaining({ formSpecPath: '/data/childcare_form.json' }),
+    undefined,
   );
 });


### PR DESCRIPTION
## Summary
- update FormRenderer.test to mock fetch URL via `formSpecPath`
- ensure ChildcareFormNavigation.test mocks the form spec URL
- check FormRenderer usage for both services in FormPage.test

## Testing
- `CI=true npm test --silent` *(fails: PASS lines observed but full summary truncated)*

------
https://chatgpt.com/codex/tasks/task_e_6869f1dc86e88331bb5ac845b612905f