### PR TITLE
Fix label behavior when placeholder is provided

### DIFF
--- a/test-form/src/components/shared/SelectField/SelectField.jsx
+++ b/test-form/src/components/shared/SelectField/SelectField.jsx
@@ -25,11 +25,14 @@ export default function SelectField({
   const [isFocused, setIsFocused] = useState(false);
   // For select, "has value" means a non-empty option is selected.
   // If there's a placeholder option (value=""), that doesn't count as having a value.
-  const [hasValue, setHasValue] = useState(Boolean(multiple ? (value || defaultValue)?.length > 0 : (value || defaultValue)));
+  const [hasValue, setHasValue] = useState(
+    Boolean(placeholder) ||
+      Boolean(multiple ? (value || defaultValue)?.length > 0 : (value || defaultValue))
+  );
 
   useEffect(() => {
-    setHasValue(Boolean(multiple ? value?.length > 0 : value));
-  }, [value, multiple]);
+    setHasValue(Boolean(placeholder) || Boolean(multiple ? value?.length > 0 : value));
+  }, [value, multiple, placeholder]);
 
   const handleFocus = (e) => {
     setIsFocused(true);
@@ -39,8 +42,8 @@ export default function SelectField({
   const handleBlur = (e) => {
     setIsFocused(false);
     // For uncontrolled select with placeholder, check if current value is not the placeholder value
-    if (defaultValue !== undefined && !multiple && placeholder) {
-        setHasValue(Boolean(e.target.value));
+    if (defaultValue !== undefined && !multiple) {
+        setHasValue(Boolean(placeholder) || Boolean(e.target.value));
     }
     props.onBlur && props.onBlur(e);
   };
@@ -48,9 +51,9 @@ export default function SelectField({
   const handleChange = (e) => {
     if (multiple) {
         const selectedValues = Array.from(e.target.selectedOptions).map(opt => opt.value);
-        setHasValue(selectedValues.length > 0);
+        setHasValue(Boolean(placeholder) || selectedValues.length > 0);
     } else {
-        setHasValue(Boolean(e.target.value)); // True if value is not ""
+        setHasValue(Boolean(placeholder) || Boolean(e.target.value)); // True if value is not "" or placeholder provided
     }
     props.onChange && props.onChange(e);
   };

--- a/test-form/src/components/shared/TextInput/TextInput.jsx
+++ b/test-form/src/components/shared/TextInput/TextInput.jsx
@@ -21,12 +21,14 @@ export default function TextInput({
 }) {
   const [isFocused, setIsFocused] = useState(false);
   // Determine if the input has a value. Handles both controlled and uncontrolled components.
-  const [hasValue, setHasValue] = useState(Boolean(value || defaultValue || props.placeholder === ' '));
+  const [hasValue, setHasValue] = useState(
+    Boolean(value || defaultValue || (props.placeholder && props.placeholder !== ' '))
+  );
 
 
   // Update hasValue state if the value prop changes (for controlled components)
   useEffect(() => {
-    setHasValue(Boolean(value || props.placeholder === ' '));
+    setHasValue(Boolean(value || (props.placeholder && props.placeholder !== ' ')));
   }, [value, props.placeholder]);
 
 


### PR DESCRIPTION
## Summary
- float select labels when a placeholder option is present
- ensure text input labels float whenever the placeholder prop is not a single space

## Testing
- `npm test --silent --prefix test-form` *(fails: react-scripts not found)*

------
https://chatgpt.com/codex/tasks/task_e_686b569919c88331a65bcc0563c4bec7