### PR TITLE
Fix missing icons in table actions

### DIFF
--- a/test-form/src/components/ApplicationCard.jsx
+++ b/test-form/src/components/ApplicationCard.jsx
@@ -59,7 +59,7 @@ export default function ApplicationCard({
           Continue
         </Button>
         <Button
-          variant="destructive"
+          variant="danger"
           size="small"
           onClick={() => onDelete && onDelete(id)}
           iconLeft={<FontAwesomeIcon icon={faTrash} aria-hidden="true" />}

--- a/test-form/src/components/shared/GroupField/GroupField.jsx
+++ b/test-form/src/components/shared/GroupField/GroupField.jsx
@@ -360,7 +360,7 @@ export default function GroupField({ field, value = [], onChange, fullData = {} 
                     Edit
                   </Button>
                   <Button
-                    variant="destructive"
+                    variant="danger"
                     size="small"
                     onClick={() => handleDelete(idx)}
                     iconLeft={<FontAwesomeIcon icon={faTrash} aria-hidden="true" />}

--- a/test-form/src/index.js
+++ b/test-form/src/index.js
@@ -4,6 +4,9 @@ import { BrowserRouter } from 'react-router-dom';
 import './index.css';
 import App from './App';
 import reportWebVitals from './reportWebVitals';
+import { config } from '@fortawesome/fontawesome-svg-core';
+import '@fortawesome/fontawesome-svg-core/styles.css';
+config.autoAddCss = false;
 import { AuthProvider } from './context/AuthContext';
 import { ToastProvider } from './context/ToastContext';
 


### PR DESCRIPTION
## Summary
- ensure FontAwesome CSS is loaded
- use `danger` variant for delete buttons so styles apply

## Testing
- `npm test --silent -- --watchAll=false` *(fails: react-scripts not found or other errors)*

------
https://chatgpt.com/codex/tasks/task_e_686b2178d40483318eb9000365423b57