### PR TITLE
Improve mobile stepper drawer UX

### DIFF
--- a/test-form/src/components/core/StepperDrawer/StepperDrawer.jsx
+++ b/test-form/src/components/core/StepperDrawer/StepperDrawer.jsx
@@ -1,5 +1,11 @@
 import React, { useState, useRef, useEffect } from 'react';
 import Stepper from '../Stepper/Stepper';
+import { FontAwesomeIcon } from '@fortawesome/react-fontawesome';
+import {
+  faAnglesRight,
+  faAnglesLeft,
+  faBarsProgress,
+} from '@fortawesome/free-solid-svg-icons';
 
 export default function StepperDrawer({
   steps = [],
@@ -31,6 +37,15 @@ export default function StepperDrawer({
 
   return (
     <div className="stepper-drawer-container">
+      {!open && (
+        <button
+          className="stepper-drawer-handle"
+          aria-label="Open step navigation"
+          onClick={() => setOpen(true)}
+        >
+          <FontAwesomeIcon icon={faAnglesRight} />
+        </button>
+      )}
       <button
         ref={toggleRef}
         className="jules-button jules-button-secondary stepper-drawer-toggle"
@@ -38,8 +53,16 @@ export default function StepperDrawer({
         aria-expanded={open}
         onClick={() => setOpen((o) => !o)}
       >
-        Steps
+        <FontAwesomeIcon icon={faBarsProgress} aria-hidden="true" />
+        <span className="sr-only">Toggle steps</span>
+        <span aria-hidden="true"> Steps</span>
       </button>
+      {open && (
+        <div
+          className="stepper-drawer-overlay open"
+          onClick={() => setOpen(false)}
+        />
+      )}
       <div
         id="stepperDrawer"
         ref={drawerRef}
@@ -50,7 +73,8 @@ export default function StepperDrawer({
           className="jules-button jules-button-tertiary stepper-drawer-close"
           onClick={() => setOpen(false)}
         >
-          Close
+          <FontAwesomeIcon icon={faAnglesLeft} aria-hidden="true" />
+          <span className="sr-only">Close</span>
         </button>
         <Stepper
           steps={steps}

--- a/test-form/src/jules_layout.css
+++ b/test-form/src/jules_layout.css
@@ -269,6 +269,50 @@
 }
 
 @media (max-width: 768px) {
+  .stepper-drawer-container {
+    position: relative;
+  }
+
+  .stepper-drawer-toggle {
+    display: flex;
+    align-items: center;
+    gap: var(--jules-space-xs);
+  }
+
+  .stepper-drawer-handle {
+    position: fixed;
+    top: var(--jules-space-md);
+    left: 0;
+    width: var(--jules-space-md);
+    height: var(--jules-space-lg);
+    background: var(--jules-primary-blue-500);
+    color: var(--jules-text-color-on-primary);
+    border-radius: 0 var(--jules-border-radius-md) var(--jules-border-radius-md) 0;
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    cursor: pointer;
+    z-index: var(--jules-z-index-modal);
+  }
+
+  .stepper-drawer-overlay {
+    position: fixed;
+    top: 0;
+    left: 0;
+    width: 100%;
+    height: 100%;
+    background: rgba(0, 0, 0, 0.2);
+    opacity: 0;
+    pointer-events: none;
+    transition: opacity 0.3s ease-in-out;
+    z-index: var(--jules-z-index-modal-backdrop);
+  }
+
+  .stepper-drawer-overlay.open {
+    opacity: 1;
+    pointer-events: auto;
+  }
+
   .stepper-drawer {
     position: fixed;
     top: 0;
@@ -298,6 +342,6 @@
   }
 
   .stepper-drawer-close {
-    margin: var(--jules-space-md);
+    margin: var(--jules-space-md) var(--jules-space-md) var(--jules-space-md) auto;
   }
 }


### PR DESCRIPTION
## Summary
- allow closing the drawer by clicking outside
- tweak drawer controls and styling for a mobile look
- add progress icon on the toggle button
- update layout styles for new handle and overlay

## Testing
- `CI=true npm test -- --runInBand --watchAll=false` *(fails: matchMedia not defined)*
- `npm run test-server --silent`

------
https://chatgpt.com/codex/tasks/task_e_686d8fea3930833192956fbe2e28e386