### PR TITLE
Add step.sections checks in helpers

### DIFF
--- a/test-form/src/utils/formHelpers.js
+++ b/test-form/src/utils/formHelpers.js
@@ -24,7 +24,7 @@ export function evaluateCondition(condition, data) {
 
 export function cleanupHiddenFields(step, formData) {
   const cleaned = { ...formData };
-  if (!step) return cleaned;
+  if (!step || !Array.isArray(step.sections)) return cleaned;
 
   step.sections.forEach((section) => {
     const sectionVisible = section.visibilityCondition
@@ -165,6 +165,10 @@ export function validateStep(step, formData, formErrors = {}, touched = {}) {
   let valid = true;
   let updatedErrors = { ...formErrors };
   let updatedTouched = { ...touched };
+
+  if (!step || !Array.isArray(step.sections)) {
+    return { valid: true, errors: { ...formErrors }, touched: { ...touched } };
+  }
 
   step.sections.forEach((section) => {
     if (section.required) {


### PR DESCRIPTION
## Summary
- avoid errors when helpers get steps with no sections
- short-circuit validation if step sections missing

## Testing
- `npm test` *(fails: process did not complete due to environment limitations)*

------
https://chatgpt.com/codex/tasks/task_e_686a03c15fd0833185e0ebb3d2551f3e