### PR TITLE
Add step validation across navigation

### DIFF
--- a/test-form/src/__tests__/ChildcareFormNavigation.test.js
+++ b/test-form/src/__tests__/ChildcareFormNavigation.test.js
@@ -16,7 +16,10 @@ beforeAll(() => {
 beforeEach(() => {
   global.fetch = jest.fn((url) => {
     if (url === formSpecPath) {
-      return Promise.resolve({ ok: true, json: () => Promise.resolve(formSpec) });
+      return Promise.resolve({
+        ok: true,
+        json: () => Promise.resolve(formSpec),
+      });
     }
     return Promise.reject(new Error(`Unexpected fetch URL: ${url}`));
   });
@@ -27,17 +30,48 @@ describe('Childcare form navigation', () => {
 
   test('renders first step by default', async () => {
     render(<FormRenderer formSpecPath={formSpecPath} />);
-    const heading = await screen.findByRole('heading', { level: 2, name: steps[0].title });
+    const heading = await screen.findByRole('heading', {
+      level: 2,
+      name: steps[0].title,
+    });
     expect(heading).toBeInTheDocument();
   });
 
   test('navigates to second step', async () => {
-      const user = userEvent.setup();
-      render(<FormRenderer formSpecPath={formSpecPath} />);
-      const btn = await screen.findByRole('button', { name: /next/i });
-      await user.click(btn);
-      expect(
-        await screen.findByRole('heading', { level: 2, name: steps[1].title })
-      ).toBeInTheDocument();
+    const user = userEvent.setup();
+    render(<FormRenderer formSpecPath={formSpecPath} />);
+    const btn = await screen.findByRole('button', { name: /next/i });
+    await user.click(btn);
+    expect(
+      await screen.findByRole('heading', { level: 2, name: steps[1].title }),
+    ).toBeInTheDocument();
+  });
+
+  test('cannot jump past invalid intermediate step', async () => {
+    const user = userEvent.setup();
+    render(<FormRenderer formSpecPath={formSpecPath} />);
+
+    await user.click(await screen.findByRole('button', { name: /next/i }));
+    await user.click(await screen.findByRole('button', { name: /next/i }));
+    expect(
+      await screen.findByRole('heading', { level: 2, name: steps[2].title }),
+    ).toBeInTheDocument();
+
+    const futureStep = screen.getByRole('button', {
+      name: new RegExp(steps[4].title, 'i'),
+    });
+    expect(futureStep).toHaveAttribute('aria-disabled', 'true');
+
+    await user.click(futureStep);
+
+    expect(
+      await screen.findByRole('heading', { level: 2, name: steps[2].title }),
+    ).toBeInTheDocument();
+    expect(
+      screen.getByText(/Please correct the following errors:/i),
+    ).toBeInTheDocument();
+    expect(
+      screen.getAllByText(/First Name is required\./i).length,
+    ).toBeGreaterThan(0);
   });
 });


### PR DESCRIPTION
## Summary
- validate all intermediate steps when changing steps
- disable stepper steps until previous ones are valid
- test that invalid steps prevent navigating ahead

## Testing
- `CI=true npm test --silent -- -w=1 src/__tests__/ChildcareFormNavigation.test.js`

------
https://chatgpt.com/codex/tasks/task_e_686d4a8ea3748331a415091ce66e28a6