### PR TITLE
Fix delete button color

### DIFF
--- a/test-form/src/components/ApplicationCard.jsx
+++ b/test-form/src/components/ApplicationCard.jsx
@@ -59,7 +59,7 @@ export default function ApplicationCard({
           Continue
         </Button>
         <Button
-          variant="danger"
+          variant="secondary"
           size="small"
           onClick={() => onDelete && onDelete(id)}
           iconLeft={<FontAwesomeIcon icon={faTrash} aria-hidden="true" />}

--- a/test-form/src/components/shared/GroupField/GroupField.jsx
+++ b/test-form/src/components/shared/GroupField/GroupField.jsx
@@ -351,7 +351,7 @@ export default function GroupField({ field, value = [], onChange, fullData = {} 
                     Edit
                   </Button>
                   <Button
-                    variant="danger"
+                    variant="secondary"
                     size="small"
                     onClick={() => handleDelete(idx)}
                     iconLeft={<FontAwesomeIcon icon={faTrash} aria-hidden="true" />}


### PR DESCRIPTION
## Summary
- avoid red color on delete buttons

## Testing
- `npm test --prefix test-form --silent` *(fails: react scripts not found)*
- `npm run lint --prefix test-form` *(fails: 12 errors, 2 warnings)*
- `npm run test-server --prefix test-form`

------
https://chatgpt.com/codex/tasks/task_e_686b4a5fc70c83319d496e30ee17d112