### PR TITLE
Fix group visibility condition

### DIFF
--- a/test-form/src/__tests__/RepeatingGroupCondition.test.js
+++ b/test-form/src/__tests__/RepeatingGroupCondition.test.js
@@ -26,14 +26,12 @@ const step = {
           label: 'Guardian',
           type: 'text',
           requiredCondition: {
+            repeatingGroup: 'children',
+            operator: 'ANY',
             condition: {
-              repeatingGroup: 'children',
-              operator: 'ANY',
-              condition: {
-                field: 'needs_help',
-                operator: 'equals',
-                value: true,
-              },
+              field: 'needs_help',
+              operator: 'equals',
+              value: true,
             },
           },
         },

--- a/test-form/src/components/core/Step/Step.jsx
+++ b/test-form/src/components/core/Step/Step.jsx
@@ -233,10 +233,8 @@ export default function Step({
   };
 
   const renderField = (field) => {
-    const conditionToCheck =
-      field.visibilityCondition ?? field.requiredCondition;
-    const visible = conditionToCheck
-      ? evaluateCondition(conditionToCheck, fullData)
+    const visible = field.visibilityCondition
+      ? evaluateCondition(field.visibilityCondition, fullData)
       : true;
     const isRequired = field.requiredCondition
       ? evaluateCondition(field.requiredCondition, fullData)

--- a/test-form/src/components/shared/GroupField/GroupField.jsx
+++ b/test-form/src/components/shared/GroupField/GroupField.jsx
@@ -105,10 +105,8 @@ export default function GroupField({ field, value = [], onChange, fullData = {} 
   };
 
   const renderField = (subField) => {
-    const conditionToCheck =
-      subField.visibilityCondition ?? subField.requiredCondition;
-    const visible = conditionToCheck
-      ? evaluateCondition(conditionToCheck, fullData)
+    const visible = subField.visibilityCondition
+      ? evaluateCondition(subField.visibilityCondition, fullData)
       : true;
     const required = subField.requiredCondition
       ? evaluateCondition(subField.requiredCondition, fullData)


### PR DESCRIPTION
## Summary
- show fields with a `requiredCondition` even when the condition is false
- update repeating group condition test for new schema format

## Testing
- `npm install --prefix test-form`
- `CI=true npm test --prefix test-form -- --runTestsByPath src/__tests__/RepeatingGroupCondition.test.js --watchAll=false --silent`
- `CI=true npx jest --runInBand` *(fails: SyntaxError: Support for the experimental syntax 'jsx' isn't currently enabled)*

------
https://chatgpt.com/codex/tasks/task_e_686b450a19ac83318d421f93db7db809