### PR TITLE
Improve dark mode UI

### DIFF
--- a/JULES_THEME_GUIDE.md
+++ b/JULES_THEME_GUIDE.md
@@ -104,4 +104,4 @@ const toggle = () => {
 };
 ```
 
-The sample `App.js` includes a button that switches between light and dark modes at runtime.
+The sample `App.js` now includes an icon toggle that switches between light and dark modes with a subtle fade transition.

--- a/test-form/src/App.js
+++ b/test-form/src/App.js
@@ -5,7 +5,7 @@ import Profile from './pages/Profile';
 // import "./form.css"; // Old theme - commented out
 import FormPage from "./pages/FormPage";
 import Dashboard from "./pages/Dashboard";
-import ThemeSettings from './components/shared/ThemeSettings';
+import ThemeToggle from './components/shared/ThemeToggle';
 import './App.css'; // App specific styles, kept for now
 
 // Jules Theme CSS Files
@@ -27,7 +27,6 @@ function App() {
   const [currentId, setCurrentId] = useState(null);
   const [currentService, setCurrentService] = useState('childcare');
   const [theme, setTheme] = useState('system');
-  const [themeModalOpen, setThemeModalOpen] = useState(false);
   const { user } = useContext(AuthContext);
   const server = process.env.REACT_APP_SERVER_URL || '';
 
@@ -60,6 +59,11 @@ function App() {
     } else {
       localStorage.setItem('themePreference', value);
     }
+  };
+
+  const toggleTheme = () => {
+    const next = theme === 'dark' ? 'light' : 'dark';
+    handleThemeChange(next);
   };
 
   const startApplication = (serviceKey, id) => {
@@ -117,21 +121,10 @@ function App() {
               )}
             </div>
           )}
-          <button
-            type="button"
-            onClick={() => setThemeModalOpen(true)}
-            className="theme-toggle"
-          >
-            Day/Night View
-          </button>
+          <ThemeToggle theme={theme} onToggle={toggleTheme} />
         </nav>
       </header>
-      <ThemeSettings
-        isOpen={themeModalOpen}
-        onClose={() => setThemeModalOpen(false)}
-        value={theme}
-        onChange={handleThemeChange}
-      />
+
 
       <main className="form-main">
         <Routes>

--- a/test-form/src/components/shared/ThemeToggle/ThemeToggle.jsx
+++ b/test-form/src/components/shared/ThemeToggle/ThemeToggle.jsx
@@ -1,0 +1,19 @@
+import React from 'react';
+import { FontAwesomeIcon } from '@fortawesome/react-fontawesome';
+import { faMoon, faSun } from '@fortawesome/free-solid-svg-icons';
+
+export default function ThemeToggle({ theme, onToggle }) {
+  const isDark = theme === 'dark';
+  const icon = isDark ? faSun : faMoon;
+  const label = isDark ? 'Switch to light mode' : 'Switch to dark mode';
+  return (
+    <button
+      type="button"
+      className="theme-toggle"
+      aria-label={label}
+      onClick={onToggle}
+    >
+      <FontAwesomeIcon icon={icon} />
+    </button>
+  );
+}

--- a/test-form/src/components/shared/ThemeToggle/index.js
+++ b/test-form/src/components/shared/ThemeToggle/index.js
@@ -1,0 +1,1 @@
+export { default } from './ThemeToggle';

--- a/test-form/src/jules_base.css
+++ b/test-form/src/jules_base.css
@@ -24,6 +24,11 @@ body {
   line-height: var(--jules-line-height-base);
   color: var(--jules-text-color-body);
   background-color: var(--jules-neutral-gray-100); /* Page background */
+  transition:
+    background-color var(--jules-transition-duration-base)
+      var(--jules-transition-timing-function),
+    color var(--jules-transition-duration-base)
+      var(--jules-transition-timing-function);
 }
 
 /* 3. Base styles for Headings (h1-h6) */

--- a/test-form/src/jules_layout.css
+++ b/test-form/src/jules_layout.css
@@ -6,6 +6,8 @@
   flex-direction: column;
   min-height: 100vh; /* Ensure it takes at least full viewport height */
   background-color: var(--jules-neutral-gray-100); /* Default page background */
+  transition: background-color var(--jules-transition-duration-base)
+    var(--jules-transition-timing-function);
 }
 
 .form-header {
@@ -18,6 +20,8 @@
   position: sticky; /* Optional: make header sticky */
   top: 0;
   z-index: 100; /* Ensure it's above other content if sticky */
+  transition: background-color var(--jules-transition-duration-base)
+    var(--jules-transition-timing-function);
 }
 
 .form-header .brand { /* Assuming .brand is the class for the title/logo area */
@@ -52,17 +56,16 @@
   background: none;
   border: none;
   color: var(--jules-text-color-link);
-  font-family: var(--jules-font-family-sans);
-  font-size: var(--jules-font-size-md);
-  font-weight: var(--jules-font-weight-medium);
+  font-size: 1.25rem;
   margin-left: var(--jules-space-lg);
   cursor: pointer;
+  transition: color var(--jules-transition-duration-fast)
+    var(--jules-transition-timing-function);
 }
 
 .theme-toggle:hover,
 .theme-toggle:focus {
   color: var(--jules-text-color-link-hover);
-  text-decoration: underline;
 }
 
 .theme-toggle:focus-visible {
@@ -143,6 +146,10 @@
   overflow-y: auto; /* Scroll content if it overflows */
   padding: var(--jules-space-xl); /* Generous padding for content area */
   background-color: var(--jules-neutral-white); /* If page background is gray, content on white */
+  transition: background-color var(--jules-transition-duration-base)
+    var(--jules-transition-timing-function),
+    color var(--jules-transition-duration-base)
+      var(--jules-transition-timing-function);
   /* In some layouts, form-main might be the gray area, and cards/sections inside are white */
 }
 
@@ -153,6 +160,10 @@
   text-align: center;
   font-size: var(--jules-font-size-sm);
   color: var(--jules-text-color-muted);
+  transition: background-color var(--jules-transition-duration-base)
+    var(--jules-transition-timing-function),
+    color var(--jules-transition-duration-base)
+      var(--jules-transition-timing-function);
 }
 
 .form-footer a {

--- a/test-form/src/jules_tokens.css
+++ b/test-form/src/jules_tokens.css
@@ -133,24 +133,25 @@
   --jules-z-index-popover: 1060;
   --jules-z-index-tooltip: 1070;
 }
+
 [data-theme='dark'] {
-  --jules-neutral-white: #000000;
-  --jules-neutral-gray-50: #1a1a1a;
-  --jules-neutral-gray-100: #222222;
-  --jules-neutral-gray-200: #2c2c2c;
-  --jules-neutral-gray-300: #444444;
-  --jules-neutral-gray-400: #555555;
-  --jules-neutral-gray-500: #888888;
-  --jules-neutral-gray-600: #aaaaaa;
-  --jules-neutral-gray-700: #cccccc;
-  --jules-neutral-gray-800: #dddddd;
+  --jules-neutral-white: #1b1b1b;
+  --jules-neutral-gray-50: #242424;
+  --jules-neutral-gray-100: #2d2d2d;
+  --jules-neutral-gray-200: #373737;
+  --jules-neutral-gray-300: #4a4a4a;
+  --jules-neutral-gray-400: #5c5c5c;
+  --jules-neutral-gray-500: #757575;
+  --jules-neutral-gray-600: #9e9e9e;
+  --jules-neutral-gray-700: #c2c2c2;
+  --jules-neutral-gray-800: #dadada;
   --jules-neutral-gray-900: #ffffff;
 
   --jules-text-color-body: var(--jules-neutral-gray-800);
   --jules-text-color-headings: var(--jules-neutral-gray-900);
   --jules-text-color-muted: var(--jules-neutral-gray-600);
   --jules-text-color-link: var(--jules-primary-blue-300);
-  --jules-text-color-link-hover: var(--jules-primary-blue-50);
+  --jules-text-color-link-hover: var(--jules-primary-blue-100);
   --jules-border-color: var(--jules-neutral-gray-300);
   --jules-focus-ring-color: var(--jules-primary-blue-700);
 }


### PR DESCRIPTION
## Summary
- add ThemeToggle component with sun/moon icon
- persist theme choice and update App header
- soften dark theme colors
- fade transitions when switching themes
- update theme guide

## Testing
- `npm test --silent` *(fails: TypeError from matchMedia during tests)*

------
https://chatgpt.com/codex/tasks/task_e_686b4e00bf908331a921938675ee917e