### PR TITLE
Improve mobile table layout for group fields

### DIFF
--- a/test-form/src/components/shared/GroupField/GroupField.jsx
+++ b/test-form/src/components/shared/GroupField/GroupField.jsx
@@ -336,10 +336,10 @@ export default function GroupField({ field, value = [], onChange, fullData = {} 
             </tr>
           </thead>
           <tbody>
-            {entries.map((item, idx) => (
+              {entries.map((item, idx) => (
               <tr key={idx}>
                 {field.fields.map((f) => (
-                  <td key={f.id}>
+                  <td key={f.id} data-label={f.label}>
                     {Array.isArray(item[f.id]) ? item[f.id].join(', ') : item[f.id]}
                   </td>
                 ))}

--- a/test-form/src/jules_groupfield.css
+++ b/test-form/src/jules_groupfield.css
@@ -124,3 +124,36 @@
   margin-bottom: var(--jules-space-md);
   font-size: var(--jules-font-size-md);
 }
+
+/* Responsive table layout for small screens */
+@media (max-width: 600px) {
+  .jules-groupfield-table thead {
+    display: none;
+  }
+  .jules-groupfield-table,
+  .jules-groupfield-table tbody,
+  .jules-groupfield-table tr,
+  .jules-groupfield-table td {
+    display: block;
+    width: 100%;
+  }
+  .jules-groupfield-table tr {
+    margin-bottom: var(--jules-space-md);
+    border-bottom: var(--jules-border-width-sm) solid var(--jules-border-color);
+  }
+  .jules-groupfield-table td {
+    text-align: left;
+    padding-left: calc(var(--jules-space-lg) + var(--jules-space-sm));
+    position: relative;
+  }
+  .jules-groupfield-table td::before {
+    content: attr(data-label);
+    position: absolute;
+    left: var(--jules-space-sm);
+    font-weight: var(--jules-font-weight-semibold);
+    text-transform: uppercase;
+  }
+  .jules-groupfield-actions {
+    justify-content: flex-start;
+  }
+}

--- a/test-form/src/setupTests.js
+++ b/test-form/src/setupTests.js
@@ -16,3 +16,17 @@ if (!global.crypto) {
 } else if (!global.crypto.randomUUID) {
   global.crypto.randomUUID = () => 'test-id';
 }
+
+// jsdom does not implement matchMedia; provide a stub used in components
+if (!window.matchMedia) {
+  window.matchMedia = jest.fn().mockImplementation((query) => ({
+    matches: false,
+    media: query,
+    onchange: null,
+    addListener: jest.fn(),
+    removeListener: jest.fn(),
+    addEventListener: jest.fn(),
+    removeEventListener: jest.fn(),
+    dispatchEvent: jest.fn(),
+  }));
+}


### PR DESCRIPTION
## Summary
- add responsive styles for GroupField tables
- expose column labels in table cells for mobile
- stub `matchMedia` in Jest setup for tests

## Testing
- `npm test --silent --prefix test-form -- --watchAll=false` *(fails: Cannot read properties of undefined (reading 'matches'))*

------
https://chatgpt.com/codex/tasks/task_e_686b0ce18bf08331925e824c8c6c7031