### PR TITLE
Respect tableColumns metadata for GroupField

### DIFF
--- a/test-form/src/components/shared/GroupField/GroupField.jsx
+++ b/test-form/src/components/shared/GroupField/GroupField.jsx
@@ -322,6 +322,13 @@ export default function GroupField({ field, value = [], onChange, fullData = {} 
     }
   };
 
+  const tableColumnIds = field.metadata?.tableColumns;
+  const tableFields = tableColumnIds
+    ? tableColumnIds
+        .map((id) => field.fields.find((f) => f.id === id))
+        .filter(Boolean)
+    : field.fields;
+
   return (
     <div className="jules-groupfield">
       <h3 className="jules-groupfield-title">{field.label}</h3> {/* Changed h4 to h3 and added class */}
@@ -329,16 +336,16 @@ export default function GroupField({ field, value = [], onChange, fullData = {} 
         <table className="jules-groupfield-table">
           <thead>
             <tr>
-              {field.fields.map((f) => (
+              {tableFields.map((f) => (
                 <th key={f.id}>{f.label}</th>
               ))}
               <th>Actions</th>
             </tr>
           </thead>
           <tbody>
-              {entries.map((item, idx) => (
+            {entries.map((item, idx) => (
               <tr key={idx}>
-                {field.fields.map((f) => (
+                {tableFields.map((f) => (
                   <td key={f.id} data-label={f.label}>
                     {Array.isArray(item[f.id]) ? item[f.id].join(', ') : item[f.id]}
                   </td>

--- a/test-form/src/components/shared/GroupField/GroupField.test.js
+++ b/test-form/src/components/shared/GroupField/GroupField.test.js
@@ -57,4 +57,21 @@ describe('GroupField component', () => {
     expect(handleChange).not.toHaveBeenCalled();
     expect(screen.getByText('Name is required.')).toBeInTheDocument();
   });
+
+  test('only displays fields listed in metadata.tableColumns', () => {
+    const fieldWithColumns = {
+      ...field,
+      metadata: { tableColumns: ['name'] },
+    };
+    const value = [{ name: 'John', age: '4' }];
+    render(<GroupField field={fieldWithColumns} value={value} onChange={() => {}} />);
+
+    // Header should only show "Name"
+    expect(screen.getByRole('columnheader', { name: 'Name' })).toBeInTheDocument();
+    expect(screen.queryByRole('columnheader', { name: 'Age' })).not.toBeInTheDocument();
+
+    // Row should only include the name value
+    expect(screen.getByText('John')).toBeInTheDocument();
+    expect(screen.queryByText('4')).not.toBeInTheDocument();
+  });
 });


### PR DESCRIPTION
## Summary
- respect `metadata.tableColumns` when displaying group entry tables
- test displaying only selected table columns

## Testing
- `CI=true npm test --silent` *(fails: some tests error due to missing `matchMedia`)*

------
https://chatgpt.com/codex/tasks/task_e_686b1b30c5688331841ba2212065aedc