### PR TITLE
Fix label overlap with icons

### DIFF
--- a/test-form/src/components/shared/TextInput/TextInput.jsx
+++ b/test-form/src/components/shared/TextInput/TextInput.jsx
@@ -56,6 +56,8 @@ export default function TextInput({
     'jules-form-field',
     isFocused ? 'is-focused' : '',
     hasValue ? 'has-value' : '',
+    iconLeft ? 'jules-form-field-has-icon-left' : '',
+    iconRight ? 'jules-form-field-has-icon-right' : '',
     className || ''
   ].join(' ').trim();
 

--- a/test-form/src/jules_input.css
+++ b/test-form/src/jules_input.css
@@ -41,6 +41,11 @@
   max-width: calc(100% - (var(--jules-space-md) * 2)); /* Prevent overflow */
 }
 
+/* If the input has a left icon, shift the label so it doesn't overlap */
+.jules-form-field-has-icon-left .jules-label {
+  left: calc(var(--jules-space-md) + 1em + var(--jules-space-sm));
+}
+
 .jules-label .jules-tooltip-wrapper {
   pointer-events: auto; /* Re-enable events for tooltip */
   margin-left: var(--jules-space-xxs);


### PR DESCRIPTION
## Summary
- add classes to form field when icons are present
- shift floating label when a left icon is used

## Testing
- `npm test --prefix test-form` *(fails: react-scripts not found)*

------
https://chatgpt.com/codex/tasks/task_e_686b5be985a48331986fb60b808dca8c