### PR TITLE
Add DOHMH service and form

### DIFF
--- a/test-form/public/data/group_cc_permit.json
+++ b/test-form/public/data/group_cc_permit.json
@@ -1,0 +1,14 @@
+{
+  "form": {
+    "title": "Group Child Care Permit Application",
+    "description": "Application for obtaining a group child care permit",
+    "layout": { "stepperPosition": "left" },
+    "steps": [
+      {
+        "id": "info",
+        "title": "Information",
+        "sections": []
+      }
+    ]
+  }
+}

--- a/test-form/src/pages/Dashboard.jsx
+++ b/test-form/src/pages/Dashboard.jsx
@@ -13,6 +13,10 @@ const SERVICE_INFO = {
     name: 'DYCD Youth Services Intake – Ages 13 and Younger',
     interaction: 'Youth Services Intake',
   },
+  DOHMH: {
+    name: 'Group Child Care Permit',
+    interaction: 'Group Child Care Permit Application',
+  },
 };
 
 export default function Dashboard({ onStart }) {
@@ -71,6 +75,12 @@ export default function Dashboard({ onStart }) {
           interaction="Youth Services Intake"
           description="Form to collect youth and guardian information for DYCD programs"
           onStart={() => createNew('dycd')}
+        />
+        <ServiceCard
+          name="Group Child Care Permit"
+          interaction="Group Child Care Permit Application"
+          description="Application for Group Child Care Permit"
+          onStart={() => createNew('DOHMH')}
         />
       </div>
 

--- a/test-form/src/pages/FormPage.jsx
+++ b/test-form/src/pages/FormPage.jsx
@@ -2,7 +2,12 @@ import React from 'react';
 import FormRenderer from '../components/core/FormRenderer/FormRenderer';
 
 export default function FormPage({ applicationId, service = 'childcare', onExit }) {
-  const path = service === 'dycd' ? '/data/dycd_form.json' : '/data/childcare_form.json';
+  let path = '/data/childcare_form.json';
+  if (service === 'dycd') {
+    path = '/data/dycd_form.json';
+  } else if (service === 'DOHMH') {
+    path = '/data/group_cc_permit.json';
+  }
   return (
     <FormRenderer
       applicationId={applicationId}

--- a/test-form/src/pages/FormPage.test.jsx
+++ b/test-form/src/pages/FormPage.test.jsx
@@ -24,3 +24,11 @@ test('uses FormRenderer for childcare service', () => {
     undefined,
   );
 });
+
+test('uses FormRenderer for DOHMH service', () => {
+  render(<FormPage service="DOHMH" />);
+  expect(FormRenderer).toHaveBeenCalledWith(
+    expect.objectContaining({ formSpecPath: '/data/group_cc_permit.json' }),
+    undefined,
+  );
+});


### PR DESCRIPTION
## Summary
- add placeholder group_cc_permit.json form spec
- extend Dashboard service catalog with DOHMH service
- load the DOHMH form in FormPage
- test FormPage for the new service

## Testing
- `CI=true npm test -- --watchAll=false --silent`
- `npm run test-server`

------
https://chatgpt.com/codex/tasks/task_e_6869fc4be2748331ab9d1c1f60f9f1f4