### PR TITLE
Improve civic theme switching

### DIFF
--- a/test-form/src/App.js
+++ b/test-form/src/App.js
@@ -5,6 +5,7 @@ import Profile from './pages/Profile';
 // import "./form.css"; // Old theme - commented out
 import FormPage from "./pages/FormPage";
 import Dashboard from "./pages/Dashboard";
+import ThemeSettings from './components/shared/ThemeSettings';
 import './App.css'; // App specific styles, kept for now
 
 // Jules Theme CSS Files
@@ -25,16 +26,40 @@ function App() {
   const [page, setPage] = useState('dashboard');
   const [currentId, setCurrentId] = useState(null);
   const [currentService, setCurrentService] = useState('childcare');
-  const [theme, setTheme] = useState('light');
+  const [theme, setTheme] = useState('system');
+  const [themeModalOpen, setThemeModalOpen] = useState(false);
   const { user } = useContext(AuthContext);
   const server = process.env.REACT_APP_SERVER_URL || '';
 
   useEffect(() => {
+    const applySystemTheme = () => {
+      const prefersDark = window.matchMedia('(prefers-color-scheme: dark)').matches;
+      document.documentElement.setAttribute('data-theme', prefersDark ? 'dark' : 'light');
+    };
+
+    if (theme === 'system') {
+      applySystemTheme();
+      const mq = window.matchMedia('(prefers-color-scheme: dark)');
+      mq.addEventListener('change', applySystemTheme);
+      return () => mq.removeEventListener('change', applySystemTheme);
+    }
     document.documentElement.setAttribute('data-theme', theme);
   }, [theme]);
 
-  const toggleTheme = () => {
-    setTheme(theme === 'light' ? 'dark' : 'light');
+  useEffect(() => {
+    const saved = localStorage.getItem('themePreference');
+    if (saved) {
+      setTheme(saved);
+    }
+  }, []);
+
+  const handleThemeChange = (value) => {
+    setTheme(value);
+    if (value === 'system') {
+      localStorage.removeItem('themePreference');
+    } else {
+      localStorage.setItem('themePreference', value);
+    }
   };
 
   const startApplication = (serviceKey, id) => {
@@ -94,13 +119,19 @@ function App() {
           )}
           <button
             type="button"
-            onClick={toggleTheme}
+            onClick={() => setThemeModalOpen(true)}
             className="theme-toggle"
           >
-            {theme === 'light' ? 'Dark Mode' : 'Light Mode'}
+            Day/Night View
           </button>
         </nav>
       </header>
+      <ThemeSettings
+        isOpen={themeModalOpen}
+        onClose={() => setThemeModalOpen(false)}
+        value={theme}
+        onChange={handleThemeChange}
+      />
 
       <main className="form-main">
         <Routes>

--- a/test-form/src/components/shared/ThemeSettings/ThemeSettings.jsx
+++ b/test-form/src/components/shared/ThemeSettings/ThemeSettings.jsx
@@ -1,0 +1,39 @@
+import React, { useEffect, useState } from 'react';
+import Modal from '../Modal/Modal';
+import RadioGroup from '../RadioGroup/RadioGroup';
+import Button from '../Button/Button';
+
+export default function ThemeSettings({ isOpen, onClose, value = 'system', onChange }) {
+  const [selected, setSelected] = useState(value);
+
+  useEffect(() => {
+    setSelected(value);
+  }, [value]);
+
+  const handleSave = () => {
+    onChange(selected);
+    onClose();
+  };
+
+  const footer = (
+    <>
+      <Button variant="secondary" onClick={onClose}>Cancel</Button>
+      <Button onClick={handleSave}>Save</Button>
+    </>
+  );
+
+  return (
+    <Modal isOpen={isOpen} onClose={onClose} title="Visual Theme" footerContent={footer}>
+      <RadioGroup
+        id="theme-select"
+        options={[
+          { value: 'light', label: '☀️ Light Mode' },
+          { value: 'dark', label: '🌙 Dark Mode' },
+          { value: 'system', label: '🖥️ Follow Device Setting' },
+        ]}
+        value={selected}
+        onChange={(e) => setSelected(e.target.value)}
+      />
+    </Modal>
+  );
+}

--- a/test-form/src/components/shared/ThemeSettings/index.js
+++ b/test-form/src/components/shared/ThemeSettings/index.js
@@ -1,0 +1,1 @@
+export { default } from './ThemeSettings';


### PR DESCRIPTION
## Summary
- add new ThemeSettings modal with Light, Dark, and System options
- update App to open ThemeSettings from a "Day/Night View" button
- persist theme choice in localStorage and respect system preferences

## Testing
- `npm test` *(fails: npm not installed)*

------
https://chatgpt.com/codex/tasks/task_e_686b0a9847c08331a49d95b3123eef61