### PR TITLE
Fix conditional visibility logic

### DIFF
--- a/test-form/src/components/core/Step/Step.jsx
+++ b/test-form/src/components/core/Step/Step.jsx
@@ -294,8 +294,9 @@ export default function Step({
   };
 
   const renderField = (field, section) => {
-    const visible = field.visibilityCondition
-      ? evaluateCondition(field.visibilityCondition, fullData)
+    const conditionToCheck = field.visibilityCondition ?? field.requiredCondition;
+    const visible = conditionToCheck
+      ? evaluateCondition(conditionToCheck, fullData)
       : true;
     const isRequired = field.requiredCondition
       ? evaluateCondition(field.requiredCondition, fullData)

--- a/test-form/src/components/shared/GroupField/GroupField.jsx
+++ b/test-form/src/components/shared/GroupField/GroupField.jsx
@@ -163,8 +163,9 @@ export default function GroupField({ field, value = [], onChange, fullData = {} 
   };
 
   const renderField = (subField) => {
-    const visible = subField.visibilityCondition
-      ? evaluateCondition(subField.visibilityCondition, fullData)
+    const conditionToCheck = subField.visibilityCondition ?? subField.requiredCondition;
+    const visible = conditionToCheck
+      ? evaluateCondition(conditionToCheck, fullData)
       : true;
     const required = subField.requiredCondition
       ? evaluateCondition(subField.requiredCondition, fullData)

--- a/test-form/src/utils/formHelpers.js
+++ b/test-form/src/utils/formHelpers.js
@@ -1,5 +1,8 @@
 export function evaluateCondition(condition, data) {
   if (!condition) return true;
+  if (condition.condition && !condition.field && !('value' in condition) && !condition.repeatingGroup) {
+    return evaluateCondition(condition.condition, data);
+  }
   if (condition.repeatingGroup) {
     return evaluateRepeatingGroupCondition(condition, data);
   }


### PR DESCRIPTION
## Summary
- restore visibility fallback to `requiredCondition`
- use fallback visibility for GroupField subfields
- support nested `condition` objects in `evaluateCondition`

## Testing
- `npm test --prefix test-form --silent` *(fails: react-scripts not found)*
- `npm run test-server --prefix test-form --silent` *(fails: jest not found)*

------
https://chatgpt.com/codex/tasks/task_e_686d2a62488083319193594bb6ebd44c