### PR TITLE
Fix requiredCondition evaluation for repeating groups

### DIFF
--- a/test-form/src/components/core/Step/Step.jsx
+++ b/test-form/src/components/core/Step/Step.jsx
@@ -234,16 +234,12 @@ export default function Step({
 
   const renderField = (field) => {
     const conditionToCheck =
-      field.visibilityCondition ??
-      (field.requiredCondition?.condition || field.requiredCondition);
+      field.visibilityCondition ?? field.requiredCondition;
     const visible = conditionToCheck
       ? evaluateCondition(conditionToCheck, fullData)
       : true;
     const isRequired = field.requiredCondition
-      ? evaluateCondition(
-          field.requiredCondition.condition || field.requiredCondition,
-          fullData
-        )
+      ? evaluateCondition(field.requiredCondition, fullData)
       : field.required;
 
     if (!visible) return null;
@@ -393,15 +389,8 @@ export default function Step({
       const { required, requiredCondition } = f;
 
       let isRequired = false;
-      if (
-        requiredCondition &&
-        (requiredCondition.condition ||
-          (requiredCondition.field && requiredCondition.operator))
-      ) {
-        isRequired = evaluateCondition(
-          requiredCondition.condition || requiredCondition,
-          fullData
-        );
+      if (requiredCondition) {
+        isRequired = evaluateCondition(requiredCondition, fullData);
       } else if (typeof required === "boolean") {
         isRequired = required;
       }

--- a/test-form/src/components/shared/GroupField/GroupField.jsx
+++ b/test-form/src/components/shared/GroupField/GroupField.jsx
@@ -50,10 +50,7 @@ export default function GroupField({ field, value = [], onChange, fullData = {} 
     const errors = {};
     (field.fields || []).forEach((subField) => {
       const required = subField.requiredCondition
-        ? evaluateCondition(
-            subField.requiredCondition.condition || subField.requiredCondition,
-            fullData
-          )
+        ? evaluateCondition(subField.requiredCondition, fullData)
         : subField.required;
       const val = currentEntry[subField.id];
       if (
@@ -109,16 +106,12 @@ export default function GroupField({ field, value = [], onChange, fullData = {} 
 
   const renderField = (subField) => {
     const conditionToCheck =
-      subField.visibilityCondition ??
-      (subField.requiredCondition?.condition || subField.requiredCondition);
+      subField.visibilityCondition ?? subField.requiredCondition;
     const visible = conditionToCheck
       ? evaluateCondition(conditionToCheck, fullData)
       : true;
     const required = subField.requiredCondition
-      ? evaluateCondition(
-          subField.requiredCondition.condition || subField.requiredCondition,
-          fullData
-        )
+      ? evaluateCondition(subField.requiredCondition, fullData)
       : subField.required;
     if (!visible) return null;
 

--- a/test-form/src/utils/formHelpers.js
+++ b/test-form/src/utils/formHelpers.js
@@ -72,10 +72,7 @@ export function cleanupHiddenFields(step, formData) {
             ? evaluateCondition(field.visibilityCondition, formData)
             : true) &&
           (field.requiredCondition
-            ? evaluateCondition(
-                field.requiredCondition.condition || field.requiredCondition,
-                formData
-              )
+            ? evaluateCondition(field.requiredCondition, formData)
             : true);
 
         if (!isVisible && cleaned[field.id] !== undefined) {
@@ -89,11 +86,7 @@ export function cleanupHiddenFields(step, formData) {
                 ? evaluateCondition(subField.visibilityCondition, formData)
                 : true) &&
               (subField.requiredCondition
-                ? evaluateCondition(
-                    subField.requiredCondition.condition ||
-                      subField.requiredCondition,
-                    formData
-                  )
+                ? evaluateCondition(subField.requiredCondition, formData)
                 : true);
 
             if (!isSubVisible && cleaned[subField.id] !== undefined) {
@@ -115,15 +108,8 @@ export function validateField(field, value, data = {}) {
   const requiredCondition = field.requiredCondition;
 
   let isRequired = false;
-  if (
-    requiredCondition &&
-    (requiredCondition.condition ||
-      (requiredCondition.field && requiredCondition.operator))
-  ) {
-    isRequired = evaluateCondition(
-      requiredCondition.condition || requiredCondition,
-      data
-    );
+  if (requiredCondition) {
+    isRequired = evaluateCondition(requiredCondition, data);
   } else if (typeof required === "boolean") {
     isRequired = required;
   } else if (typeof field.isRequired === "boolean") {
@@ -232,15 +218,8 @@ export function validateStep(
               } = subField;
 
               let isRequired = false;
-              if (
-                requiredCondition &&
-                (requiredCondition.condition ||
-                  (requiredCondition.field && requiredCondition.operator))
-              ) {
-                isRequired = evaluateCondition(
-                  requiredCondition.condition || requiredCondition,
-                  fullData
-                );
+              if (requiredCondition) {
+                isRequired = evaluateCondition(requiredCondition, fullData);
               } else if (typeof required === "boolean") {
                 isRequired = required;
               } else if (typeof precomputedRequired === "boolean") {
@@ -278,14 +257,8 @@ export function validateStep(
           const requiredCondition = field.requiredCondition;
 
           let isRequired = false;
-          if (
-            requiredCondition &&
-            (requiredCondition.condition || (requiredCondition.field && requiredCondition.operator))
-          ) {
-            isRequired = evaluateCondition(
-              requiredCondition.condition || requiredCondition,
-              fullData
-            );
+          if (requiredCondition) {
+            isRequired = evaluateCondition(requiredCondition, fullData);
           } else if (typeof required === "boolean") {
             isRequired = required;
           }


### PR DESCRIPTION
## Summary
- ensure requiredCondition objects are passed directly to `evaluateCondition`
- update Step and GroupField components to use full condition

## Testing
- `npm test --silent` *(fails: react-scripts not found)*
- `npm run test-server --silent` *(fails: jest not found)*

------
https://chatgpt.com/codex/tasks/task_e_686b420f85288331835c7457972fbab9