### PR TITLE
Implement i18n support with language selector

### DIFF
--- a/test-form/package-lock.json
+++ b/test-form/package-lock.json
@@ -20,6 +20,8 @@
         "express-rate-limit": "^7.5.1",
         "express-session": "^1.17.3",
         "helmet": "^8.1.0",
+        "i18next": "^23.8.1",
+        "i18next-http-backend": "^2.2.2",
         "multer": "^1.4.5-lts.1",
         "node-fetch": "^2.6.9",
         "passport": "^0.6.0",
@@ -27,6 +29,7 @@
         "pg": "^8.11.5",
         "react": "^19.1.0",
         "react-dom": "^19.1.0",
+        "react-i18next": "^13.2.2",
         "react-imask": "^7.6.1",
         "react-markdown": "^10.1.0",
         "react-router-dom": "^6.23.0",
@@ -6675,6 +6678,15 @@
         "node": ">=10"
       }
     },
+    "node_modules/cross-fetch": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/cross-fetch/-/cross-fetch-4.0.0.tgz",
+      "integrity": "sha512-e4a5N8lVvuLgAWgnCrLr2PP0YyDOTHa9H/Rj54dirp61qXnNq46m82bRhNqIA5VccJtWBvPTFRV3TtvHUKPB1g==",
+      "license": "MIT",
+      "dependencies": {
+        "node-fetch": "^2.6.12"
+      }
+    },
     "node_modules/cross-spawn": {
       "version": "7.0.6",
       "resolved": "https://registry.npmjs.org/cross-spawn/-/cross-spawn-7.0.6.tgz",
@@ -10134,6 +10146,15 @@
         "node": ">=12"
       }
     },
+    "node_modules/html-parse-stringify": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/html-parse-stringify/-/html-parse-stringify-3.0.1.tgz",
+      "integrity": "sha512-KknJ50kTInJ7qIScF3jeaFRpMpE8/lfiTdzf/twXyPBLAGrLRTmkz3AdTnKeh40X8k9L2fdYwEp/42WGXIRGcg==",
+      "license": "MIT",
+      "dependencies": {
+        "void-elements": "3.1.0"
+      }
+    },
     "node_modules/html-url-attributes": {
       "version": "3.0.1",
       "resolved": "https://registry.npmjs.org/html-url-attributes/-/html-url-attributes-3.0.1.tgz",
@@ -10295,6 +10316,38 @@
       "license": "Apache-2.0",
       "engines": {
         "node": ">=10.17.0"
+      }
+    },
+    "node_modules/i18next": {
+      "version": "23.16.8",
+      "resolved": "https://registry.npmjs.org/i18next/-/i18next-23.16.8.tgz",
+      "integrity": "sha512-06r/TitrM88Mg5FdUXAKL96dJMzgqLE5dv3ryBAra4KCwD9mJ4ndOTS95ZuymIGoE+2hzfdaMak2X11/es7ZWg==",
+      "funding": [
+        {
+          "type": "individual",
+          "url": "https://locize.com"
+        },
+        {
+          "type": "individual",
+          "url": "https://locize.com/i18next.html"
+        },
+        {
+          "type": "individual",
+          "url": "https://www.i18next.com/how-to/faq#i18next-is-awesome.-how-can-i-support-the-project"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "@babel/runtime": "^7.23.2"
+      }
+    },
+    "node_modules/i18next-http-backend": {
+      "version": "2.7.3",
+      "resolved": "https://registry.npmjs.org/i18next-http-backend/-/i18next-http-backend-2.7.3.tgz",
+      "integrity": "sha512-FgZxrXdRA5u44xfYsJlEBL4/KH3f2IluBpgV/7riW0YW2VEyM8FzVt2XHAOi6id0Ppj7vZvCZVpp5LrGXnc8Ig==",
+      "license": "MIT",
+      "dependencies": {
+        "cross-fetch": "4.0.0"
       }
     },
     "node_modules/iconv-lite": {
@@ -16547,6 +16600,28 @@
       "integrity": "sha512-SN/U6Ytxf1QGkw/9ve5Y+NxBbZM6Ht95tuXNMKs8EJyFa/Vy/+Co3stop3KBHARfn/giv+Lj1uUnTfOJ3moFEQ==",
       "license": "MIT"
     },
+    "node_modules/react-i18next": {
+      "version": "13.5.0",
+      "resolved": "https://registry.npmjs.org/react-i18next/-/react-i18next-13.5.0.tgz",
+      "integrity": "sha512-CFJ5NDGJ2MUyBohEHxljOq/39NQ972rh1ajnadG9BjTk+UXbHLq4z5DKEbEQBDoIhUmmbuS/fIMJKo6VOax1HA==",
+      "license": "MIT",
+      "dependencies": {
+        "@babel/runtime": "^7.22.5",
+        "html-parse-stringify": "^3.0.1"
+      },
+      "peerDependencies": {
+        "i18next": ">= 23.2.3",
+        "react": ">= 16.8.0"
+      },
+      "peerDependenciesMeta": {
+        "react-dom": {
+          "optional": true
+        },
+        "react-native": {
+          "optional": true
+        }
+      }
+    },
     "node_modules/react-imask": {
       "version": "7.6.1",
       "resolved": "https://registry.npmjs.org/react-imask/-/react-imask-7.6.1.tgz",
@@ -19870,6 +19945,15 @@
       "funding": {
         "type": "opencollective",
         "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/void-elements": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/void-elements/-/void-elements-3.1.0.tgz",
+      "integrity": "sha512-Dhxzh5HZuiHQhbvTW9AMetFfBHDMYpo23Uo9btPXgdYP+3T5S+p+jgNy7spra+veYhBP2dCSgxR/i2Y02h5/6w==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.10.0"
       }
     },
     "node_modules/w3c-hr-time": {

--- a/test-form/package.json
+++ b/test-form/package.json
@@ -28,7 +28,10 @@
     "react-scripts": "5.0.1",
     "remark-gfm": "^4.0.1",
     "web-vitals": "^2.1.4",
-    "winston": "^3.17.0"
+    "winston": "^3.17.0",
+    "i18next": "^23.8.1",
+    "react-i18next": "^13.2.2",
+    "i18next-http-backend": "^2.2.2"
   },
   "scripts": {
     "start": "react-scripts start",

--- a/test-form/public/data/childcare_form.ar.json
+++ b/test-form/public/data/childcare_form.ar.json
@@ -1,0 +1,2287 @@
+{
+  "form": {
+    "title": "Childcare Voucher Application",
+    "description": "Step-by-step form for applying for Childcare Assistance",
+    "layout": {
+      "stepperPosition": "left"
+    },
+    "steps": [
+      {
+        "id": "consent_step",
+        "title": "Consent",
+        "sections": [
+          {
+            "id": "mycity_consent_info",
+            "title": "ModelCity Consent",
+            "type": "info",
+            "ui": {
+              "markdown": true,
+              "collapsible": false,
+              "defaultCollapsed": false
+            },
+            "content": "In connection with this application for child care services, **ModelCity**:\\n\\n- Collects, processes, stores, and shares the information you submit to screen you when you apply for child care services;\\n- Receives, processes, and stores the information the City already knows about you to screen you when you apply for child care services;\\n- Uses your information to improve ModelCity; and\\n- Communicates with you about your ModelCity account.\\n\\n---\\n\\nIf you consent, the following information may be shared between child care services agencies:\\n\\n- Demographic and background information, including address, phone number, household composition.\\n- Housing information, including benefits awarded/received, current housing/shelter status.\\n- Benefits information, including public assistance awarded/received, child care program participation.\\n\\n---\\n\\nIf you choose not to consent, **you will not be denied** any benefits or services you are receiving or any benefits for which you are eligible.\\n\\nThe [ModelCity Privacy Policy](https://www.nyc.gov/privacy) details how ModelCity handles the information you submit through ModelCity."
+          }
+        ]
+      },
+      {
+        "id": "instructions_step",
+        "title": "Instructions",
+        "sections": [
+          {
+            "id": "application_instructions",
+            "title": "Application Instructions",
+            "type": "info",
+            "ui": {
+              "markdown": true,
+              "collapsible": false,
+              "defaultCollapsed": false
+            },
+            "content": "**Let’s get started on your application!**\\n\\nTo complete this application, you will be asked for information about:\\n\\n- Yourself\\n- Your household\\n- Your employment or reason for care\\n- Your income\\n\\nAll required fields are marked and must be filled out to move forward with the application. The pages of the application are shown on the right-hand side of the screen and will be highlighted as you move through the application.\\n\\nYour application will be saved automatically as you progress to each page.  \\nIf you need to pause at any time, click the **“Save for later”** button at the bottom of each page to save your application.  \\nYou can log back in to resume your application.\\n\\nWhen you’re ready to begin, click **“Next”** below.\\n\\n---\\n\\n⚠️ **Important:**  \\nTo keep your information current and safe, applications in draft status that you have not edited for **30 days** will be deleted.  \\nIf your draft application is deleted, you can still create and submit a new application when you're ready to apply."
+          },
+          {
+            "id": "new_york_city_residency",
+            "title": "New York City Residency",
+            "type": "info",
+            "ui": {
+              "markdown": true,
+              "collapsible": true,
+              "defaultCollapsed": true
+            },
+            "content": "You will need to upload **ONE** of the following documents to confirm your NYC residency:\\n\\n- IDNYC\\n- Driver’s License\\n- Utility Bill (dated within the last 60 days, with your address)\\n- Current lease, rent, or mortgage statement (dated within the last 60 days, with your address)\\n- Section 8 Award Letter\\n- NYCHA Certificate\\n- CFWB-027 Housing Attestation with address listed\\n- Shelter Residency Letter with address listed\\n\\nIf you do not have any of those documents, you must submit a **CFWB-067 Residency Attestation**."
+          },
+          {
+            "id": "children_documents",
+            "title": "Children Documents",
+            "type": "info",
+            "ui": {
+              "markdown": true,
+              "collapsible": true,
+              "defaultCollapsed": true
+            },
+            "content": "### Citizenship or Immigration Status\\nThese documents confirm the citizenship or immigration status of the children in your family for whom you’re applying for child care assistance. Please upload one of the following documents for each child needing care. *Do not upload these documents for children who do not need care.*\\n\\n- Birth Certificate from US state or territory\\n- Alien Registration Card including Permanent Resident or Green Card\\n- Passport\\n- FS-240 (Consular Report of Birth Abroad)\\n- Naturalization Certificate\\n- Other documentation that proves child’s immigration status\\n\\n### Child's Relationship to Applicant\\nThese documents confirm your relationship to the children in your household under age 18. Please upload one of the following documents for every child in the household under age 18, regardless of whether they need child care.\\n\\n- Birth certificate\\n- Adoption record\\n- Baptismal record\\n- Passport with parent's signature\\n- Court order for legal guardian with financial responsibility\\n- Letter of guardianship\\n- Other - CFWB-058 Caretaker Attestation\\n\\nIf you are not the child's parent or stepparent, you must submit a **CFWB-058 Caretaker Attestation Form**.\\n\\n### Age of Children\\nYou will need to upload **ONE** of the following documents for every child in the household under age 18, regardless of whether child care is needed for them:\\n\\n- Birth certificate\\n- Adoption record\\n- Baptismal record\\n- Alien Registration Card\\n- Passport\\n- Official hospital documentation of the child’s birth"
+          },
+          {
+            "id": "employment_income",
+            "title": "Employment & Income",
+            "type": "info",
+            "ui": {
+              "markdown": true,
+              "collapsible": true,
+              "defaultCollapsed": true
+            },
+            "content": "### Income\\nThese documents confirm your family’s income.\\n\\n---\\n\\n### If You Are Employed\\nIf you are employed and receive paystubs, you must submit them to confirm your income. The number of paystubs you must submit varies by how often you get paid and whether your payment amount is the same or different each time you are paid – see the table below for details. Submit the most recent paystub you have received, followed by others in consecutive order.\\n\\n**Income Information**\\n\\n| How Often Do You Get Paid? | Always the SAME Amount | DIFFERENT Amounts Each Time |\\n|----------------------------|-------------------------|------------------------------|\\n| Weekly (Every Week) | 4 most recent, consecutive pay stubs | 12 most recent, consecutive pay stubs |\\n| Bi-Weekly (Every Two Weeks) | 2 most recent, consecutive pay stubs | 6 most recent, consecutive pay stubs |\\n| Semi-Monthly (Two Times Per Month) | 2 most recent, consecutive pay stubs | 6 most recent, consecutive pay stubs |\\n| Monthly (One Time Per Month) | 3 most recent, consecutive pay stubs | 3 most recent, consecutive pay stubs |\\n\\nIf you do not have any paystubs, you must submit a **CFWB-015 Referral to Employer for Employee Income Information Form**.\\n\\n---\\n\\n### If You Are Self-Employed\\nIf you have been self-employed for **one year or more**, you must submit a current, complete and signed income tax package (e.g., 1040, 1065, Schedule C, SE for partnership, K-1, etc.).\\n\\nIf you have been self-employed for **less than one year**, you must submit a **CFWB-031 Self-Employment Income Information Attestation Form**.\\n\\n---\\n\\n### Other Income\\nIf you receive other types of income outside or instead of employment income, you must submit your most recent check, pay stub, or current award letter that indicates the amount you receive. If your other income fluctuates, **3 months of documentation is required**.\\n\\nThis includes, but is not limited to:\\n- Income from SSI, SSD\\n- Unemployment benefits\\n- Rental income\\n- Pensions\\n- Annuities\\n- Worker’s compensation\\n- Alimony\\n- Child support"
+          },
+          {
+            "id": "reason_for_care",
+            "title": "Reason for Care",
+            "type": "info",
+            "ui": {
+              "markdown": true,
+              "collapsible": true,
+              "defaultCollapsed": true
+            },
+            "content": "### Reason for Care\\nThese documents confirm your reason for care. Every applicant must have a qualified reason for care; in a two-parent household, parents or caretakers can have the same or different reasons for care. Only the documents related to your stated reasons for care need to be uploaded, and documentation must be uploaded for all parent or caretakers in the household.\\n\\n---\\n\\n### Working 10+ Hours Per Week\\nYour employment or self-employment income documents will cover this reason for care. You do not need to submit additional documentation.\\n\\n---\\n\\n### Participating in an Educational or Vocational Training Program\\nYou will need to upload **ONE** of the following documents to confirm your participation in vocational school, two-year college, or four-year college.\\n\\n- CFWB-005 Vocational, Education and Training Verification Form\\n- A letter from the educational or vocational training program on their official letterhead; this letter must contain all the information required in the CFWB-005 Vocational, Education and Training Verification Form.\\n\\n---\\n\\n### Looking for Work\\nYou will need to upload **ONE** of the following documents to confirm that you are looking for work.\\n\\n- CFWB-026 Work Search Record Form\\n- Approved work search plan from the NYS Dept. of Labor\\n- Proof of receipt of unemployment insurance\\n\\n---\\n\\n### Experiencing Homelessness\\nYou will need to upload **ONE** of the following documents to confirm that you are experiencing homelessness. This includes families who may be living in shelter or sharing the housing of others due to loss of housing, economic hardship, or similar reason.\\n\\n- Shelter Residency Letter (If living in Shelter, including Humanitarian Emergency Relief Centers)\\n- CFWB-027 Housing Attestation (If living doubled-up, in a place not meant for human habitation, in a hotel/motel, or in another living situation)\\n\\n---\\n\\n### Attending Services for Domestic Violence\\nYou will need to upload a referral for services from a domestic violence service provider to confirm that you are attending services for domestic violence.\\n\\n---\\n\\n### Attending Services for Substance Abuse Treatment\\nYou will need to upload a referral for a substance abuse treatment service provider to confirm that you are attending services for substance abuse treatment."
+          },
+          {
+            "id": "additional_details",
+            "title": "Additional Details",
+            "type": "info",
+            "ui": {
+              "markdown": true,
+              "collapsible": true,
+              "defaultCollapsed": true
+            },
+            "content": "### Application Scope\\nThis application is used to apply **only** for **Category 2 or 3 child care assistance** (for families not in receipt of cash assistance). To apply for **Cash Assistance** or other benefits, including **Category 1 Child Care Assistance** (for families in receipt of cash assistance), you must use the **New York State Application for Certain Benefits and Services (LDSS-2921)**.\\n\\n---\\n\\n### Exempt Applicants\\nThe following applicants may be eligible for child care assistance **without regard to income** and do not need to complete this application:\\n\\n- Foster parents who need child care assistance to allow them to work and are only applying for assistance for the foster children;\\n- Families in receipt of protective or preventive services.\\n\\n---\\n\\n### Application Completion\\nAll sections of this form must be filled out to be considered complete **unless the section is identified as optional**. If you do not complete all required sections of this form, you may not be considered for Child Care Assistance.\\n\\n---\\n\\n### Rights and Responsibilities\\nYou may obtain information about your rights and responsibilities [here](https://otda.ny.gov/programs/applications/). If you do not have access to the internet, you can call the **Administration for Children’s Services at 212-835-7610** to request that physical copies of the booklets which highlight your rights and responsibilities be mailed to you, including:\\n\\n- **LDSS-4148A**: What You Should Know About Your Rights and Responsibilities\\n- **LDSS-4148B**: What You Should Know About Social Services Programs\\n- **LDSS-4148C**: What You Should Know If You Have an Emergency"
+          }
+        ]
+      },
+      {
+        "id": "applicant",
+        "title": "Applicant",
+        "sections": [
+          {
+            "id": "personal_info",
+            "title": "Personal Information",
+            "fields": [
+              {
+                "id": "first_name",
+                "label": "First Name",
+                "type": "text",
+                "required": true
+              },
+              {
+                "id": "last_name",
+                "label": "Last Name",
+                "type": "text",
+                "required": true
+              },
+              {
+                "id": "mi",
+                "label": "Middle Initial",
+                "type": "text",
+                "required": false
+              },
+              {
+                "id": "date_of_birth",
+                "label": "Date of Birth",
+                "type": "date",
+                "required": true,
+                "tooltip": "To edit Date of Birth click on NYC ModelCity in the top-left corner then click on Account Settings."
+              },
+              {
+                "id": "sex",
+                "label": "Sex",
+                "type": "radio",
+                "required": true,
+                "ui": {
+                  "options": [
+                    "Male",
+                    "Female"
+                  ]
+                }
+              },
+              {
+                "id": "marital_status",
+                "label": "Marital Status",
+                "type": "select",
+                "required": true,
+                "tooltip": "Indicate your marital status (single, married, divorced, separated or widowed).",
+                "ui": {
+                  "options": [
+                    "",
+                    "Single",
+                    "Married",
+                    "Divorced",
+                    "Widowed",
+                    "Separated"
+                  ]
+                }
+              }
+            ]
+          },
+          {
+            "id": "contact_info",
+            "title": "Contact Information",
+            "fields": [
+              {
+                "id": "telephone_home",
+                "label": "Home Phone",
+                "type": "tel",
+                "required": false,
+                "constraints": {
+                  "pattern": "^\\\\(?[0-9]{3}\\\\)?[-. ]?[0-9]{3}[-. ]?[0-9]{4}$"
+                },
+                "ui": {
+                  "placeholder": "(123) 456-7890"
+                }
+              },
+              {
+                "id": "telephone_work",
+                "label": "Work Phone",
+                "type": "tel",
+                "required": false,
+                "constraints": {
+                  "pattern": "^\\\\(?[0-9]{3}\\\\)?[-. ]?[0-9]{3}[-. ]?[0-9]{4}$"
+                },
+                "ui": {
+                  "placeholder": "(123) 456-7890"
+                }
+              },
+              {
+                "id": "telephone_mobile_or_other",
+                "label": "Mobile or Other Phone",
+                "type": "tel",
+                "required": false,
+                "tooltip": "To edit Telephone (Cell or Other) click on NYC ModelCity in the top-left corner then click on Account Settings and then click on Contact.",
+                "constraints": {
+                  "pattern": "^\\\\(?[0-9]{3}\\\\)?[-. ]?[0-9]{3}[-. ]?[0-9]{4}$"
+                },
+                "ui": {
+                  "placeholder": "(123) 456-7890"
+                }
+              },
+              {
+                "id": "email",
+                "label": "Email",
+                "type": "email",
+                "required": true,
+                "tooltip": "To edit email, go to NYC ID Profile tab by clicking your name at the top right corner"
+              }
+            ]
+          },
+          {
+            "id": "address_info",
+            "title": "Address",
+            "tooltip": "To edit home address click on NYC ModelCity in the top-left corner then click on Account Settings.",
+            "ui": {
+              "autocomplete": "street",
+              "placeholder": "Start typing your street address",
+              "overrideComponent": "AddressAutocomplete"
+            },
+            "metadata": {
+              "integration": {
+                "provider": "Google",
+                "feature": "AddressAutocomplete"
+              },
+              "autofillTargets": [
+                {
+                  "fieldId": "city",
+                  "source": "locality",
+                  "fallbackSources": [
+                    "postal_town",
+                    "sublocality_level_1",
+                    "administrative_area_level_2"
+                  ]
+                },
+                {
+                  "fieldId": "borough",
+                  "source": "sublocality_level_1",
+                  "fallbackSources": [
+                    "administrative_area_level_2"
+                  ],
+                  "mapping": "boroughMap"
+                },
+                { "fieldId": "state", "source": "administrative_area_level_1" },
+                { "fieldId": "zip_code", "source": "postal_code" },
+                { "fieldId": "latitude", "source": "location.latitude" },
+                { "fieldId": "longitude", "source": "location.longitude" }
+              ]
+            },
+            "fields": [
+              {
+                "id": "street",
+                "label": "Street Address",
+                "type": "text",
+                "required": true,
+                "tooltip": "To edit home address click on NYC ModelCity in the top-left corner then click on Account Settings."
+              },
+              {
+                "id": "apt",
+                "label": "Apt #",
+                "type": "text",
+                "required": false
+              },
+              {
+                "id": "city",
+                "label": "City",
+                "type": "text",
+                "required": true
+              },
+              {
+                "id": "borough",
+                "label": "Borough",
+                "type": "select",
+                "required": true,
+                "ui": {
+                  "options": [
+                    "",
+                    "Bronx",
+                    "Brooklyn",
+                    "Manhattan",
+                    "Queens",
+                    "Staten Island"
+                  ]
+                }
+              },
+              {
+                "id": "state",
+                "label": "State",
+                "type": "text",
+                "required": true
+              },
+              {
+                "id": "zip_code",
+                "label": "Zip Code",
+                "type": "text",
+                "required": true
+              },
+              {
+                "id": "latitude",
+                "label": "Latitude",
+                "type": "number",
+                "required": false
+              },
+              {
+                "id": "longitude",
+                "label": "Longitude",
+                "type": "number",
+                "required": false
+              },
+              {
+                "id": "is_temporary_address",
+                "label": "Is Temporary Address",
+                "type": "radio",
+                "required": true,
+                "tooltip": "Check YES if you are currently living in a homeless shelter, doubled-up with another family, in a hotel/motel, in a car/ bus/ train, in a park/campsite, or other temporary accomodation.",
+                "ui": {
+                  "options": [
+                    "Yes",
+                    "No"
+                  ]
+                }
+              },
+              {
+                "id": "currently_living_in",
+                "label": "Currently Living In",
+                "type": "select",
+                "required": false,
+                "requiredCondition": {
+                  "field": "is_temporary_address",
+                  "operator": "equals",
+                  "value": "Yes"
+                },
+                "ui": {
+                  "options": [
+                    "",
+                    "Homeless Shelter",
+                    "Doubled-up with another Family",
+                    "Hotel/Motel",
+                    "Car, Bus, Train",
+                    "Park",
+                    "Campsite",
+                    "Other"
+                  ]
+                }
+              }
+            ]
+          },
+          {
+            "id": "demographics",
+            "title": "Demographics",
+            "fields": [
+              {
+                "id": "ethnicity",
+                "label": "Ethnicity",
+                "type": "select",
+                "required": false,
+                "ui": {
+                  "options": [
+                    "",
+                    "Hispanic",
+                    "Latino",
+                    "No",
+                    "Prefer not to answer"
+                  ]
+                }
+              },
+              {
+                "id": "race",
+                "label": "Race",
+                "type": "checkbox",
+                "required": false,
+                "tooltip": "You may choose multiple race categories. Providing race information is voluntary and will not affect your eligibility for Child Care Assistance or the amount of assistance that you will be given by this agency.",
+                "ui": {
+                  "options": [
+                    {
+                      "value": "AI",
+                      "label": "American Indian or Alaska Native"
+                    },
+                    {
+                      "value": "AS",
+                      "label": "Asian"
+                    },
+                    {
+                      "value": "BL",
+                      "label": "Black or African American"
+                    },
+                    {
+                      "value": "HP",
+                      "label": "Native Hawaiian or Pacific Islander"
+                    },
+                    {
+                      "value": "WH",
+                      "label": "White"
+                    }
+                  ]
+                },
+                "metadata": {
+                  "multiple": true
+                }
+              },
+              {
+                "id": "ssn",
+                "label": "Social Security Number",
+                "type": "text",
+                "tooltip": "To edit social security number click on NYC ModelCity in the top-left corner then click on Account Settings.",
+                "required": false,
+                "constraints": {
+                  "pattern": "^\\\\d{3}-\\\\d{2}-\\\\d{4}$"
+                },
+                "ui": {
+                  "placeholder": "123-45-6789"
+                }
+              }
+            ]
+          },
+          {
+            "id": "language_info",
+            "title": "Language Preferences",
+            "fields": [
+              {
+                "id": "primary_language",
+                "label": "Primary Language",
+                "type": "radio",
+                "required": true,
+                "tooltip": "Select the language that is spoken most often in your household. If “other”, provide the name of the language.",
+                "ui": {
+                  "options": [
+                    "English",
+                    "Spanish",
+                    "Other"
+                  ]
+                }
+              },
+              {
+                "id": "preferred_language",
+                "label": "Preferred Language",
+                "type": "radio",
+                "required": true,
+                "tooltip": "Select the language you prefer to communicate in. If “other”, provide the name of the language.",
+                "ui": {
+                  "options": [
+                    "English",
+                    "Spanish",
+                    "Other"
+                  ]
+                }
+              },
+              {
+                "id": "other_primary_language",
+                "label": "Other Primary Language",
+                "type": "text",
+                "required": false,
+                "requiredCondition": {
+                  "field": "primary_language",
+                  "operator": "equals",
+                  "value": "Other"
+                }
+              },
+              {
+                "id": "other_preferred_language",
+                "label": "Other Preferred Language",
+                "type": "text",
+                "required": false,
+                "requiredCondition": {
+                  "field": "preferred_language",
+                  "operator": "equals",
+                  "value": "Other"
+                }
+              }
+            ]
+          },
+          {
+            "id": "cash_assistance",
+            "title": "Cash Assistance",
+            "fields": [
+              {
+                "id": "has_cash_assistance",
+                "label": "Do you receive Cash Assistance?",
+                "type": "radio",
+                "required": false,
+                "ui": {
+                  "options": [
+                    "Yes",
+                    "No"
+                  ]
+                }
+              },
+              {
+                "id": "ca_number",
+                "label": "Cash Assistance Number",
+                "type": "text",
+                "required": false,
+                "requiredCondition": {
+                  "condition": {
+                    "field": "has_cash_assistance",
+                    "operator": "equals",
+                    "value": "Yes"
+                  }
+                }
+              }
+            ]
+          }
+        ]
+      },
+      {
+        "id": "children_needing_care",
+        "title": "Children Needing Care",
+        "sections": [
+          {
+            "id": "child_details",
+            "title": "Child Details",
+            "required": true,
+            "fields": [
+              {
+                "id": "children",
+                "label": "Children Needing Care",
+                "type": "group",
+                "metadata": {
+                  "multiple": true,
+                  "tableColumns": [
+                  "first_name",
+                  "last_name",
+                  "date_of_birth",
+                  "relationship_to_applicant"
+                  ]
+                },
+                "fields": [
+                  {
+                    "id": "first_name",
+                    "label": "First Name",
+                    "type": "text",
+                    "required": true,
+                    "tooltip": "Provide the first name, last name, and middle initial of each child you are applying for child care assistance for."
+                  },
+                  {
+                    "id": "last_name",
+                    "label": "Last Name",
+                    "type": "text",
+                    "required": true
+                  },
+                  {
+                    "id": "mi",
+                    "label": "Middle Initial",
+                    "type": "text",
+                    "required": false
+                  },
+                  {
+                    "id": "relationship_to_applicant",
+                    "label": "Relationship to Applicant",
+                    "type": "select",
+                    "required": true,
+                    "ui": {
+                      "options": [
+                        "",
+                        "Child",
+                        "Grandchild",
+                        "Foster Child",
+                        "Other"
+                      ]
+                    }
+                  },
+                  {
+                    "id": "date_of_birth",
+                    "label": "Date of Birth",
+                    "type": "date",
+                    "required": true,
+                    "tooltip": "Provide the date of birth."
+                  },
+                  {
+                    "id": "sex",
+                    "label": "Sex",
+                    "type": "radio",
+                    "required": true,
+                    "tooltip": "Select to indicate the sex.",
+                    "ui": {
+                      "options": [
+                        "Male",
+                        "Female"
+                      ]
+                    }
+                  },
+                  {
+                    "id": "ethnicity",
+                    "label": "Ethnicity Hispanic or Latino",
+                    "type": "select",
+                    "required": false,
+                    "tooltip": "Check “YES” or “NO” to indicate if each child in need of child care is Hispanic or Latino or not. Providing ethnicity information is voluntary and will not affect your eligibility for child care assistance or the amount of assistance that you will be given by this agency.",
+                    "ui": {
+                      "options": [
+                        "",
+                        "Yes",
+                        "No",
+                        "Prefer not to answer"
+                      ]
+                    }
+                  },
+                  {
+                    "id": "race",
+                    "label": "Race",
+                    "type": "checkbox",
+                    "required": false,
+                    "tooltip": "You may choose multiple race categories for a single child. Providing race information is voluntary and will not affect your eligibility for Child Care Assistance or the amount of assistance that you will be given by this agency.",
+                    "ui": {
+                      "options": [
+                        {
+                          "value": "AI",
+                          "label": "American Indian or Alaska Native"
+                        },
+                        {
+                          "value": "AS",
+                          "label": "Asian"
+                        },
+                        {
+                          "value": "BL",
+                          "label": "Black or African American"
+                        },
+                        {
+                          "value": "HP",
+                          "label": "Native Hawaiian or Pacific Islander"
+                        },
+                        {
+                          "value": "WH",
+                          "label": "White"
+                        }
+                      ]
+                    },
+                    "metadata": {
+                      "multiple": true
+                    }
+                  },
+                  {
+                    "id": "ssn",
+                    "label": "Social Security Number",
+                    "type": "text",
+                    "required": false,
+                    "tooltip": "Provide each child’s Social Security Number (SSN). You are not required to provide SSNs. They may be used by federal, state, and local agencies to prevent duplication of services and fraud, and for Federal Reporting.",
+                    "constraints": {
+                      "pattern": "^\\\\d{3}-\\\\d{2}-\\\\d{4}$"
+                    },
+                    "ui": {
+                      "placeholder": "123-45-6789"
+                    }
+                  },
+                  {
+                    "id": "do_both_parents_reside_in_home",
+                    "label": "Do both parents reside in the home?",
+                    "type": "radio",
+                    "required": true,
+                    "tooltip": "Check “YES” or “NO” to indicate whether both of the child’s parents live in the home.",
+                    "ui": {
+                      "options": [
+                        "Yes",
+                        "No"
+                      ]
+                    }
+                  },
+                  {
+                    "id": "has_disability",
+                    "label": "Does the child have a disability?",
+                    "type": "radio",
+                    "required": true,
+                    "tooltip": "Check “YES” or “NO” to indicate whether the child needing child care has a disability.",
+                    "ui": {
+                      "options": [
+                        "Yes",
+                        "No"
+                      ]
+                    }
+                  },
+                  {
+                    "id": "is_immigration_status_satisfactory",
+                    "label": "Is child U.S. Citizen, U.S. National, or person with satisfactory immigration status?",
+                    "type": "radio",
+                    "required": true,
+                    "tooltip": "You will only be asked about the immigration status of the children in need of care. Other members of the family will not need to state or prove their immigration status. Your child will be eligible for care if they are a U.S. citizen, a legal permanent resident (green card holder), a refugee, or an asylee; have a T-visa; or hold another qualified immigration status. Please select “Yes” if your child holds one of these statuses.",
+                    "ui": {
+                      "options": [
+                        "Yes",
+                        "No"
+                      ]
+                    }
+                  }
+                ]
+              }
+            ]
+          }
+        ]
+      },
+      {
+        "id": "family_members",
+        "title": "Family Members",
+        "sections": [
+          {
+            "id": "household_members_info",
+            "title": "Household Members Information",
+            "type": "info",
+            "ui": {
+              "markdown": true,
+              "collapsible": false,
+              "defaultCollapsed": false
+            },
+            "content": "**List the household members who do _not_ need child care.**\\n\\nIf applicable, list:\\n\\n- Your **spouse**, your child’s **second parent**, **caretaker**, or **step-parent**\\n- Any other **adult with whom you share a child**, if they live in your home\\n\\nThen, if applicable, list:\\n\\n- Any **siblings under the age of 18** who live in your home\\n\\n> **Only list other household members** — such as **aunts, uncles, cousins, grandparents, or friends** — _if they have financial responsibility_ for the child.\\n\\nA household member with financial responsibility, other than a parent or step-parent, is one who has a **letter or order of guardianship**.\\n\\n**Otherwise, do not include them.**"
+          },
+          {
+            "id": "family_member_details",
+            "title": "Household Member Details",
+            "description": "Include household members who do not need child care assistance (e.g., spouse, partner, other children).",
+            "fields": [
+              {
+                "id": "familymember",
+                "label": "Family Members",
+                "type": "group",
+                "requiredCondition": {
+                  "repeatingGroup": "children",
+                  "operator": "ANY",
+                  "condition": { "field": "do_both_parents_reside_in_home", "operator": "equals", "value": "Yes" }
+                },  
+                "metadata": {
+                  "multiple": true,
+                  "tableColumns": [
+                    "first_name",
+                    "last_name",
+                    "relationship_to_applicant",
+                    "date_of_birth"
+                  ]
+                },
+                "fields": [
+                  {
+                    "id": "first_name",
+                    "label": "First Name",
+                    "type": "text",
+                    "required": true,
+                    "tooltip": "Provide last and first name, and middle initial if applicable."
+                  },
+                  {
+                    "id": "last_name",
+                    "label": "Last Name",
+                    "type": "text",
+                    "required": true
+                  },
+                  {
+                    "id": "mi",
+                    "label": "Middle Initial",
+                    "type": "text",
+                    "required": false
+                  },
+                  {
+                    "id": "relationship_to_applicant",
+                    "label": "Relationship to Applicant",
+                    "type": "select",
+                    "required": true,
+                    "tooltip": "Provide each person’s relationship to you (e.g. spouse, partner, child, foster parent, other).",
+                    "ui": {
+                      "options": [
+                        "",
+                        "Spouse",
+                        "Partner",
+                        "Foster Parent",
+                        "Child",
+                        "Other"
+                      ]
+                    }
+                  },
+                  {
+                    "id": "date_of_birth",
+                    "label": "Date of Birth",
+                    "type": "date",
+                    "required": true,
+                    "tooltip": "Provide the family member's date of birth."
+                  },
+                  {
+                    "id": "sex",
+                    "label": "Sex",
+                    "type": "radio",
+                    "required": true,
+                    "tooltip": "Indicate the sex for each family member listed.",
+                    "ui": {
+                      "options": [
+                        "Male",
+                        "Female"
+                      ]
+                    }
+                  },
+                  {
+                    "id": "ethnicity",
+                    "label": "Ethnicity Hispanic or Latino",
+                    "type": "select",
+                    "required": false,
+                    "tooltip": "Check “YES” or “NO” to indicate if each member in the household is Hispanic or Latino or not. Providing ethnicity information is voluntary and will not affect your eligibility for Child Care Assistance or the amount of assistance that you will be given by this agency.",
+                    "ui": {
+                      "options": [
+                        "",
+                        "Yes",
+                        "No",
+                        "Prefer not to answer"
+                      ]
+                    }
+                  },
+                  {
+                    "id": "race",
+                    "label": "Race",
+                    "type": "checkbox",
+                    "required": false,
+                    "tooltip": "You may choose multiple race categories for a single person. Providing race information is voluntary and will not affect your eligibility for Child Care Assistance or the amount of assistance that you will be given by this agency.",
+                    "ui": {
+                      "options": [
+                        {
+                          "value": "AI",
+                          "label": "American Indian or Alaska Native"
+                        },
+                        {
+                          "value": "AS",
+                          "label": "Asian"
+                        },
+                        {
+                          "value": "BL",
+                          "label": "Black or African American"
+                        },
+                        {
+                          "value": "HP",
+                          "label": "Native Hawaiian or Pacific Islander"
+                        },
+                        {
+                          "value": "WH",
+                          "label": "White"
+                        }
+                      ]
+                    },
+                    "metadata": {
+                      "multiple": true
+                    }
+                  },
+                  {
+                    "id": "ssn",
+                    "label": "Social Security Number",
+                    "type": "text",
+                    "required": false,
+                    "tooltip": "Fill in the Social Security Number (SSN) for your family members. SSN is optional. SSN may be used by federal, state, and local agencies to prevent duplication of services and fraud, and for Federal Reporting.",
+                    "constraints": {
+                      "pattern": "^\\\\d{3}-\\\\d{2}-\\\\d{4}$"
+                    },
+                    "ui": {
+                      "placeholder": "123-45-6789"
+                    }
+                  }
+                ]
+              }
+            ]
+          }
+        ]
+      },
+      {
+        "id": "child_family_needs",
+        "title": "Child / Family Needs",
+        "sections": [
+          {
+            "id": "assistance_reason",
+            "title": "Reason for Child Care Assistance",
+            "description": "Select one or two reasons you are requesting Child Care Assistance.",
+            "tooltip": "Select one reason. In a two-parent household, parents/caretakers can have the same or different reasons for needing child care. Both parents/caretakers will be required to submit documentation in support of their own reason. If you are living in temporary housing, please select Homelessness even if you have another reason that applies to you.",
+            "fields": [
+              {
+                "id": "assistance_reason",
+                "label": "Reason(s) for Assistance",
+                "type": "select",
+                "required": true,
+                "ui": {
+                  "options": [
+                    "",
+                    "Employment",
+                    "Looking for Work",
+                    "Vocational Training/Educational Activities",
+                    "Receiving Domestic Violence Services",
+                    "Homelessness"
+                  ]
+                },
+                "constraints": {
+                  "minSelections": 1,
+                  "maxSelections": 2
+                },
+                "metadata": {
+                  "multiple": true
+                }
+              }
+            ]
+          },
+          {
+            "id": "military_status",
+            "title": "Military and Parental Availability",
+            "description": "Provide information about parental military status and availability for child care.",
+            "fields": [
+              {
+                "id": "is_parent_currently_active_in_military",
+                "label": "Is a Parent Currently Active Full-Time in the U.S. Military?",
+                "tooltip": "Check “YES” or “NO” to indicate whether a parent is currently active full-time in the U.S. Military.",
+                "type": "radio",
+                "required": true,
+                "ui": {
+                  "options": [
+                    "Yes",
+                    "No"
+                  ]
+                }
+              },
+              {
+                "id": "is_parent_mem_of_guard_or_mru",
+                "label": "Is a Parent a Member of National Guard or Military Reserve Unit?",
+                "tooltip": "Check “YES” or “NO” to indicate whether a parent is currently a member of a National Guard or Military Reserve Unit.",
+                "type": "radio",
+                "required": true,
+                "ui": {
+                  "options": [
+                    "Yes",
+                    "No"
+                  ]
+                }
+              },
+              {
+                "id": "is_non_custodial_parent_available",
+                "label": "Is the Non-Custodial Parent Available to Provide Care?",
+                "tooltip": "Check “YES” or “NO” to indicate whether there is a non-custodial parent available to provide child care.",
+                "type": "radio",
+                "required": true,
+                "ui": {
+                  "options": [
+                    "Yes",
+                    "No"
+                  ]
+                }
+              }
+            ]
+          },
+          {
+            "id": "duplicate_application",
+            "title": "Other Applications",
+            "description": "Indicate if you are also applying for or receiving child care from other agencies.",
+            "tooltip": "Indicate whether you are currently receiving or have applied for child care assistance with one of the agencies or organizations listed below. Note: If you are receiving Cash Assistance and are interested in child care assistance, you must apply through the Human Resources Administration. Reach out to your Benefits Access Center or visit the Human Resources Administration webpage.",
+            "fields": [
+              {
+                "id": "duplicate_app",
+                "label": "Are You Receiving or Applying for Child Care Through Another Agency?",
+                "type": "select",
+                "required": false,
+                "ui": {
+                  "options": [
+                    "",
+                    "Not Applicable",
+                    "Department of Education (DOE)",
+                    "Human Resources Administration (HRA)",
+                    "Department of Youth and Community Development (DYCD)",
+                    "Department of Homeless Services (DHS)",
+                    "Consortium for Worker Education (CWE)",
+                    "Administration for Children's Services (ACS)"
+                  ]
+                }
+              }
+            ]
+          }
+        ]
+      },
+      {
+        "id": "employment",
+        "title": "Employment",
+        "sections": [
+          {
+            "id": "employment_precheck",
+            "title": "Tell us about your employment",
+            "description": "Tell us about your employment",
+            "fields": [
+              {
+                "id": "applicant_emp_income_indicator",
+                "label": "Does applicant earn any income/ wages from employment? ",
+                "type": "radio",
+                "required": false,
+                "ui": {
+                  "options": [
+                    "Yes",
+                    "No"
+                  ]
+                }
+              },
+              {
+                "id": "coparent_emp_income_indicator",
+                "label": "Does Coparent/2nd Guardian earn any income/ wages from employment? ",
+                "type": "radio",
+                "required": false,
+                "ui": {
+                  "options": [
+                    "Yes",
+                    "No"
+                  ]
+                }
+              }
+            ]
+          },
+          {
+            "id": "applicant_jobs",
+            "title": "Applicant Employment Information",
+            "description": "Enter details for up to two jobs held by the applicant.",
+            "visibilityCondition": {
+              "field": "applicant_emp_income_indicator",
+              "operator": "equals",
+              "value": "Yes"
+            },
+            "fields": [
+              {
+                "id": "applicant_1st_job_start_date",
+                "label": "1st Job - Start Date",
+                "type": "date",
+                "required": false,
+                "ui": {
+                  "group": "1st Job"
+                }
+              },
+              {
+                "id": "applicant_1st_job_rotating_shift",
+                "label": "1st Job - Has Rotating Shift?",
+                "type": "radio",
+                "required": false,
+                "ui": {
+                  "options": [
+                    "Yes",
+                    "No"
+                  ],
+                  "group": "1st Job"
+                }
+              },
+              {
+                "id": "applicant_1st_job_requires_overtime",
+                "label": "1st Job - Requires Overtime?",
+                "type": "radio",
+                "required": false,
+                "ui": {
+                  "options": [
+                    "Yes",
+                    "No"
+                  ],
+                  "group": "1st Job"
+                }
+              },
+              {
+                "id": "applicant_1st_job_employer_name",
+                "label": "1st Job - Employer Name",
+                "type": "text",
+                "required": false,
+                "ui": {
+                  "group": "1st Job"
+                }
+              },
+              {
+                "id": "applicant_1st_job_employer_phone",
+                "label": "1st Job - Employer Phone",
+                "type": "tel",
+                "required": false,
+                "ui": {
+                  "group": "1st Job"
+                }
+              },
+              {
+                "id": "applicant_1st_job_employer_street",
+                "label": "1st Job - Employer Street Address",
+                "type": "text",
+                "required": false,
+                "ui": {
+                  "group": "1st Job"
+                }
+              },
+              {
+                "id": "applicant_1st_job_employer_city",
+                "label": "1st Job - Employer City",
+                "type": "text",
+                "required": false,
+                "ui": {
+                  "group": "1st Job"
+                }
+              },
+              {
+                "id": "applicant_1st_job_employer_state",
+                "label": "1st Job - Employer State",
+                "type": "text",
+                "required": false,
+                "ui": {
+                  "group": "1st Job"
+                }
+              },
+              {
+                "id": "applicant_1st_job_employer_zipcode",
+                "label": "1st Job - Employer ZIP Code",
+                "type": "text",
+                "required": false,
+                "ui": {
+                  "group": "1st Job"
+                }
+              },
+              {
+                "id": "applicant_2nd_job_start_date",
+                "label": "2nd Job - Start Date",
+                "type": "date",
+                "required": false,
+                "ui": {
+                  "group": "2nd Job"
+                }
+              },
+              {
+                "id": "applicant_2nd_job_rotating_shift",
+                "label": "2nd Job - Has Rotating Shift?",
+                "type": "radio",
+                "required": false,
+                "ui": {
+                  "options": [
+                    "Yes",
+                    "No"
+                  ],
+                  "group": "2nd Job"
+                }
+              },
+              {
+                "id": "applicant_2nd_job_requires_overtime",
+                "label": "2nd Job - Requires Overtime?",
+                "type": "radio",
+                "required": false,
+                "ui": {
+                  "options": [
+                    "Yes",
+                    "No"
+                  ],
+                  "group": "2nd Job"
+                }
+              },
+              {
+                "id": "applicant_2nd_job_employer_name",
+                "label": "2nd Job - Employer Name",
+                "type": "text",
+                "required": false,
+                "ui": {
+                  "group": "2nd Job"
+                }
+              },
+              {
+                "id": "applicant_2nd_job_employer_phone",
+                "label": "2nd Job - Employer Phone",
+                "type": "tel",
+                "required": false,
+                "ui": {
+                  "group": "2nd Job"
+                }
+              },
+              {
+                "id": "applicant_2nd_job_employer_street",
+                "label": "2nd Job - Employer Street Address",
+                "type": "text",
+                "required": false,
+                "ui": {
+                  "group": "2nd Job"
+                }
+              },
+              {
+                "id": "applicant_2nd_job_employer_city",
+                "label": "2nd Job - Employer City",
+                "type": "text",
+                "required": false,
+                "ui": {
+                  "group": "2nd Job"
+                }
+              },
+              {
+                "id": "applicant_2nd_job_employer_state",
+                "label": "2nd Job - Employer State",
+                "type": "text",
+                "required": false,
+                "ui": {
+                  "group": "2nd Job"
+                }
+              },
+              {
+                "id": "applicant_2nd_job_employer_zipcode",
+                "label": "2nd Job - Employer ZIP Code",
+                "type": "text",
+                "required": false,
+                "ui": {
+                  "group": "2nd Job"
+                }
+              }
+            ]
+          },
+          {
+            "id": "second_parent_jobs",
+            "title": "Second Parent Employment Information",
+            "description": "Enter details for up to two jobs held by the second parent (if applicable).",
+            "visibilityCondition": {
+              "field": "coparent_emp_income_indicator",
+              "operator": "equals",
+              "value": "Yes"
+            },
+            "fields": [
+              {
+                "id": "second_parent_1st_job_start_date",
+                "label": "1st Job - Start Date",
+                "type": "date",
+                "required": false
+              },
+              {
+                "id": "second_parent_1st_job_rotating_shift",
+                "label": "1st Job - Has Rotating Shift?",
+                "type": "radio",
+                "required": false,
+                "ui": {
+                  "options": [
+                    "Yes",
+                    "No"
+                  ]
+                }
+              },
+              {
+                "id": "second_parent_1st_job_requires_overtime",
+                "label": "1st Job - Requires Overtime?",
+                "type": "radio",
+                "required": false,
+                "ui": {
+                  "options": [
+                    "Yes",
+                    "No"
+                  ]
+                }
+              },
+              {
+                "id": "second_parent_1st_job_employer_name",
+                "label": "1st Job - Employer Name",
+                "type": "text",
+                "required": false
+              },
+              {
+                "id": "second_parent_1st_job_employer_phone",
+                "label": "1st Job - Employer Phone",
+                "type": "tel",
+                "required": false
+              },
+              {
+                "id": "second_parent_1st_job_employer_street",
+                "label": "1st Job - Employer Street Address",
+                "type": "text",
+                "required": false
+              },
+              {
+                "id": "second_parent_1st_job_employer_city",
+                "label": "1st Job - Employer City",
+                "type": "text",
+                "required": false
+              },
+              {
+                "id": "second_parent_1st_job_employer_state",
+                "label": "1st Job - Employer State",
+                "type": "text",
+                "required": false
+              },
+              {
+                "id": "second_parent_1st_job_employer_zipcode",
+                "label": "1st Job - Employer ZIP Code",
+                "type": "text",
+                "required": false
+              },
+              {
+                "id": "second_parent_2nd_job_start_date",
+                "label": "2nd Job - Start Date",
+                "type": "date",
+                "required": false
+              },
+              {
+                "id": "second_parent_2nd_job_rotating_shift",
+                "label": "2nd Job - Has Rotating Shift?",
+                "type": "radio",
+                "required": false,
+                "ui": {
+                  "options": [
+                    "Yes",
+                    "No"
+                  ]
+                }
+              },
+              {
+                "id": "second_parent_2nd_job_requires_overtime",
+                "label": "2nd Job - Requires Overtime?",
+                "type": "radio",
+                "required": false,
+                "ui": {
+                  "options": [
+                    "Yes",
+                    "No"
+                  ]
+                }
+              },
+              {
+                "id": "second_parent_2nd_job_employer_name",
+                "label": "2nd Job - Employer Name",
+                "type": "text",
+                "required": false
+              },
+              {
+                "id": "second_parent_2nd_job_employer_phone",
+                "label": "2nd Job - Employer Phone",
+                "type": "tel",
+                "required": false
+              },
+              {
+                "id": "second_parent_2nd_job_employer_street",
+                "label": "2nd Job - Employer Street Address",
+                "type": "text",
+                "required": false
+              },
+              {
+                "id": "second_parent_2nd_job_employer_city",
+                "label": "2nd Job - Employer City",
+                "type": "text",
+                "required": false
+              },
+              {
+                "id": "second_parent_2nd_job_employer_state",
+                "label": "2nd Job - Employer State",
+                "type": "text",
+                "required": false
+              },
+              {
+                "id": "second_parent_2nd_job_employer_zipcode",
+                "label": "2nd Job - Employer ZIP Code",
+                "type": "text",
+                "required": false
+              }
+            ]
+          }
+        ]
+      },
+      {
+        "id": "schedule",
+        "title": "Work/Activity/Travel Time Schedule",
+        "sections": [
+          {
+            "id": "schedule_section_info",
+            "title": "Schedule Information",
+            "type": "info",
+            "ui": {
+              "markdown": true,
+              "collapsible": false,
+              "defaultCollapsed": false
+            },
+            "content": "Please indicate what days and hours you will need child care for based on your reason for care.\\n\\n- **Employed**: Indicate the hours you attend work\\n- **Educational or Vocational Program**: Indicate the hours you attend school or your program\\n- **Looking for Work**: Indicate the hours you spend looking for work\\n- **Homeless**: Indicate the hours you spend looking for housing\\n- **Attending Services for Domestic Violence**: Indicate the hours you attend services.\\n- **Attending Services for Substance Abuse Treatment**: Indicate the hours you attend services."
+          },
+          {
+            "id": "first_parent_activity_schedule",
+            "title": "First Parent Activity Schedule",
+            "description": "Enter the start and end times for each day of the week for the first parent's activities.",
+            "ui": {
+              "layout": "table",
+              "columns": [
+                "Start Time",
+                "End Time"
+              ],
+              "rowCopy": {
+                "enableUserPickSource": true,
+                "rowIdentifier": "ui.rowGroup",
+                "fieldsToCopy": [
+                  1,
+                  2
+                ],
+                "targetRowValues": [
+                  "Monday",
+                  "Tuesday",
+                  "Wednesday",
+                  "Thursday",
+                  "Friday"
+                ],
+                "copyControlLabel": "Apply selected schedule to other weekdays",
+                "sourceOptions": [
+                  "Monday",
+                  "Tuesday",
+                  "Wednesday",
+                  "Thursday",
+                  "Friday",
+                  "Saturday",
+                  "Sunday"
+                ]
+              }
+            },
+            "fields": [
+              {
+                "id": "fp_monday_from",
+                "label": "Monday From",
+                "type": "time",
+                "ui": {
+                  "rowGroup": "Monday",
+                  "column": 1
+                }
+              },
+              {
+                "id": "fp_monday_to",
+                "label": "Monday To",
+                "type": "time",
+                "ui": {
+                  "rowGroup": "Monday",
+                  "column": 2
+                }
+              },
+              {
+                "id": "fp_tuesday_from",
+                "label": "Tuesday From",
+                "type": "time",
+                "ui": {
+                  "rowGroup": "Tuesday",
+                  "column": 1
+                }
+              },
+              {
+                "id": "fp_tuesday_to",
+                "label": "Tuesday To",
+                "type": "time",
+                "ui": {
+                  "rowGroup": "Tuesday",
+                  "column": 2
+                }
+              },
+              {
+                "id": "fp_wednesday_from",
+                "label": "Wednesday From",
+                "type": "time",
+                "ui": {
+                  "rowGroup": "Wednesday",
+                  "column": 1
+                }
+              },
+              {
+                "id": "fp_wednesday_to",
+                "label": "Wednesday To",
+                "type": "time",
+                "ui": {
+                  "rowGroup": "Wednesday",
+                  "column": 2
+                }
+              },
+              {
+                "id": "fp_thursday_from",
+                "label": "Thursday From",
+                "type": "time",
+                "ui": {
+                  "rowGroup": "Thursday",
+                  "column": 1
+                }
+              },
+              {
+                "id": "fp_thursday_to",
+                "label": "Thursday To",
+                "type": "time",
+                "ui": {
+                  "rowGroup": "Thursday",
+                  "column": 2
+                }
+              },
+              {
+                "id": "fp_friday_from",
+                "label": "Friday From",
+                "type": "time",
+                "ui": {
+                  "rowGroup": "Friday",
+                  "column": 1
+                }
+              },
+              {
+                "id": "fp_friday_to",
+                "label": "Friday To",
+                "type": "time",
+                "ui": {
+                  "rowGroup": "Friday",
+                  "column": 2
+                }
+              },
+              {
+                "id": "fp_saturday_from",
+                "label": "Saturday From",
+                "type": "time",
+                "ui": {
+                  "rowGroup": "Saturday",
+                  "column": 1
+                }
+              },
+              {
+                "id": "fp_saturday_to",
+                "label": "Saturday To",
+                "type": "time",
+                "ui": {
+                  "rowGroup": "Saturday",
+                  "column": 2
+                }
+              },
+              {
+                "id": "fp_sunday_from",
+                "label": "Sunday From",
+                "type": "time",
+                "ui": {
+                  "rowGroup": "Sunday",
+                  "column": 1
+                }
+              },
+              {
+                "id": "fp_sunday_to",
+                "label": "Sunday To",
+                "type": "time",
+                "ui": {
+                  "rowGroup": "Sunday",
+                  "column": 2
+                }
+              }
+            ]
+          },
+          {
+            "id": "second_parent_activity_schedule",
+            "title": "Second Parent Activity Schedule",
+            "description": "Enter the start and end times for each day of the week for the second parent's activities.",
+            "ui": {
+              "layout": "table",
+              "columns": [
+                "Start Time",
+                "End Time"
+              ],
+              "rowCopy": {
+                "enableUserPickSource": true,
+                "rowIdentifier": "ui.rowGroup",
+                "fieldsToCopy": [
+                  1,
+                  2
+                ],
+                "targetRowValues": [
+                  "Monday",
+                  "Tuesday",
+                  "Wednesday",
+                  "Thursday",
+                  "Friday"
+                ],
+                "copyControlLabel": "Apply selected schedule to other weekdays",
+                "sourceOptions": [
+                  "Monday",
+                  "Tuesday",
+                  "Wednesday",
+                  "Thursday",
+                  "Friday",
+                  "Saturday",
+                  "Sunday"
+                ]
+              }
+            },
+            "fields": [
+              {
+                "id": "sp_monday_from",
+                "label": "Monday From",
+                "type": "time",
+                "ui": {
+                  "rowGroup": "Monday",
+                  "column": 1
+                }
+              },
+              {
+                "id": "sp_monday_to",
+                "label": "Monday To",
+                "type": "time",
+                "ui": {
+                  "rowGroup": "Monday",
+                  "column": 2
+                }
+              },
+              {
+                "id": "sp_tuesday_from",
+                "label": "Tuesday From",
+                "type": "time",
+                "ui": {
+                  "rowGroup": "Tuesday",
+                  "column": 1
+                }
+              },
+              {
+                "id": "sp_tuesday_to",
+                "label": "Tuesday To",
+                "type": "time",
+                "ui": {
+                  "rowGroup": "Tuesday",
+                  "column": 2
+                }
+              },
+              {
+                "id": "sp_wednesday_from",
+                "label": "Wednesday From",
+                "type": "time",
+                "ui": {
+                  "rowGroup": "Wednesday",
+                  "column": 1
+                }
+              },
+              {
+                "id": "sp_wednesday_to",
+                "label": "Wednesday To",
+                "type": "time",
+                "ui": {
+                  "rowGroup": "Wednesday",
+                  "column": 2
+                }
+              },
+              {
+                "id": "sp_thursday_from",
+                "label": "Thursday From",
+                "type": "time",
+                "ui": {
+                  "rowGroup": "Thursday",
+                  "column": 1
+                }
+              },
+              {
+                "id": "sp_thursday_to",
+                "label": "Thursday To",
+                "type": "time",
+                "ui": {
+                  "rowGroup": "Thursday",
+                  "column": 2
+                }
+              },
+              {
+                "id": "sp_friday_from",
+                "label": "Friday From",
+                "type": "time",
+                "ui": {
+                  "rowGroup": "Friday",
+                  "column": 1
+                }
+              },
+              {
+                "id": "sp_friday_to",
+                "label": "Friday To",
+                "type": "time",
+                "ui": {
+                  "rowGroup": "Friday",
+                  "column": 2
+                }
+              },
+              {
+                "id": "sp_saturday_from",
+                "label": "Saturday From",
+                "type": "time",
+                "ui": {
+                  "rowGroup": "Saturday",
+                  "column": 1
+                }
+              },
+              {
+                "id": "sp_saturday_to",
+                "label": "Saturday To",
+                "type": "time",
+                "ui": {
+                  "rowGroup": "Saturday",
+                  "column": 2
+                }
+              },
+              {
+                "id": "sp_sunday_from",
+                "label": "Sunday From",
+                "type": "time",
+                "ui": {
+                  "rowGroup": "Sunday",
+                  "column": 1
+                }
+              },
+              {
+                "id": "sp_sunday_to",
+                "label": "Sunday To",
+                "type": "time",
+                "ui": {
+                  "rowGroup": "Sunday",
+                  "column": 2
+                }
+              }
+            ]
+          },
+          {
+            "id": "first_parent_travel_time",
+            "title": "First Parent Travel Time",
+            "description": "Enter the travel times and method of transport for the first parent.",
+            "fields": [
+              {
+                "id": "fp_dropoff_travel_time",
+                "label": "Drop-off Travel Time",
+                "type": "select",
+                "tooltip": "Select your typical travel time from work/activity to your child care provider",
+                "ui": {
+                  "options": [
+                    "",
+                    "15 min",
+                    "30 min",
+                    "45 min",
+                    "1 hour",
+                    "More than 1 hour"
+                  ]
+                }
+              },
+              {
+                "id": "fp_dropoff_time_gt_1hr",
+                "label": "Drop-off Time (if > 1 hour)",
+                "type": "text",
+                "requiredCondition": {
+                  "field": "fp_dropoff_travel_time",
+                  "operator": "equals",
+                  "value": "More than 1 hour"
+                }
+              },
+              {
+                "id": "fp_pickup_travel_time",
+                "label": "Pick-up Travel Time",
+                "type": "select",
+                "tooltip": "Select your typical travel time from work/activity to your child care provider",
+                "ui": {
+                  "options": [
+                    "",
+                    "15 min",
+                    "30 min",
+                    "45 min",
+                    "1 hour",
+                    "More than 1 hour"
+                  ]
+                }
+              },
+              {
+                "id": "fp_pickup_time_gt_1hr",
+                "label": "Pick-up Time (if > 1 hour)",
+                "type": "text",
+                "requiredCondition": {
+                  "field": "fp_pickup_travel_time",
+                  "operator": "equals",
+                  "value": "More than 1 hour"
+                }
+              },
+              {
+                "id": "fp_public_transport_dropoff",
+                "label": "Public Transport for Drop-off?",
+                "type": "radio",
+                "tooltip": "Indicate if the applicant uses public transportation to travel to and from work/activity to provider.",
+                "ui": {
+                  "options": [
+                    "Yes",
+                    "No"
+                  ]
+                }
+              },
+              {
+                "id": "fp_public_transport_pickup",
+                "label": "Public Transport for Pick-up?",
+                "tooltip": "Indicate if the applicant uses public transportation to travel to and from work/activity to provider.",
+                "type": "radio",
+                "ui": {
+                  "options": [
+                    "Yes",
+                    "No"
+                  ]
+                }
+              }
+            ]
+          },
+          {
+            "id": "second_parent_travel_time",
+            "title": "Second Parent Travel Time",
+            "description": "Enter the travel times and method of transport for the second parent.",
+            "fields": [
+              {
+                "id": "sp_dropoff_travel_time",
+                "label": "Drop-off Travel Time",
+                "type": "select",
+                "ui": {
+                  "options": [
+                    "",
+                    "15 min",
+                    "30 min",
+                    "45 min",
+                    "1 hour",
+                    "More than 1 hour"
+                  ]
+                }
+              },
+              {
+                "id": "sp_pickup_travel_time",
+                "label": "Pick-up Travel Time",
+                "type": "select",
+                "ui": {
+                  "options": [
+                    "",
+                    "15 min",
+                    "30 min",
+                    "45 min",
+                    "1 hour",
+                    "More than 1 hour"
+                  ]
+                }
+              },
+              {
+                "id": "sp_dropoff_time_gt_1hr",
+                "label": "Drop-off Time (if > 1 hour)",
+                "type": "text",
+                "requiredCondition": {
+                  "field": "sp_dropoff_travel_time",
+                  "operator": "equals",
+                  "value": "More than 1 hour"
+                }
+              },
+              {
+                "id": "sp_pickup_time_gt_1hr",
+                "label": "Pick-up Time (if > 1 hour)",
+                "type": "text",
+                "requiredCondition": {
+                  "field": "sp_pickup_travel_time",
+                  "operator": "equals",
+                  "value": "More than 1 hour"
+                }
+              },
+              {
+                "id": "sp_public_transport_dropoff",
+                "label": "Public Transport for Drop-off?",
+                "type": "radio",
+                "ui": {
+                  "options": [
+                    "Yes",
+                    "No"
+                  ]
+                }
+              },
+              {
+                "id": "sp_public_transport_pickup",
+                "label": "Public Transport for Pick-up?",
+                "type": "radio",
+                "ui": {
+                  "options": [
+                    "Yes",
+                    "No"
+                  ]
+                }
+              }
+            ]
+          }
+        ]
+      },
+      {
+        "id": "income",
+        "title": "Income Information",
+        "sections": [
+          {
+            "id": "income_step_info",
+            "title": "Instructions",
+            "type": "info",
+            "ui": {
+              "markdown": true,
+              "collapsible": false,
+              "defaultCollapsed": false
+            },
+            "content": "Please include income/benefits information for yourself and, if applicable, your spouse, your child’s second caretaker, and/or any other adult with whom you share a child, if they live in your home.\\n\\nIndicate if you receive money from the following sources by selecting “Yes” or “No.” If you select “Yes,” you will be asked for additional information.\\n\\nIf the second caretaker in the household also receives the same income source, add a separate line for their income."
+          },
+          {
+            "id": "income_sources",
+            "title": "Income Sources",
+            "description": "Provide details about all income sources applicable to the applicant or household.",
+            "fields": [
+              {
+                "id": "income_sources",
+                "label": "List of Income Sources",
+                "type": "group",
+                "metadata": {
+                  "multiple": true,
+                  "tableColumns": [
+                    "name_ref",
+                    "how_often",
+                    "recipient",
+                    "monthly_amount"
+                  ]
+                },
+                "fields": [
+                  {
+                    "id": "name_ref",
+                    "label": "Income Source Type",
+                    "type": "select",
+                    "required": true,
+                    "ui": {
+                      "options": [
+                        "",
+                        "ApplicantWages",
+                        "SecondParentWages",
+                        "SelfEmployment",
+                        "ChildSupport",
+                        "Alimony",
+                        "Unemployment",
+                        "SocialSecurity",
+                        "Disability",
+                        "Rental",
+                        "Dividends",
+                        "Retirement",
+                        "CashAssistance",
+                        "Other"
+                      ]
+                    }
+                  },
+                  {
+                    "id": "other_source_text",
+                    "label": "Other Source (If applicable)",
+                    "type": "text",
+                    "visibilityCondition": {
+                      "field": "name_ref",
+                      "operator": "equals",
+                      "value": "Other"
+                    },
+                    "requiredCondition": {
+                      "condition": {
+                        "field": "name_ref",
+                        "operator": "equals",
+                        "value": "Other"
+                      }
+                    }
+                  },
+                  {
+                    "id": "is_source_applicable",
+                    "label": "Is this Source Applicable?",
+                    "type": "radio",
+                    "required": true,
+                    "ui": {
+                      "options": [
+                        "Yes",
+                        "No"
+                      ]
+                    }
+                  },
+                  {
+                    "id": "gross_amount",
+                    "label": "Gross Amount ($)",
+                    "type": "number",
+                    "required": true
+                  },
+                  {
+                    "id": "how_often",
+                    "label": "Frequency of Income",
+                    "type": "radio",
+                    "required": true,
+                    "ui": {
+                      "options": [
+                        "Weekly",
+                        "Bi-weekly",
+                        "Monthly",
+                        "Other"
+                      ]
+                    }
+                  },
+                  {
+                    "id": "recipient",
+                    "label": "Recipient of Income",
+                    "type": "text",
+                    "required": true
+                  },
+                  {
+                    "id": "monthly_amount",
+                    "label": "Monthly Amount ($)",
+                    "type": "number",
+                    "required": true
+                  }
+                ]
+              }
+            ]
+          },
+          {
+            "id": "total_income",
+            "title": "Total Household Income",
+            "description": "Sum of all monthly income across sources.",
+            "fields": [
+              {
+                "id": "total_income",
+                "label": "Total Monthly Income ($)",
+                "type": "number",
+                "required": true
+              }
+            ]
+          },
+          {
+            "id": "income_proof_section",
+            "title": "Income Proof",
+            "fields": [
+              {
+                "id": "income_proof",
+                "label": "Upload Income Proof",
+                "type": "file",
+                "requiredCondition": {
+                  "condition": {
+                    "field": "assistance_reason",
+                    "operator": "includes",
+                    "value": "Employment"
+                  }
+                },
+                "constraints": {
+                  "maxFileSizeMB": 5,
+                  "allowedTypes": [
+                    "application/pdf",
+                    "image/jpeg"
+                  ],
+                  "imageResolution": {
+                    "minWidth": 800,
+                    "minHeight": 600
+                  }
+                },
+                "metadata": {
+                  "proofCategory": "Income Verification",
+                  "examples": [
+                    "Pay Stub",
+                    "W-2"
+                  ],
+                  "multiple": true
+                }
+              }
+            ]
+          }
+        ]
+      },
+      {
+        "id": "provider",
+        "title": "Provider",
+        "sections": [
+          {
+            "id": "provider_step_info",
+            "title": "Instructions",
+            "type": "info",
+            "ui": {
+              "markdown": true,
+              "collapsible": false,
+              "defaultCollapsed": false
+            },
+            "content": "If you are found eligible for child care assistance, you can choose center-based or home-based care from a licensed, registered, or legally exempt provider. If you choose a provider that is not licensed or registered, the provider must be enrolled as a legally exempt provider.\\n\\nIf you know which child care providers you would like your child to attend, provide the names and addresses of your choice of providers. You can leave this section blank if you do not know (it will not impact your eligibility and you will have an opportunity to select a provider if determined eligible)."
+          },
+          {
+            "id": "provider_choices",
+            "title": "Provider Choices",
+            "description": "Specify details of the provider where you intend to enroll the child(ren).",
+            "fields": [
+              {
+                "id": "provider_choices",
+                "label": "List of Providers",
+                "type": "group",
+                "metadata": {
+                  "multiple": true,
+                  "tableColumns": [
+                    "provider_name",
+                    "program_number",
+                    "provider_zip_code"
+                  ]
+                },
+                "fields": [
+                  {
+                    "id": "provider_name",
+                    "label": "Provider Name",
+                    "type": "text",
+                    "required": true
+                  },
+                  {
+                    "id": "program_number",
+                    "label": "Program Number (If Applicable)",
+                    "type": "text",
+                    "required": false
+                  },
+                  {
+                    "id": "provider_street",
+                    "label": "Street Address",
+                    "type": "text",
+                    "required": true
+                  },
+                  {
+                    "id": "provider_city",
+                    "label": "City",
+                    "type": "text",
+                    "required": true
+                  },
+                  {
+                    "id": "provider_state",
+                    "label": "State",
+                    "type": "text",
+                    "required": true
+                  },
+                  {
+                    "id": "provider_zip_code",
+                    "label": "Zip Code",
+                    "type": "text",
+                    "required": true
+                  }
+                ]
+              }
+            ]
+          }
+        ]
+      },
+      {
+        "id": "document_upload_step",
+        "title": "Document Upload",
+        "description": "The Application for Child Care Assistance (CFWB-012) must include supporting documentation. Check to ensure that documentation is provided for each requirement of subsidy eligibility.",
+        "sections": [
+          {
+            "id": "nyc_residency",
+            "title": "New York City Residency",
+            "description": "These documents confirm that you live in New York City. Please upload one of the following documents.",
+            "fields": [
+              {
+                "id": "nyc_residency_type",
+                "label": "Select one of the following:",
+                "type": "radio",
+                "required": true,
+                "ui": {
+                  "options": [
+                    "IDNYC",
+                    "Utility Bill",
+                    "Section 8 Award Letter",
+                    "Driver’s License",
+                    "Rent Receipt",
+                    "NYCHA Certificate",
+                    "CFWB-067 Residency Attestation",
+                    "CFWB-027 Housing Attestation with address listed",
+                    "Shelter Residency Letter with address listed",
+                    "Other"
+                  ]
+                }
+              },
+              {
+                "id": "nyc_residency_file",
+                "label": "Upload Residency Proof Document",
+                "description": "To add a document to your application, you can upload an image or scanned file from your phone or device. Accepted formats include .pdf, .gif, .jpeg, .jpg and .png up to 25 MB. Learn how to upload your files with this Tutorial Video.",
+                "type": "file",
+                "required": true, 
+                "constraints": {
+                  "maxFileSizeMB": 25,
+                  "allowedTypes": [
+                    "application/pdf",
+                    "image/jpeg",
+                    "image/jpg",
+                    "image/png",
+                    "image/gif"
+                  ]
+                },
+                "metadata": {
+                  "proofCategory": "NYC Residency",
+                  "multiple": false
+                }
+              }
+            ]
+          },
+          {
+            "id": "citizenship_status",
+            "title": "Citizenship or Immigration Status",
+            "description": "These documents confirm the citizenship/immigration status of the children in your family for whom you’re applying for child care assistance. Please upload one of the following documents for ONLY each child needing care.",
+            "fields": [
+              {
+                "id": "citizenship_doc_type",
+                "label": "Select one of the following:",
+                "type": "radio",
+                "required": true,
+                "ui": {
+                  "options": [
+                    "US Birth Certificate",
+                    "Alien Registration Card including Permanent Resident or Green Card",
+                    "Passport",
+                    "FS-240 (Report of Birth Abroad of a U.S. Citizen)",
+                    "Naturalization Certificate",
+                    "Other"
+                  ]
+                }
+              },
+              {
+                "id": "citizenship_doc_file",
+                "label": "Upload Citizenship/Immigration Document",
+                "description": "To add a document to your application, you can upload an image or scanned file from your phone or device. Accepted formats include .pdf, .gif, .jpeg, .jpg and .png up to 25 MB. Learn how to upload your files with this Tutorial Video.",
+                "type": "file",
+                "required": true,
+                "constraints": {
+                  "maxFileSizeMB": 25,
+                  "allowedTypes": [
+                    "application/pdf",
+                    "image/jpeg",
+                    "image/jpg",
+                    "image/png",
+                    "image/gif"
+                  ]
+                },
+                "metadata": {
+                  "proofCategory": "Citizenship/Immigration Status",
+                  "multiple": false
+                }
+              }
+            ]
+          },
+          {
+            "id": "child_relationship",
+            "title": "Child’s Relationship to Parent/Applicant",
+            "description": "These documents confirm your relationship to the children in your household under age 18. Please upload one of the following documents for every child in the household under age 18, regardless of whether child care is needed for them or not. If you are a legal guardian with financial responsibility, you must upload a Court order OR a letter of guardianship.",
+            "fields": [
+              {
+                "id": "relationship_doc_type",
+                "label": "Select one of the following:",
+                "type": "radio",
+                "required": true,
+                "ui": {
+                  "options": [
+                    "Birth Certificate",
+                    "Adoption record",
+                    "Baptismal record",
+                    "Passport with parent's signature",
+                    "Court order for legal guardian with financial responsibility",
+                    "Letter of Guardianship",
+                    "Other - CFWB-058 Caretaker Attestation"
+                  ]
+                }
+              },
+              {
+                "id": "relationship_doc_file",
+                "label": "Upload Relationship Document",
+                "description": "To add a document to your application, you can upload an image or scanned file from your phone or device. Accepted formats include .pdf, .gif, .jpeg, .jpg and .png up to 25 MB. Learn how to upload your files with this Tutorial Video.",
+                "type": "file",
+                "required": true,
+                "constraints": {
+                  "maxFileSizeMB": 25,
+                  "allowedTypes": [
+                    "application/pdf",
+                    "image/jpeg",
+                    "image/jpg",
+                    "image/png",
+                    "image/gif"
+                  ]
+                },
+                "metadata": {
+                  "proofCategory": "Child Relationship",
+                  "multiple": false
+                }
+              }
+            ]
+          },
+          {
+            "id": "age_proof",
+            "title": "Age",
+            "description": "These documents confirm the age of the children in your household. Please upload one of the following documents for every child in the household under age 18, regardless of whether child care is needed for them:",
+            "fields": [
+              {
+                "id": "age_doc_type",
+                "label": "Select one of the following:",
+                "type": "radio",
+                "required": true,
+                "ui": {
+                  "options": [
+                    "Birth Certificate",
+                    "Adoption record",
+                    "Baptismal record",
+                    "Alien Registration Card",
+                    "Passport",
+                    "Official hospital documentation of the child’s birth"
+                  ]
+                }
+              },
+              {
+                "id": "age_doc_file",
+                "label": "Upload Age Proof Document",
+                "description": "To add a document to your application, you can upload an image or scanned file from your phone or device. Accepted formats include .pdf, .gif, .jpeg, .jpg and .png up to 25 MB. Learn how to upload your files with this Tutorial Video.",
+                "type": "file",
+                "required": true,
+                "constraints": {
+                  "maxFileSizeMB": 25,
+                  "allowedTypes": [
+                    "application/pdf",
+                    "image/jpeg",
+                    "image/jpg",
+                    "image/png",
+                    "image/gif"
+                  ]
+                },
+                "metadata": {
+                  "proofCategory": "Child Age",
+                  "multiple": false
+                }
+              }
+            ]
+          }
+        ]
+      },
+      {
+        "id": "review",
+        "title": "Review & Submit",
+        "type": "review",
+        "sections": []
+      }
+    ]
+  }
+}

--- a/test-form/public/data/childcare_form.bn.json
+++ b/test-form/public/data/childcare_form.bn.json
@@ -1,0 +1,2287 @@
+{
+  "form": {
+    "title": "Childcare Voucher Application",
+    "description": "Step-by-step form for applying for Childcare Assistance",
+    "layout": {
+      "stepperPosition": "left"
+    },
+    "steps": [
+      {
+        "id": "consent_step",
+        "title": "Consent",
+        "sections": [
+          {
+            "id": "mycity_consent_info",
+            "title": "ModelCity Consent",
+            "type": "info",
+            "ui": {
+              "markdown": true,
+              "collapsible": false,
+              "defaultCollapsed": false
+            },
+            "content": "In connection with this application for child care services, **ModelCity**:\\n\\n- Collects, processes, stores, and shares the information you submit to screen you when you apply for child care services;\\n- Receives, processes, and stores the information the City already knows about you to screen you when you apply for child care services;\\n- Uses your information to improve ModelCity; and\\n- Communicates with you about your ModelCity account.\\n\\n---\\n\\nIf you consent, the following information may be shared between child care services agencies:\\n\\n- Demographic and background information, including address, phone number, household composition.\\n- Housing information, including benefits awarded/received, current housing/shelter status.\\n- Benefits information, including public assistance awarded/received, child care program participation.\\n\\n---\\n\\nIf you choose not to consent, **you will not be denied** any benefits or services you are receiving or any benefits for which you are eligible.\\n\\nThe [ModelCity Privacy Policy](https://www.nyc.gov/privacy) details how ModelCity handles the information you submit through ModelCity."
+          }
+        ]
+      },
+      {
+        "id": "instructions_step",
+        "title": "Instructions",
+        "sections": [
+          {
+            "id": "application_instructions",
+            "title": "Application Instructions",
+            "type": "info",
+            "ui": {
+              "markdown": true,
+              "collapsible": false,
+              "defaultCollapsed": false
+            },
+            "content": "**Let’s get started on your application!**\\n\\nTo complete this application, you will be asked for information about:\\n\\n- Yourself\\n- Your household\\n- Your employment or reason for care\\n- Your income\\n\\nAll required fields are marked and must be filled out to move forward with the application. The pages of the application are shown on the right-hand side of the screen and will be highlighted as you move through the application.\\n\\nYour application will be saved automatically as you progress to each page.  \\nIf you need to pause at any time, click the **“Save for later”** button at the bottom of each page to save your application.  \\nYou can log back in to resume your application.\\n\\nWhen you’re ready to begin, click **“Next”** below.\\n\\n---\\n\\n⚠️ **Important:**  \\nTo keep your information current and safe, applications in draft status that you have not edited for **30 days** will be deleted.  \\nIf your draft application is deleted, you can still create and submit a new application when you're ready to apply."
+          },
+          {
+            "id": "new_york_city_residency",
+            "title": "New York City Residency",
+            "type": "info",
+            "ui": {
+              "markdown": true,
+              "collapsible": true,
+              "defaultCollapsed": true
+            },
+            "content": "You will need to upload **ONE** of the following documents to confirm your NYC residency:\\n\\n- IDNYC\\n- Driver’s License\\n- Utility Bill (dated within the last 60 days, with your address)\\n- Current lease, rent, or mortgage statement (dated within the last 60 days, with your address)\\n- Section 8 Award Letter\\n- NYCHA Certificate\\n- CFWB-027 Housing Attestation with address listed\\n- Shelter Residency Letter with address listed\\n\\nIf you do not have any of those documents, you must submit a **CFWB-067 Residency Attestation**."
+          },
+          {
+            "id": "children_documents",
+            "title": "Children Documents",
+            "type": "info",
+            "ui": {
+              "markdown": true,
+              "collapsible": true,
+              "defaultCollapsed": true
+            },
+            "content": "### Citizenship or Immigration Status\\nThese documents confirm the citizenship or immigration status of the children in your family for whom you’re applying for child care assistance. Please upload one of the following documents for each child needing care. *Do not upload these documents for children who do not need care.*\\n\\n- Birth Certificate from US state or territory\\n- Alien Registration Card including Permanent Resident or Green Card\\n- Passport\\n- FS-240 (Consular Report of Birth Abroad)\\n- Naturalization Certificate\\n- Other documentation that proves child’s immigration status\\n\\n### Child's Relationship to Applicant\\nThese documents confirm your relationship to the children in your household under age 18. Please upload one of the following documents for every child in the household under age 18, regardless of whether they need child care.\\n\\n- Birth certificate\\n- Adoption record\\n- Baptismal record\\n- Passport with parent's signature\\n- Court order for legal guardian with financial responsibility\\n- Letter of guardianship\\n- Other - CFWB-058 Caretaker Attestation\\n\\nIf you are not the child's parent or stepparent, you must submit a **CFWB-058 Caretaker Attestation Form**.\\n\\n### Age of Children\\nYou will need to upload **ONE** of the following documents for every child in the household under age 18, regardless of whether child care is needed for them:\\n\\n- Birth certificate\\n- Adoption record\\n- Baptismal record\\n- Alien Registration Card\\n- Passport\\n- Official hospital documentation of the child’s birth"
+          },
+          {
+            "id": "employment_income",
+            "title": "Employment & Income",
+            "type": "info",
+            "ui": {
+              "markdown": true,
+              "collapsible": true,
+              "defaultCollapsed": true
+            },
+            "content": "### Income\\nThese documents confirm your family’s income.\\n\\n---\\n\\n### If You Are Employed\\nIf you are employed and receive paystubs, you must submit them to confirm your income. The number of paystubs you must submit varies by how often you get paid and whether your payment amount is the same or different each time you are paid – see the table below for details. Submit the most recent paystub you have received, followed by others in consecutive order.\\n\\n**Income Information**\\n\\n| How Often Do You Get Paid? | Always the SAME Amount | DIFFERENT Amounts Each Time |\\n|----------------------------|-------------------------|------------------------------|\\n| Weekly (Every Week) | 4 most recent, consecutive pay stubs | 12 most recent, consecutive pay stubs |\\n| Bi-Weekly (Every Two Weeks) | 2 most recent, consecutive pay stubs | 6 most recent, consecutive pay stubs |\\n| Semi-Monthly (Two Times Per Month) | 2 most recent, consecutive pay stubs | 6 most recent, consecutive pay stubs |\\n| Monthly (One Time Per Month) | 3 most recent, consecutive pay stubs | 3 most recent, consecutive pay stubs |\\n\\nIf you do not have any paystubs, you must submit a **CFWB-015 Referral to Employer for Employee Income Information Form**.\\n\\n---\\n\\n### If You Are Self-Employed\\nIf you have been self-employed for **one year or more**, you must submit a current, complete and signed income tax package (e.g., 1040, 1065, Schedule C, SE for partnership, K-1, etc.).\\n\\nIf you have been self-employed for **less than one year**, you must submit a **CFWB-031 Self-Employment Income Information Attestation Form**.\\n\\n---\\n\\n### Other Income\\nIf you receive other types of income outside or instead of employment income, you must submit your most recent check, pay stub, or current award letter that indicates the amount you receive. If your other income fluctuates, **3 months of documentation is required**.\\n\\nThis includes, but is not limited to:\\n- Income from SSI, SSD\\n- Unemployment benefits\\n- Rental income\\n- Pensions\\n- Annuities\\n- Worker’s compensation\\n- Alimony\\n- Child support"
+          },
+          {
+            "id": "reason_for_care",
+            "title": "Reason for Care",
+            "type": "info",
+            "ui": {
+              "markdown": true,
+              "collapsible": true,
+              "defaultCollapsed": true
+            },
+            "content": "### Reason for Care\\nThese documents confirm your reason for care. Every applicant must have a qualified reason for care; in a two-parent household, parents or caretakers can have the same or different reasons for care. Only the documents related to your stated reasons for care need to be uploaded, and documentation must be uploaded for all parent or caretakers in the household.\\n\\n---\\n\\n### Working 10+ Hours Per Week\\nYour employment or self-employment income documents will cover this reason for care. You do not need to submit additional documentation.\\n\\n---\\n\\n### Participating in an Educational or Vocational Training Program\\nYou will need to upload **ONE** of the following documents to confirm your participation in vocational school, two-year college, or four-year college.\\n\\n- CFWB-005 Vocational, Education and Training Verification Form\\n- A letter from the educational or vocational training program on their official letterhead; this letter must contain all the information required in the CFWB-005 Vocational, Education and Training Verification Form.\\n\\n---\\n\\n### Looking for Work\\nYou will need to upload **ONE** of the following documents to confirm that you are looking for work.\\n\\n- CFWB-026 Work Search Record Form\\n- Approved work search plan from the NYS Dept. of Labor\\n- Proof of receipt of unemployment insurance\\n\\n---\\n\\n### Experiencing Homelessness\\nYou will need to upload **ONE** of the following documents to confirm that you are experiencing homelessness. This includes families who may be living in shelter or sharing the housing of others due to loss of housing, economic hardship, or similar reason.\\n\\n- Shelter Residency Letter (If living in Shelter, including Humanitarian Emergency Relief Centers)\\n- CFWB-027 Housing Attestation (If living doubled-up, in a place not meant for human habitation, in a hotel/motel, or in another living situation)\\n\\n---\\n\\n### Attending Services for Domestic Violence\\nYou will need to upload a referral for services from a domestic violence service provider to confirm that you are attending services for domestic violence.\\n\\n---\\n\\n### Attending Services for Substance Abuse Treatment\\nYou will need to upload a referral for a substance abuse treatment service provider to confirm that you are attending services for substance abuse treatment."
+          },
+          {
+            "id": "additional_details",
+            "title": "Additional Details",
+            "type": "info",
+            "ui": {
+              "markdown": true,
+              "collapsible": true,
+              "defaultCollapsed": true
+            },
+            "content": "### Application Scope\\nThis application is used to apply **only** for **Category 2 or 3 child care assistance** (for families not in receipt of cash assistance). To apply for **Cash Assistance** or other benefits, including **Category 1 Child Care Assistance** (for families in receipt of cash assistance), you must use the **New York State Application for Certain Benefits and Services (LDSS-2921)**.\\n\\n---\\n\\n### Exempt Applicants\\nThe following applicants may be eligible for child care assistance **without regard to income** and do not need to complete this application:\\n\\n- Foster parents who need child care assistance to allow them to work and are only applying for assistance for the foster children;\\n- Families in receipt of protective or preventive services.\\n\\n---\\n\\n### Application Completion\\nAll sections of this form must be filled out to be considered complete **unless the section is identified as optional**. If you do not complete all required sections of this form, you may not be considered for Child Care Assistance.\\n\\n---\\n\\n### Rights and Responsibilities\\nYou may obtain information about your rights and responsibilities [here](https://otda.ny.gov/programs/applications/). If you do not have access to the internet, you can call the **Administration for Children’s Services at 212-835-7610** to request that physical copies of the booklets which highlight your rights and responsibilities be mailed to you, including:\\n\\n- **LDSS-4148A**: What You Should Know About Your Rights and Responsibilities\\n- **LDSS-4148B**: What You Should Know About Social Services Programs\\n- **LDSS-4148C**: What You Should Know If You Have an Emergency"
+          }
+        ]
+      },
+      {
+        "id": "applicant",
+        "title": "Applicant",
+        "sections": [
+          {
+            "id": "personal_info",
+            "title": "Personal Information",
+            "fields": [
+              {
+                "id": "first_name",
+                "label": "First Name",
+                "type": "text",
+                "required": true
+              },
+              {
+                "id": "last_name",
+                "label": "Last Name",
+                "type": "text",
+                "required": true
+              },
+              {
+                "id": "mi",
+                "label": "Middle Initial",
+                "type": "text",
+                "required": false
+              },
+              {
+                "id": "date_of_birth",
+                "label": "Date of Birth",
+                "type": "date",
+                "required": true,
+                "tooltip": "To edit Date of Birth click on NYC ModelCity in the top-left corner then click on Account Settings."
+              },
+              {
+                "id": "sex",
+                "label": "Sex",
+                "type": "radio",
+                "required": true,
+                "ui": {
+                  "options": [
+                    "Male",
+                    "Female"
+                  ]
+                }
+              },
+              {
+                "id": "marital_status",
+                "label": "Marital Status",
+                "type": "select",
+                "required": true,
+                "tooltip": "Indicate your marital status (single, married, divorced, separated or widowed).",
+                "ui": {
+                  "options": [
+                    "",
+                    "Single",
+                    "Married",
+                    "Divorced",
+                    "Widowed",
+                    "Separated"
+                  ]
+                }
+              }
+            ]
+          },
+          {
+            "id": "contact_info",
+            "title": "Contact Information",
+            "fields": [
+              {
+                "id": "telephone_home",
+                "label": "Home Phone",
+                "type": "tel",
+                "required": false,
+                "constraints": {
+                  "pattern": "^\\\\(?[0-9]{3}\\\\)?[-. ]?[0-9]{3}[-. ]?[0-9]{4}$"
+                },
+                "ui": {
+                  "placeholder": "(123) 456-7890"
+                }
+              },
+              {
+                "id": "telephone_work",
+                "label": "Work Phone",
+                "type": "tel",
+                "required": false,
+                "constraints": {
+                  "pattern": "^\\\\(?[0-9]{3}\\\\)?[-. ]?[0-9]{3}[-. ]?[0-9]{4}$"
+                },
+                "ui": {
+                  "placeholder": "(123) 456-7890"
+                }
+              },
+              {
+                "id": "telephone_mobile_or_other",
+                "label": "Mobile or Other Phone",
+                "type": "tel",
+                "required": false,
+                "tooltip": "To edit Telephone (Cell or Other) click on NYC ModelCity in the top-left corner then click on Account Settings and then click on Contact.",
+                "constraints": {
+                  "pattern": "^\\\\(?[0-9]{3}\\\\)?[-. ]?[0-9]{3}[-. ]?[0-9]{4}$"
+                },
+                "ui": {
+                  "placeholder": "(123) 456-7890"
+                }
+              },
+              {
+                "id": "email",
+                "label": "Email",
+                "type": "email",
+                "required": true,
+                "tooltip": "To edit email, go to NYC ID Profile tab by clicking your name at the top right corner"
+              }
+            ]
+          },
+          {
+            "id": "address_info",
+            "title": "Address",
+            "tooltip": "To edit home address click on NYC ModelCity in the top-left corner then click on Account Settings.",
+            "ui": {
+              "autocomplete": "street",
+              "placeholder": "Start typing your street address",
+              "overrideComponent": "AddressAutocomplete"
+            },
+            "metadata": {
+              "integration": {
+                "provider": "Google",
+                "feature": "AddressAutocomplete"
+              },
+              "autofillTargets": [
+                {
+                  "fieldId": "city",
+                  "source": "locality",
+                  "fallbackSources": [
+                    "postal_town",
+                    "sublocality_level_1",
+                    "administrative_area_level_2"
+                  ]
+                },
+                {
+                  "fieldId": "borough",
+                  "source": "sublocality_level_1",
+                  "fallbackSources": [
+                    "administrative_area_level_2"
+                  ],
+                  "mapping": "boroughMap"
+                },
+                { "fieldId": "state", "source": "administrative_area_level_1" },
+                { "fieldId": "zip_code", "source": "postal_code" },
+                { "fieldId": "latitude", "source": "location.latitude" },
+                { "fieldId": "longitude", "source": "location.longitude" }
+              ]
+            },
+            "fields": [
+              {
+                "id": "street",
+                "label": "Street Address",
+                "type": "text",
+                "required": true,
+                "tooltip": "To edit home address click on NYC ModelCity in the top-left corner then click on Account Settings."
+              },
+              {
+                "id": "apt",
+                "label": "Apt #",
+                "type": "text",
+                "required": false
+              },
+              {
+                "id": "city",
+                "label": "City",
+                "type": "text",
+                "required": true
+              },
+              {
+                "id": "borough",
+                "label": "Borough",
+                "type": "select",
+                "required": true,
+                "ui": {
+                  "options": [
+                    "",
+                    "Bronx",
+                    "Brooklyn",
+                    "Manhattan",
+                    "Queens",
+                    "Staten Island"
+                  ]
+                }
+              },
+              {
+                "id": "state",
+                "label": "State",
+                "type": "text",
+                "required": true
+              },
+              {
+                "id": "zip_code",
+                "label": "Zip Code",
+                "type": "text",
+                "required": true
+              },
+              {
+                "id": "latitude",
+                "label": "Latitude",
+                "type": "number",
+                "required": false
+              },
+              {
+                "id": "longitude",
+                "label": "Longitude",
+                "type": "number",
+                "required": false
+              },
+              {
+                "id": "is_temporary_address",
+                "label": "Is Temporary Address",
+                "type": "radio",
+                "required": true,
+                "tooltip": "Check YES if you are currently living in a homeless shelter, doubled-up with another family, in a hotel/motel, in a car/ bus/ train, in a park/campsite, or other temporary accomodation.",
+                "ui": {
+                  "options": [
+                    "Yes",
+                    "No"
+                  ]
+                }
+              },
+              {
+                "id": "currently_living_in",
+                "label": "Currently Living In",
+                "type": "select",
+                "required": false,
+                "requiredCondition": {
+                  "field": "is_temporary_address",
+                  "operator": "equals",
+                  "value": "Yes"
+                },
+                "ui": {
+                  "options": [
+                    "",
+                    "Homeless Shelter",
+                    "Doubled-up with another Family",
+                    "Hotel/Motel",
+                    "Car, Bus, Train",
+                    "Park",
+                    "Campsite",
+                    "Other"
+                  ]
+                }
+              }
+            ]
+          },
+          {
+            "id": "demographics",
+            "title": "Demographics",
+            "fields": [
+              {
+                "id": "ethnicity",
+                "label": "Ethnicity",
+                "type": "select",
+                "required": false,
+                "ui": {
+                  "options": [
+                    "",
+                    "Hispanic",
+                    "Latino",
+                    "No",
+                    "Prefer not to answer"
+                  ]
+                }
+              },
+              {
+                "id": "race",
+                "label": "Race",
+                "type": "checkbox",
+                "required": false,
+                "tooltip": "You may choose multiple race categories. Providing race information is voluntary and will not affect your eligibility for Child Care Assistance or the amount of assistance that you will be given by this agency.",
+                "ui": {
+                  "options": [
+                    {
+                      "value": "AI",
+                      "label": "American Indian or Alaska Native"
+                    },
+                    {
+                      "value": "AS",
+                      "label": "Asian"
+                    },
+                    {
+                      "value": "BL",
+                      "label": "Black or African American"
+                    },
+                    {
+                      "value": "HP",
+                      "label": "Native Hawaiian or Pacific Islander"
+                    },
+                    {
+                      "value": "WH",
+                      "label": "White"
+                    }
+                  ]
+                },
+                "metadata": {
+                  "multiple": true
+                }
+              },
+              {
+                "id": "ssn",
+                "label": "Social Security Number",
+                "type": "text",
+                "tooltip": "To edit social security number click on NYC ModelCity in the top-left corner then click on Account Settings.",
+                "required": false,
+                "constraints": {
+                  "pattern": "^\\\\d{3}-\\\\d{2}-\\\\d{4}$"
+                },
+                "ui": {
+                  "placeholder": "123-45-6789"
+                }
+              }
+            ]
+          },
+          {
+            "id": "language_info",
+            "title": "Language Preferences",
+            "fields": [
+              {
+                "id": "primary_language",
+                "label": "Primary Language",
+                "type": "radio",
+                "required": true,
+                "tooltip": "Select the language that is spoken most often in your household. If “other”, provide the name of the language.",
+                "ui": {
+                  "options": [
+                    "English",
+                    "Spanish",
+                    "Other"
+                  ]
+                }
+              },
+              {
+                "id": "preferred_language",
+                "label": "Preferred Language",
+                "type": "radio",
+                "required": true,
+                "tooltip": "Select the language you prefer to communicate in. If “other”, provide the name of the language.",
+                "ui": {
+                  "options": [
+                    "English",
+                    "Spanish",
+                    "Other"
+                  ]
+                }
+              },
+              {
+                "id": "other_primary_language",
+                "label": "Other Primary Language",
+                "type": "text",
+                "required": false,
+                "requiredCondition": {
+                  "field": "primary_language",
+                  "operator": "equals",
+                  "value": "Other"
+                }
+              },
+              {
+                "id": "other_preferred_language",
+                "label": "Other Preferred Language",
+                "type": "text",
+                "required": false,
+                "requiredCondition": {
+                  "field": "preferred_language",
+                  "operator": "equals",
+                  "value": "Other"
+                }
+              }
+            ]
+          },
+          {
+            "id": "cash_assistance",
+            "title": "Cash Assistance",
+            "fields": [
+              {
+                "id": "has_cash_assistance",
+                "label": "Do you receive Cash Assistance?",
+                "type": "radio",
+                "required": false,
+                "ui": {
+                  "options": [
+                    "Yes",
+                    "No"
+                  ]
+                }
+              },
+              {
+                "id": "ca_number",
+                "label": "Cash Assistance Number",
+                "type": "text",
+                "required": false,
+                "requiredCondition": {
+                  "condition": {
+                    "field": "has_cash_assistance",
+                    "operator": "equals",
+                    "value": "Yes"
+                  }
+                }
+              }
+            ]
+          }
+        ]
+      },
+      {
+        "id": "children_needing_care",
+        "title": "Children Needing Care",
+        "sections": [
+          {
+            "id": "child_details",
+            "title": "Child Details",
+            "required": true,
+            "fields": [
+              {
+                "id": "children",
+                "label": "Children Needing Care",
+                "type": "group",
+                "metadata": {
+                  "multiple": true,
+                  "tableColumns": [
+                  "first_name",
+                  "last_name",
+                  "date_of_birth",
+                  "relationship_to_applicant"
+                  ]
+                },
+                "fields": [
+                  {
+                    "id": "first_name",
+                    "label": "First Name",
+                    "type": "text",
+                    "required": true,
+                    "tooltip": "Provide the first name, last name, and middle initial of each child you are applying for child care assistance for."
+                  },
+                  {
+                    "id": "last_name",
+                    "label": "Last Name",
+                    "type": "text",
+                    "required": true
+                  },
+                  {
+                    "id": "mi",
+                    "label": "Middle Initial",
+                    "type": "text",
+                    "required": false
+                  },
+                  {
+                    "id": "relationship_to_applicant",
+                    "label": "Relationship to Applicant",
+                    "type": "select",
+                    "required": true,
+                    "ui": {
+                      "options": [
+                        "",
+                        "Child",
+                        "Grandchild",
+                        "Foster Child",
+                        "Other"
+                      ]
+                    }
+                  },
+                  {
+                    "id": "date_of_birth",
+                    "label": "Date of Birth",
+                    "type": "date",
+                    "required": true,
+                    "tooltip": "Provide the date of birth."
+                  },
+                  {
+                    "id": "sex",
+                    "label": "Sex",
+                    "type": "radio",
+                    "required": true,
+                    "tooltip": "Select to indicate the sex.",
+                    "ui": {
+                      "options": [
+                        "Male",
+                        "Female"
+                      ]
+                    }
+                  },
+                  {
+                    "id": "ethnicity",
+                    "label": "Ethnicity Hispanic or Latino",
+                    "type": "select",
+                    "required": false,
+                    "tooltip": "Check “YES” or “NO” to indicate if each child in need of child care is Hispanic or Latino or not. Providing ethnicity information is voluntary and will not affect your eligibility for child care assistance or the amount of assistance that you will be given by this agency.",
+                    "ui": {
+                      "options": [
+                        "",
+                        "Yes",
+                        "No",
+                        "Prefer not to answer"
+                      ]
+                    }
+                  },
+                  {
+                    "id": "race",
+                    "label": "Race",
+                    "type": "checkbox",
+                    "required": false,
+                    "tooltip": "You may choose multiple race categories for a single child. Providing race information is voluntary and will not affect your eligibility for Child Care Assistance or the amount of assistance that you will be given by this agency.",
+                    "ui": {
+                      "options": [
+                        {
+                          "value": "AI",
+                          "label": "American Indian or Alaska Native"
+                        },
+                        {
+                          "value": "AS",
+                          "label": "Asian"
+                        },
+                        {
+                          "value": "BL",
+                          "label": "Black or African American"
+                        },
+                        {
+                          "value": "HP",
+                          "label": "Native Hawaiian or Pacific Islander"
+                        },
+                        {
+                          "value": "WH",
+                          "label": "White"
+                        }
+                      ]
+                    },
+                    "metadata": {
+                      "multiple": true
+                    }
+                  },
+                  {
+                    "id": "ssn",
+                    "label": "Social Security Number",
+                    "type": "text",
+                    "required": false,
+                    "tooltip": "Provide each child’s Social Security Number (SSN). You are not required to provide SSNs. They may be used by federal, state, and local agencies to prevent duplication of services and fraud, and for Federal Reporting.",
+                    "constraints": {
+                      "pattern": "^\\\\d{3}-\\\\d{2}-\\\\d{4}$"
+                    },
+                    "ui": {
+                      "placeholder": "123-45-6789"
+                    }
+                  },
+                  {
+                    "id": "do_both_parents_reside_in_home",
+                    "label": "Do both parents reside in the home?",
+                    "type": "radio",
+                    "required": true,
+                    "tooltip": "Check “YES” or “NO” to indicate whether both of the child’s parents live in the home.",
+                    "ui": {
+                      "options": [
+                        "Yes",
+                        "No"
+                      ]
+                    }
+                  },
+                  {
+                    "id": "has_disability",
+                    "label": "Does the child have a disability?",
+                    "type": "radio",
+                    "required": true,
+                    "tooltip": "Check “YES” or “NO” to indicate whether the child needing child care has a disability.",
+                    "ui": {
+                      "options": [
+                        "Yes",
+                        "No"
+                      ]
+                    }
+                  },
+                  {
+                    "id": "is_immigration_status_satisfactory",
+                    "label": "Is child U.S. Citizen, U.S. National, or person with satisfactory immigration status?",
+                    "type": "radio",
+                    "required": true,
+                    "tooltip": "You will only be asked about the immigration status of the children in need of care. Other members of the family will not need to state or prove their immigration status. Your child will be eligible for care if they are a U.S. citizen, a legal permanent resident (green card holder), a refugee, or an asylee; have a T-visa; or hold another qualified immigration status. Please select “Yes” if your child holds one of these statuses.",
+                    "ui": {
+                      "options": [
+                        "Yes",
+                        "No"
+                      ]
+                    }
+                  }
+                ]
+              }
+            ]
+          }
+        ]
+      },
+      {
+        "id": "family_members",
+        "title": "Family Members",
+        "sections": [
+          {
+            "id": "household_members_info",
+            "title": "Household Members Information",
+            "type": "info",
+            "ui": {
+              "markdown": true,
+              "collapsible": false,
+              "defaultCollapsed": false
+            },
+            "content": "**List the household members who do _not_ need child care.**\\n\\nIf applicable, list:\\n\\n- Your **spouse**, your child’s **second parent**, **caretaker**, or **step-parent**\\n- Any other **adult with whom you share a child**, if they live in your home\\n\\nThen, if applicable, list:\\n\\n- Any **siblings under the age of 18** who live in your home\\n\\n> **Only list other household members** — such as **aunts, uncles, cousins, grandparents, or friends** — _if they have financial responsibility_ for the child.\\n\\nA household member with financial responsibility, other than a parent or step-parent, is one who has a **letter or order of guardianship**.\\n\\n**Otherwise, do not include them.**"
+          },
+          {
+            "id": "family_member_details",
+            "title": "Household Member Details",
+            "description": "Include household members who do not need child care assistance (e.g., spouse, partner, other children).",
+            "fields": [
+              {
+                "id": "familymember",
+                "label": "Family Members",
+                "type": "group",
+                "requiredCondition": {
+                  "repeatingGroup": "children",
+                  "operator": "ANY",
+                  "condition": { "field": "do_both_parents_reside_in_home", "operator": "equals", "value": "Yes" }
+                },  
+                "metadata": {
+                  "multiple": true,
+                  "tableColumns": [
+                    "first_name",
+                    "last_name",
+                    "relationship_to_applicant",
+                    "date_of_birth"
+                  ]
+                },
+                "fields": [
+                  {
+                    "id": "first_name",
+                    "label": "First Name",
+                    "type": "text",
+                    "required": true,
+                    "tooltip": "Provide last and first name, and middle initial if applicable."
+                  },
+                  {
+                    "id": "last_name",
+                    "label": "Last Name",
+                    "type": "text",
+                    "required": true
+                  },
+                  {
+                    "id": "mi",
+                    "label": "Middle Initial",
+                    "type": "text",
+                    "required": false
+                  },
+                  {
+                    "id": "relationship_to_applicant",
+                    "label": "Relationship to Applicant",
+                    "type": "select",
+                    "required": true,
+                    "tooltip": "Provide each person’s relationship to you (e.g. spouse, partner, child, foster parent, other).",
+                    "ui": {
+                      "options": [
+                        "",
+                        "Spouse",
+                        "Partner",
+                        "Foster Parent",
+                        "Child",
+                        "Other"
+                      ]
+                    }
+                  },
+                  {
+                    "id": "date_of_birth",
+                    "label": "Date of Birth",
+                    "type": "date",
+                    "required": true,
+                    "tooltip": "Provide the family member's date of birth."
+                  },
+                  {
+                    "id": "sex",
+                    "label": "Sex",
+                    "type": "radio",
+                    "required": true,
+                    "tooltip": "Indicate the sex for each family member listed.",
+                    "ui": {
+                      "options": [
+                        "Male",
+                        "Female"
+                      ]
+                    }
+                  },
+                  {
+                    "id": "ethnicity",
+                    "label": "Ethnicity Hispanic or Latino",
+                    "type": "select",
+                    "required": false,
+                    "tooltip": "Check “YES” or “NO” to indicate if each member in the household is Hispanic or Latino or not. Providing ethnicity information is voluntary and will not affect your eligibility for Child Care Assistance or the amount of assistance that you will be given by this agency.",
+                    "ui": {
+                      "options": [
+                        "",
+                        "Yes",
+                        "No",
+                        "Prefer not to answer"
+                      ]
+                    }
+                  },
+                  {
+                    "id": "race",
+                    "label": "Race",
+                    "type": "checkbox",
+                    "required": false,
+                    "tooltip": "You may choose multiple race categories for a single person. Providing race information is voluntary and will not affect your eligibility for Child Care Assistance or the amount of assistance that you will be given by this agency.",
+                    "ui": {
+                      "options": [
+                        {
+                          "value": "AI",
+                          "label": "American Indian or Alaska Native"
+                        },
+                        {
+                          "value": "AS",
+                          "label": "Asian"
+                        },
+                        {
+                          "value": "BL",
+                          "label": "Black or African American"
+                        },
+                        {
+                          "value": "HP",
+                          "label": "Native Hawaiian or Pacific Islander"
+                        },
+                        {
+                          "value": "WH",
+                          "label": "White"
+                        }
+                      ]
+                    },
+                    "metadata": {
+                      "multiple": true
+                    }
+                  },
+                  {
+                    "id": "ssn",
+                    "label": "Social Security Number",
+                    "type": "text",
+                    "required": false,
+                    "tooltip": "Fill in the Social Security Number (SSN) for your family members. SSN is optional. SSN may be used by federal, state, and local agencies to prevent duplication of services and fraud, and for Federal Reporting.",
+                    "constraints": {
+                      "pattern": "^\\\\d{3}-\\\\d{2}-\\\\d{4}$"
+                    },
+                    "ui": {
+                      "placeholder": "123-45-6789"
+                    }
+                  }
+                ]
+              }
+            ]
+          }
+        ]
+      },
+      {
+        "id": "child_family_needs",
+        "title": "Child / Family Needs",
+        "sections": [
+          {
+            "id": "assistance_reason",
+            "title": "Reason for Child Care Assistance",
+            "description": "Select one or two reasons you are requesting Child Care Assistance.",
+            "tooltip": "Select one reason. In a two-parent household, parents/caretakers can have the same or different reasons for needing child care. Both parents/caretakers will be required to submit documentation in support of their own reason. If you are living in temporary housing, please select Homelessness even if you have another reason that applies to you.",
+            "fields": [
+              {
+                "id": "assistance_reason",
+                "label": "Reason(s) for Assistance",
+                "type": "select",
+                "required": true,
+                "ui": {
+                  "options": [
+                    "",
+                    "Employment",
+                    "Looking for Work",
+                    "Vocational Training/Educational Activities",
+                    "Receiving Domestic Violence Services",
+                    "Homelessness"
+                  ]
+                },
+                "constraints": {
+                  "minSelections": 1,
+                  "maxSelections": 2
+                },
+                "metadata": {
+                  "multiple": true
+                }
+              }
+            ]
+          },
+          {
+            "id": "military_status",
+            "title": "Military and Parental Availability",
+            "description": "Provide information about parental military status and availability for child care.",
+            "fields": [
+              {
+                "id": "is_parent_currently_active_in_military",
+                "label": "Is a Parent Currently Active Full-Time in the U.S. Military?",
+                "tooltip": "Check “YES” or “NO” to indicate whether a parent is currently active full-time in the U.S. Military.",
+                "type": "radio",
+                "required": true,
+                "ui": {
+                  "options": [
+                    "Yes",
+                    "No"
+                  ]
+                }
+              },
+              {
+                "id": "is_parent_mem_of_guard_or_mru",
+                "label": "Is a Parent a Member of National Guard or Military Reserve Unit?",
+                "tooltip": "Check “YES” or “NO” to indicate whether a parent is currently a member of a National Guard or Military Reserve Unit.",
+                "type": "radio",
+                "required": true,
+                "ui": {
+                  "options": [
+                    "Yes",
+                    "No"
+                  ]
+                }
+              },
+              {
+                "id": "is_non_custodial_parent_available",
+                "label": "Is the Non-Custodial Parent Available to Provide Care?",
+                "tooltip": "Check “YES” or “NO” to indicate whether there is a non-custodial parent available to provide child care.",
+                "type": "radio",
+                "required": true,
+                "ui": {
+                  "options": [
+                    "Yes",
+                    "No"
+                  ]
+                }
+              }
+            ]
+          },
+          {
+            "id": "duplicate_application",
+            "title": "Other Applications",
+            "description": "Indicate if you are also applying for or receiving child care from other agencies.",
+            "tooltip": "Indicate whether you are currently receiving or have applied for child care assistance with one of the agencies or organizations listed below. Note: If you are receiving Cash Assistance and are interested in child care assistance, you must apply through the Human Resources Administration. Reach out to your Benefits Access Center or visit the Human Resources Administration webpage.",
+            "fields": [
+              {
+                "id": "duplicate_app",
+                "label": "Are You Receiving or Applying for Child Care Through Another Agency?",
+                "type": "select",
+                "required": false,
+                "ui": {
+                  "options": [
+                    "",
+                    "Not Applicable",
+                    "Department of Education (DOE)",
+                    "Human Resources Administration (HRA)",
+                    "Department of Youth and Community Development (DYCD)",
+                    "Department of Homeless Services (DHS)",
+                    "Consortium for Worker Education (CWE)",
+                    "Administration for Children's Services (ACS)"
+                  ]
+                }
+              }
+            ]
+          }
+        ]
+      },
+      {
+        "id": "employment",
+        "title": "Employment",
+        "sections": [
+          {
+            "id": "employment_precheck",
+            "title": "Tell us about your employment",
+            "description": "Tell us about your employment",
+            "fields": [
+              {
+                "id": "applicant_emp_income_indicator",
+                "label": "Does applicant earn any income/ wages from employment? ",
+                "type": "radio",
+                "required": false,
+                "ui": {
+                  "options": [
+                    "Yes",
+                    "No"
+                  ]
+                }
+              },
+              {
+                "id": "coparent_emp_income_indicator",
+                "label": "Does Coparent/2nd Guardian earn any income/ wages from employment? ",
+                "type": "radio",
+                "required": false,
+                "ui": {
+                  "options": [
+                    "Yes",
+                    "No"
+                  ]
+                }
+              }
+            ]
+          },
+          {
+            "id": "applicant_jobs",
+            "title": "Applicant Employment Information",
+            "description": "Enter details for up to two jobs held by the applicant.",
+            "visibilityCondition": {
+              "field": "applicant_emp_income_indicator",
+              "operator": "equals",
+              "value": "Yes"
+            },
+            "fields": [
+              {
+                "id": "applicant_1st_job_start_date",
+                "label": "1st Job - Start Date",
+                "type": "date",
+                "required": false,
+                "ui": {
+                  "group": "1st Job"
+                }
+              },
+              {
+                "id": "applicant_1st_job_rotating_shift",
+                "label": "1st Job - Has Rotating Shift?",
+                "type": "radio",
+                "required": false,
+                "ui": {
+                  "options": [
+                    "Yes",
+                    "No"
+                  ],
+                  "group": "1st Job"
+                }
+              },
+              {
+                "id": "applicant_1st_job_requires_overtime",
+                "label": "1st Job - Requires Overtime?",
+                "type": "radio",
+                "required": false,
+                "ui": {
+                  "options": [
+                    "Yes",
+                    "No"
+                  ],
+                  "group": "1st Job"
+                }
+              },
+              {
+                "id": "applicant_1st_job_employer_name",
+                "label": "1st Job - Employer Name",
+                "type": "text",
+                "required": false,
+                "ui": {
+                  "group": "1st Job"
+                }
+              },
+              {
+                "id": "applicant_1st_job_employer_phone",
+                "label": "1st Job - Employer Phone",
+                "type": "tel",
+                "required": false,
+                "ui": {
+                  "group": "1st Job"
+                }
+              },
+              {
+                "id": "applicant_1st_job_employer_street",
+                "label": "1st Job - Employer Street Address",
+                "type": "text",
+                "required": false,
+                "ui": {
+                  "group": "1st Job"
+                }
+              },
+              {
+                "id": "applicant_1st_job_employer_city",
+                "label": "1st Job - Employer City",
+                "type": "text",
+                "required": false,
+                "ui": {
+                  "group": "1st Job"
+                }
+              },
+              {
+                "id": "applicant_1st_job_employer_state",
+                "label": "1st Job - Employer State",
+                "type": "text",
+                "required": false,
+                "ui": {
+                  "group": "1st Job"
+                }
+              },
+              {
+                "id": "applicant_1st_job_employer_zipcode",
+                "label": "1st Job - Employer ZIP Code",
+                "type": "text",
+                "required": false,
+                "ui": {
+                  "group": "1st Job"
+                }
+              },
+              {
+                "id": "applicant_2nd_job_start_date",
+                "label": "2nd Job - Start Date",
+                "type": "date",
+                "required": false,
+                "ui": {
+                  "group": "2nd Job"
+                }
+              },
+              {
+                "id": "applicant_2nd_job_rotating_shift",
+                "label": "2nd Job - Has Rotating Shift?",
+                "type": "radio",
+                "required": false,
+                "ui": {
+                  "options": [
+                    "Yes",
+                    "No"
+                  ],
+                  "group": "2nd Job"
+                }
+              },
+              {
+                "id": "applicant_2nd_job_requires_overtime",
+                "label": "2nd Job - Requires Overtime?",
+                "type": "radio",
+                "required": false,
+                "ui": {
+                  "options": [
+                    "Yes",
+                    "No"
+                  ],
+                  "group": "2nd Job"
+                }
+              },
+              {
+                "id": "applicant_2nd_job_employer_name",
+                "label": "2nd Job - Employer Name",
+                "type": "text",
+                "required": false,
+                "ui": {
+                  "group": "2nd Job"
+                }
+              },
+              {
+                "id": "applicant_2nd_job_employer_phone",
+                "label": "2nd Job - Employer Phone",
+                "type": "tel",
+                "required": false,
+                "ui": {
+                  "group": "2nd Job"
+                }
+              },
+              {
+                "id": "applicant_2nd_job_employer_street",
+                "label": "2nd Job - Employer Street Address",
+                "type": "text",
+                "required": false,
+                "ui": {
+                  "group": "2nd Job"
+                }
+              },
+              {
+                "id": "applicant_2nd_job_employer_city",
+                "label": "2nd Job - Employer City",
+                "type": "text",
+                "required": false,
+                "ui": {
+                  "group": "2nd Job"
+                }
+              },
+              {
+                "id": "applicant_2nd_job_employer_state",
+                "label": "2nd Job - Employer State",
+                "type": "text",
+                "required": false,
+                "ui": {
+                  "group": "2nd Job"
+                }
+              },
+              {
+                "id": "applicant_2nd_job_employer_zipcode",
+                "label": "2nd Job - Employer ZIP Code",
+                "type": "text",
+                "required": false,
+                "ui": {
+                  "group": "2nd Job"
+                }
+              }
+            ]
+          },
+          {
+            "id": "second_parent_jobs",
+            "title": "Second Parent Employment Information",
+            "description": "Enter details for up to two jobs held by the second parent (if applicable).",
+            "visibilityCondition": {
+              "field": "coparent_emp_income_indicator",
+              "operator": "equals",
+              "value": "Yes"
+            },
+            "fields": [
+              {
+                "id": "second_parent_1st_job_start_date",
+                "label": "1st Job - Start Date",
+                "type": "date",
+                "required": false
+              },
+              {
+                "id": "second_parent_1st_job_rotating_shift",
+                "label": "1st Job - Has Rotating Shift?",
+                "type": "radio",
+                "required": false,
+                "ui": {
+                  "options": [
+                    "Yes",
+                    "No"
+                  ]
+                }
+              },
+              {
+                "id": "second_parent_1st_job_requires_overtime",
+                "label": "1st Job - Requires Overtime?",
+                "type": "radio",
+                "required": false,
+                "ui": {
+                  "options": [
+                    "Yes",
+                    "No"
+                  ]
+                }
+              },
+              {
+                "id": "second_parent_1st_job_employer_name",
+                "label": "1st Job - Employer Name",
+                "type": "text",
+                "required": false
+              },
+              {
+                "id": "second_parent_1st_job_employer_phone",
+                "label": "1st Job - Employer Phone",
+                "type": "tel",
+                "required": false
+              },
+              {
+                "id": "second_parent_1st_job_employer_street",
+                "label": "1st Job - Employer Street Address",
+                "type": "text",
+                "required": false
+              },
+              {
+                "id": "second_parent_1st_job_employer_city",
+                "label": "1st Job - Employer City",
+                "type": "text",
+                "required": false
+              },
+              {
+                "id": "second_parent_1st_job_employer_state",
+                "label": "1st Job - Employer State",
+                "type": "text",
+                "required": false
+              },
+              {
+                "id": "second_parent_1st_job_employer_zipcode",
+                "label": "1st Job - Employer ZIP Code",
+                "type": "text",
+                "required": false
+              },
+              {
+                "id": "second_parent_2nd_job_start_date",
+                "label": "2nd Job - Start Date",
+                "type": "date",
+                "required": false
+              },
+              {
+                "id": "second_parent_2nd_job_rotating_shift",
+                "label": "2nd Job - Has Rotating Shift?",
+                "type": "radio",
+                "required": false,
+                "ui": {
+                  "options": [
+                    "Yes",
+                    "No"
+                  ]
+                }
+              },
+              {
+                "id": "second_parent_2nd_job_requires_overtime",
+                "label": "2nd Job - Requires Overtime?",
+                "type": "radio",
+                "required": false,
+                "ui": {
+                  "options": [
+                    "Yes",
+                    "No"
+                  ]
+                }
+              },
+              {
+                "id": "second_parent_2nd_job_employer_name",
+                "label": "2nd Job - Employer Name",
+                "type": "text",
+                "required": false
+              },
+              {
+                "id": "second_parent_2nd_job_employer_phone",
+                "label": "2nd Job - Employer Phone",
+                "type": "tel",
+                "required": false
+              },
+              {
+                "id": "second_parent_2nd_job_employer_street",
+                "label": "2nd Job - Employer Street Address",
+                "type": "text",
+                "required": false
+              },
+              {
+                "id": "second_parent_2nd_job_employer_city",
+                "label": "2nd Job - Employer City",
+                "type": "text",
+                "required": false
+              },
+              {
+                "id": "second_parent_2nd_job_employer_state",
+                "label": "2nd Job - Employer State",
+                "type": "text",
+                "required": false
+              },
+              {
+                "id": "second_parent_2nd_job_employer_zipcode",
+                "label": "2nd Job - Employer ZIP Code",
+                "type": "text",
+                "required": false
+              }
+            ]
+          }
+        ]
+      },
+      {
+        "id": "schedule",
+        "title": "Work/Activity/Travel Time Schedule",
+        "sections": [
+          {
+            "id": "schedule_section_info",
+            "title": "Schedule Information",
+            "type": "info",
+            "ui": {
+              "markdown": true,
+              "collapsible": false,
+              "defaultCollapsed": false
+            },
+            "content": "Please indicate what days and hours you will need child care for based on your reason for care.\\n\\n- **Employed**: Indicate the hours you attend work\\n- **Educational or Vocational Program**: Indicate the hours you attend school or your program\\n- **Looking for Work**: Indicate the hours you spend looking for work\\n- **Homeless**: Indicate the hours you spend looking for housing\\n- **Attending Services for Domestic Violence**: Indicate the hours you attend services.\\n- **Attending Services for Substance Abuse Treatment**: Indicate the hours you attend services."
+          },
+          {
+            "id": "first_parent_activity_schedule",
+            "title": "First Parent Activity Schedule",
+            "description": "Enter the start and end times for each day of the week for the first parent's activities.",
+            "ui": {
+              "layout": "table",
+              "columns": [
+                "Start Time",
+                "End Time"
+              ],
+              "rowCopy": {
+                "enableUserPickSource": true,
+                "rowIdentifier": "ui.rowGroup",
+                "fieldsToCopy": [
+                  1,
+                  2
+                ],
+                "targetRowValues": [
+                  "Monday",
+                  "Tuesday",
+                  "Wednesday",
+                  "Thursday",
+                  "Friday"
+                ],
+                "copyControlLabel": "Apply selected schedule to other weekdays",
+                "sourceOptions": [
+                  "Monday",
+                  "Tuesday",
+                  "Wednesday",
+                  "Thursday",
+                  "Friday",
+                  "Saturday",
+                  "Sunday"
+                ]
+              }
+            },
+            "fields": [
+              {
+                "id": "fp_monday_from",
+                "label": "Monday From",
+                "type": "time",
+                "ui": {
+                  "rowGroup": "Monday",
+                  "column": 1
+                }
+              },
+              {
+                "id": "fp_monday_to",
+                "label": "Monday To",
+                "type": "time",
+                "ui": {
+                  "rowGroup": "Monday",
+                  "column": 2
+                }
+              },
+              {
+                "id": "fp_tuesday_from",
+                "label": "Tuesday From",
+                "type": "time",
+                "ui": {
+                  "rowGroup": "Tuesday",
+                  "column": 1
+                }
+              },
+              {
+                "id": "fp_tuesday_to",
+                "label": "Tuesday To",
+                "type": "time",
+                "ui": {
+                  "rowGroup": "Tuesday",
+                  "column": 2
+                }
+              },
+              {
+                "id": "fp_wednesday_from",
+                "label": "Wednesday From",
+                "type": "time",
+                "ui": {
+                  "rowGroup": "Wednesday",
+                  "column": 1
+                }
+              },
+              {
+                "id": "fp_wednesday_to",
+                "label": "Wednesday To",
+                "type": "time",
+                "ui": {
+                  "rowGroup": "Wednesday",
+                  "column": 2
+                }
+              },
+              {
+                "id": "fp_thursday_from",
+                "label": "Thursday From",
+                "type": "time",
+                "ui": {
+                  "rowGroup": "Thursday",
+                  "column": 1
+                }
+              },
+              {
+                "id": "fp_thursday_to",
+                "label": "Thursday To",
+                "type": "time",
+                "ui": {
+                  "rowGroup": "Thursday",
+                  "column": 2
+                }
+              },
+              {
+                "id": "fp_friday_from",
+                "label": "Friday From",
+                "type": "time",
+                "ui": {
+                  "rowGroup": "Friday",
+                  "column": 1
+                }
+              },
+              {
+                "id": "fp_friday_to",
+                "label": "Friday To",
+                "type": "time",
+                "ui": {
+                  "rowGroup": "Friday",
+                  "column": 2
+                }
+              },
+              {
+                "id": "fp_saturday_from",
+                "label": "Saturday From",
+                "type": "time",
+                "ui": {
+                  "rowGroup": "Saturday",
+                  "column": 1
+                }
+              },
+              {
+                "id": "fp_saturday_to",
+                "label": "Saturday To",
+                "type": "time",
+                "ui": {
+                  "rowGroup": "Saturday",
+                  "column": 2
+                }
+              },
+              {
+                "id": "fp_sunday_from",
+                "label": "Sunday From",
+                "type": "time",
+                "ui": {
+                  "rowGroup": "Sunday",
+                  "column": 1
+                }
+              },
+              {
+                "id": "fp_sunday_to",
+                "label": "Sunday To",
+                "type": "time",
+                "ui": {
+                  "rowGroup": "Sunday",
+                  "column": 2
+                }
+              }
+            ]
+          },
+          {
+            "id": "second_parent_activity_schedule",
+            "title": "Second Parent Activity Schedule",
+            "description": "Enter the start and end times for each day of the week for the second parent's activities.",
+            "ui": {
+              "layout": "table",
+              "columns": [
+                "Start Time",
+                "End Time"
+              ],
+              "rowCopy": {
+                "enableUserPickSource": true,
+                "rowIdentifier": "ui.rowGroup",
+                "fieldsToCopy": [
+                  1,
+                  2
+                ],
+                "targetRowValues": [
+                  "Monday",
+                  "Tuesday",
+                  "Wednesday",
+                  "Thursday",
+                  "Friday"
+                ],
+                "copyControlLabel": "Apply selected schedule to other weekdays",
+                "sourceOptions": [
+                  "Monday",
+                  "Tuesday",
+                  "Wednesday",
+                  "Thursday",
+                  "Friday",
+                  "Saturday",
+                  "Sunday"
+                ]
+              }
+            },
+            "fields": [
+              {
+                "id": "sp_monday_from",
+                "label": "Monday From",
+                "type": "time",
+                "ui": {
+                  "rowGroup": "Monday",
+                  "column": 1
+                }
+              },
+              {
+                "id": "sp_monday_to",
+                "label": "Monday To",
+                "type": "time",
+                "ui": {
+                  "rowGroup": "Monday",
+                  "column": 2
+                }
+              },
+              {
+                "id": "sp_tuesday_from",
+                "label": "Tuesday From",
+                "type": "time",
+                "ui": {
+                  "rowGroup": "Tuesday",
+                  "column": 1
+                }
+              },
+              {
+                "id": "sp_tuesday_to",
+                "label": "Tuesday To",
+                "type": "time",
+                "ui": {
+                  "rowGroup": "Tuesday",
+                  "column": 2
+                }
+              },
+              {
+                "id": "sp_wednesday_from",
+                "label": "Wednesday From",
+                "type": "time",
+                "ui": {
+                  "rowGroup": "Wednesday",
+                  "column": 1
+                }
+              },
+              {
+                "id": "sp_wednesday_to",
+                "label": "Wednesday To",
+                "type": "time",
+                "ui": {
+                  "rowGroup": "Wednesday",
+                  "column": 2
+                }
+              },
+              {
+                "id": "sp_thursday_from",
+                "label": "Thursday From",
+                "type": "time",
+                "ui": {
+                  "rowGroup": "Thursday",
+                  "column": 1
+                }
+              },
+              {
+                "id": "sp_thursday_to",
+                "label": "Thursday To",
+                "type": "time",
+                "ui": {
+                  "rowGroup": "Thursday",
+                  "column": 2
+                }
+              },
+              {
+                "id": "sp_friday_from",
+                "label": "Friday From",
+                "type": "time",
+                "ui": {
+                  "rowGroup": "Friday",
+                  "column": 1
+                }
+              },
+              {
+                "id": "sp_friday_to",
+                "label": "Friday To",
+                "type": "time",
+                "ui": {
+                  "rowGroup": "Friday",
+                  "column": 2
+                }
+              },
+              {
+                "id": "sp_saturday_from",
+                "label": "Saturday From",
+                "type": "time",
+                "ui": {
+                  "rowGroup": "Saturday",
+                  "column": 1
+                }
+              },
+              {
+                "id": "sp_saturday_to",
+                "label": "Saturday To",
+                "type": "time",
+                "ui": {
+                  "rowGroup": "Saturday",
+                  "column": 2
+                }
+              },
+              {
+                "id": "sp_sunday_from",
+                "label": "Sunday From",
+                "type": "time",
+                "ui": {
+                  "rowGroup": "Sunday",
+                  "column": 1
+                }
+              },
+              {
+                "id": "sp_sunday_to",
+                "label": "Sunday To",
+                "type": "time",
+                "ui": {
+                  "rowGroup": "Sunday",
+                  "column": 2
+                }
+              }
+            ]
+          },
+          {
+            "id": "first_parent_travel_time",
+            "title": "First Parent Travel Time",
+            "description": "Enter the travel times and method of transport for the first parent.",
+            "fields": [
+              {
+                "id": "fp_dropoff_travel_time",
+                "label": "Drop-off Travel Time",
+                "type": "select",
+                "tooltip": "Select your typical travel time from work/activity to your child care provider",
+                "ui": {
+                  "options": [
+                    "",
+                    "15 min",
+                    "30 min",
+                    "45 min",
+                    "1 hour",
+                    "More than 1 hour"
+                  ]
+                }
+              },
+              {
+                "id": "fp_dropoff_time_gt_1hr",
+                "label": "Drop-off Time (if > 1 hour)",
+                "type": "text",
+                "requiredCondition": {
+                  "field": "fp_dropoff_travel_time",
+                  "operator": "equals",
+                  "value": "More than 1 hour"
+                }
+              },
+              {
+                "id": "fp_pickup_travel_time",
+                "label": "Pick-up Travel Time",
+                "type": "select",
+                "tooltip": "Select your typical travel time from work/activity to your child care provider",
+                "ui": {
+                  "options": [
+                    "",
+                    "15 min",
+                    "30 min",
+                    "45 min",
+                    "1 hour",
+                    "More than 1 hour"
+                  ]
+                }
+              },
+              {
+                "id": "fp_pickup_time_gt_1hr",
+                "label": "Pick-up Time (if > 1 hour)",
+                "type": "text",
+                "requiredCondition": {
+                  "field": "fp_pickup_travel_time",
+                  "operator": "equals",
+                  "value": "More than 1 hour"
+                }
+              },
+              {
+                "id": "fp_public_transport_dropoff",
+                "label": "Public Transport for Drop-off?",
+                "type": "radio",
+                "tooltip": "Indicate if the applicant uses public transportation to travel to and from work/activity to provider.",
+                "ui": {
+                  "options": [
+                    "Yes",
+                    "No"
+                  ]
+                }
+              },
+              {
+                "id": "fp_public_transport_pickup",
+                "label": "Public Transport for Pick-up?",
+                "tooltip": "Indicate if the applicant uses public transportation to travel to and from work/activity to provider.",
+                "type": "radio",
+                "ui": {
+                  "options": [
+                    "Yes",
+                    "No"
+                  ]
+                }
+              }
+            ]
+          },
+          {
+            "id": "second_parent_travel_time",
+            "title": "Second Parent Travel Time",
+            "description": "Enter the travel times and method of transport for the second parent.",
+            "fields": [
+              {
+                "id": "sp_dropoff_travel_time",
+                "label": "Drop-off Travel Time",
+                "type": "select",
+                "ui": {
+                  "options": [
+                    "",
+                    "15 min",
+                    "30 min",
+                    "45 min",
+                    "1 hour",
+                    "More than 1 hour"
+                  ]
+                }
+              },
+              {
+                "id": "sp_pickup_travel_time",
+                "label": "Pick-up Travel Time",
+                "type": "select",
+                "ui": {
+                  "options": [
+                    "",
+                    "15 min",
+                    "30 min",
+                    "45 min",
+                    "1 hour",
+                    "More than 1 hour"
+                  ]
+                }
+              },
+              {
+                "id": "sp_dropoff_time_gt_1hr",
+                "label": "Drop-off Time (if > 1 hour)",
+                "type": "text",
+                "requiredCondition": {
+                  "field": "sp_dropoff_travel_time",
+                  "operator": "equals",
+                  "value": "More than 1 hour"
+                }
+              },
+              {
+                "id": "sp_pickup_time_gt_1hr",
+                "label": "Pick-up Time (if > 1 hour)",
+                "type": "text",
+                "requiredCondition": {
+                  "field": "sp_pickup_travel_time",
+                  "operator": "equals",
+                  "value": "More than 1 hour"
+                }
+              },
+              {
+                "id": "sp_public_transport_dropoff",
+                "label": "Public Transport for Drop-off?",
+                "type": "radio",
+                "ui": {
+                  "options": [
+                    "Yes",
+                    "No"
+                  ]
+                }
+              },
+              {
+                "id": "sp_public_transport_pickup",
+                "label": "Public Transport for Pick-up?",
+                "type": "radio",
+                "ui": {
+                  "options": [
+                    "Yes",
+                    "No"
+                  ]
+                }
+              }
+            ]
+          }
+        ]
+      },
+      {
+        "id": "income",
+        "title": "Income Information",
+        "sections": [
+          {
+            "id": "income_step_info",
+            "title": "Instructions",
+            "type": "info",
+            "ui": {
+              "markdown": true,
+              "collapsible": false,
+              "defaultCollapsed": false
+            },
+            "content": "Please include income/benefits information for yourself and, if applicable, your spouse, your child’s second caretaker, and/or any other adult with whom you share a child, if they live in your home.\\n\\nIndicate if you receive money from the following sources by selecting “Yes” or “No.” If you select “Yes,” you will be asked for additional information.\\n\\nIf the second caretaker in the household also receives the same income source, add a separate line for their income."
+          },
+          {
+            "id": "income_sources",
+            "title": "Income Sources",
+            "description": "Provide details about all income sources applicable to the applicant or household.",
+            "fields": [
+              {
+                "id": "income_sources",
+                "label": "List of Income Sources",
+                "type": "group",
+                "metadata": {
+                  "multiple": true,
+                  "tableColumns": [
+                    "name_ref",
+                    "how_often",
+                    "recipient",
+                    "monthly_amount"
+                  ]
+                },
+                "fields": [
+                  {
+                    "id": "name_ref",
+                    "label": "Income Source Type",
+                    "type": "select",
+                    "required": true,
+                    "ui": {
+                      "options": [
+                        "",
+                        "ApplicantWages",
+                        "SecondParentWages",
+                        "SelfEmployment",
+                        "ChildSupport",
+                        "Alimony",
+                        "Unemployment",
+                        "SocialSecurity",
+                        "Disability",
+                        "Rental",
+                        "Dividends",
+                        "Retirement",
+                        "CashAssistance",
+                        "Other"
+                      ]
+                    }
+                  },
+                  {
+                    "id": "other_source_text",
+                    "label": "Other Source (If applicable)",
+                    "type": "text",
+                    "visibilityCondition": {
+                      "field": "name_ref",
+                      "operator": "equals",
+                      "value": "Other"
+                    },
+                    "requiredCondition": {
+                      "condition": {
+                        "field": "name_ref",
+                        "operator": "equals",
+                        "value": "Other"
+                      }
+                    }
+                  },
+                  {
+                    "id": "is_source_applicable",
+                    "label": "Is this Source Applicable?",
+                    "type": "radio",
+                    "required": true,
+                    "ui": {
+                      "options": [
+                        "Yes",
+                        "No"
+                      ]
+                    }
+                  },
+                  {
+                    "id": "gross_amount",
+                    "label": "Gross Amount ($)",
+                    "type": "number",
+                    "required": true
+                  },
+                  {
+                    "id": "how_often",
+                    "label": "Frequency of Income",
+                    "type": "radio",
+                    "required": true,
+                    "ui": {
+                      "options": [
+                        "Weekly",
+                        "Bi-weekly",
+                        "Monthly",
+                        "Other"
+                      ]
+                    }
+                  },
+                  {
+                    "id": "recipient",
+                    "label": "Recipient of Income",
+                    "type": "text",
+                    "required": true
+                  },
+                  {
+                    "id": "monthly_amount",
+                    "label": "Monthly Amount ($)",
+                    "type": "number",
+                    "required": true
+                  }
+                ]
+              }
+            ]
+          },
+          {
+            "id": "total_income",
+            "title": "Total Household Income",
+            "description": "Sum of all monthly income across sources.",
+            "fields": [
+              {
+                "id": "total_income",
+                "label": "Total Monthly Income ($)",
+                "type": "number",
+                "required": true
+              }
+            ]
+          },
+          {
+            "id": "income_proof_section",
+            "title": "Income Proof",
+            "fields": [
+              {
+                "id": "income_proof",
+                "label": "Upload Income Proof",
+                "type": "file",
+                "requiredCondition": {
+                  "condition": {
+                    "field": "assistance_reason",
+                    "operator": "includes",
+                    "value": "Employment"
+                  }
+                },
+                "constraints": {
+                  "maxFileSizeMB": 5,
+                  "allowedTypes": [
+                    "application/pdf",
+                    "image/jpeg"
+                  ],
+                  "imageResolution": {
+                    "minWidth": 800,
+                    "minHeight": 600
+                  }
+                },
+                "metadata": {
+                  "proofCategory": "Income Verification",
+                  "examples": [
+                    "Pay Stub",
+                    "W-2"
+                  ],
+                  "multiple": true
+                }
+              }
+            ]
+          }
+        ]
+      },
+      {
+        "id": "provider",
+        "title": "Provider",
+        "sections": [
+          {
+            "id": "provider_step_info",
+            "title": "Instructions",
+            "type": "info",
+            "ui": {
+              "markdown": true,
+              "collapsible": false,
+              "defaultCollapsed": false
+            },
+            "content": "If you are found eligible for child care assistance, you can choose center-based or home-based care from a licensed, registered, or legally exempt provider. If you choose a provider that is not licensed or registered, the provider must be enrolled as a legally exempt provider.\\n\\nIf you know which child care providers you would like your child to attend, provide the names and addresses of your choice of providers. You can leave this section blank if you do not know (it will not impact your eligibility and you will have an opportunity to select a provider if determined eligible)."
+          },
+          {
+            "id": "provider_choices",
+            "title": "Provider Choices",
+            "description": "Specify details of the provider where you intend to enroll the child(ren).",
+            "fields": [
+              {
+                "id": "provider_choices",
+                "label": "List of Providers",
+                "type": "group",
+                "metadata": {
+                  "multiple": true,
+                  "tableColumns": [
+                    "provider_name",
+                    "program_number",
+                    "provider_zip_code"
+                  ]
+                },
+                "fields": [
+                  {
+                    "id": "provider_name",
+                    "label": "Provider Name",
+                    "type": "text",
+                    "required": true
+                  },
+                  {
+                    "id": "program_number",
+                    "label": "Program Number (If Applicable)",
+                    "type": "text",
+                    "required": false
+                  },
+                  {
+                    "id": "provider_street",
+                    "label": "Street Address",
+                    "type": "text",
+                    "required": true
+                  },
+                  {
+                    "id": "provider_city",
+                    "label": "City",
+                    "type": "text",
+                    "required": true
+                  },
+                  {
+                    "id": "provider_state",
+                    "label": "State",
+                    "type": "text",
+                    "required": true
+                  },
+                  {
+                    "id": "provider_zip_code",
+                    "label": "Zip Code",
+                    "type": "text",
+                    "required": true
+                  }
+                ]
+              }
+            ]
+          }
+        ]
+      },
+      {
+        "id": "document_upload_step",
+        "title": "Document Upload",
+        "description": "The Application for Child Care Assistance (CFWB-012) must include supporting documentation. Check to ensure that documentation is provided for each requirement of subsidy eligibility.",
+        "sections": [
+          {
+            "id": "nyc_residency",
+            "title": "New York City Residency",
+            "description": "These documents confirm that you live in New York City. Please upload one of the following documents.",
+            "fields": [
+              {
+                "id": "nyc_residency_type",
+                "label": "Select one of the following:",
+                "type": "radio",
+                "required": true,
+                "ui": {
+                  "options": [
+                    "IDNYC",
+                    "Utility Bill",
+                    "Section 8 Award Letter",
+                    "Driver’s License",
+                    "Rent Receipt",
+                    "NYCHA Certificate",
+                    "CFWB-067 Residency Attestation",
+                    "CFWB-027 Housing Attestation with address listed",
+                    "Shelter Residency Letter with address listed",
+                    "Other"
+                  ]
+                }
+              },
+              {
+                "id": "nyc_residency_file",
+                "label": "Upload Residency Proof Document",
+                "description": "To add a document to your application, you can upload an image or scanned file from your phone or device. Accepted formats include .pdf, .gif, .jpeg, .jpg and .png up to 25 MB. Learn how to upload your files with this Tutorial Video.",
+                "type": "file",
+                "required": true, 
+                "constraints": {
+                  "maxFileSizeMB": 25,
+                  "allowedTypes": [
+                    "application/pdf",
+                    "image/jpeg",
+                    "image/jpg",
+                    "image/png",
+                    "image/gif"
+                  ]
+                },
+                "metadata": {
+                  "proofCategory": "NYC Residency",
+                  "multiple": false
+                }
+              }
+            ]
+          },
+          {
+            "id": "citizenship_status",
+            "title": "Citizenship or Immigration Status",
+            "description": "These documents confirm the citizenship/immigration status of the children in your family for whom you’re applying for child care assistance. Please upload one of the following documents for ONLY each child needing care.",
+            "fields": [
+              {
+                "id": "citizenship_doc_type",
+                "label": "Select one of the following:",
+                "type": "radio",
+                "required": true,
+                "ui": {
+                  "options": [
+                    "US Birth Certificate",
+                    "Alien Registration Card including Permanent Resident or Green Card",
+                    "Passport",
+                    "FS-240 (Report of Birth Abroad of a U.S. Citizen)",
+                    "Naturalization Certificate",
+                    "Other"
+                  ]
+                }
+              },
+              {
+                "id": "citizenship_doc_file",
+                "label": "Upload Citizenship/Immigration Document",
+                "description": "To add a document to your application, you can upload an image or scanned file from your phone or device. Accepted formats include .pdf, .gif, .jpeg, .jpg and .png up to 25 MB. Learn how to upload your files with this Tutorial Video.",
+                "type": "file",
+                "required": true,
+                "constraints": {
+                  "maxFileSizeMB": 25,
+                  "allowedTypes": [
+                    "application/pdf",
+                    "image/jpeg",
+                    "image/jpg",
+                    "image/png",
+                    "image/gif"
+                  ]
+                },
+                "metadata": {
+                  "proofCategory": "Citizenship/Immigration Status",
+                  "multiple": false
+                }
+              }
+            ]
+          },
+          {
+            "id": "child_relationship",
+            "title": "Child’s Relationship to Parent/Applicant",
+            "description": "These documents confirm your relationship to the children in your household under age 18. Please upload one of the following documents for every child in the household under age 18, regardless of whether child care is needed for them or not. If you are a legal guardian with financial responsibility, you must upload a Court order OR a letter of guardianship.",
+            "fields": [
+              {
+                "id": "relationship_doc_type",
+                "label": "Select one of the following:",
+                "type": "radio",
+                "required": true,
+                "ui": {
+                  "options": [
+                    "Birth Certificate",
+                    "Adoption record",
+                    "Baptismal record",
+                    "Passport with parent's signature",
+                    "Court order for legal guardian with financial responsibility",
+                    "Letter of Guardianship",
+                    "Other - CFWB-058 Caretaker Attestation"
+                  ]
+                }
+              },
+              {
+                "id": "relationship_doc_file",
+                "label": "Upload Relationship Document",
+                "description": "To add a document to your application, you can upload an image or scanned file from your phone or device. Accepted formats include .pdf, .gif, .jpeg, .jpg and .png up to 25 MB. Learn how to upload your files with this Tutorial Video.",
+                "type": "file",
+                "required": true,
+                "constraints": {
+                  "maxFileSizeMB": 25,
+                  "allowedTypes": [
+                    "application/pdf",
+                    "image/jpeg",
+                    "image/jpg",
+                    "image/png",
+                    "image/gif"
+                  ]
+                },
+                "metadata": {
+                  "proofCategory": "Child Relationship",
+                  "multiple": false
+                }
+              }
+            ]
+          },
+          {
+            "id": "age_proof",
+            "title": "Age",
+            "description": "These documents confirm the age of the children in your household. Please upload one of the following documents for every child in the household under age 18, regardless of whether child care is needed for them:",
+            "fields": [
+              {
+                "id": "age_doc_type",
+                "label": "Select one of the following:",
+                "type": "radio",
+                "required": true,
+                "ui": {
+                  "options": [
+                    "Birth Certificate",
+                    "Adoption record",
+                    "Baptismal record",
+                    "Alien Registration Card",
+                    "Passport",
+                    "Official hospital documentation of the child’s birth"
+                  ]
+                }
+              },
+              {
+                "id": "age_doc_file",
+                "label": "Upload Age Proof Document",
+                "description": "To add a document to your application, you can upload an image or scanned file from your phone or device. Accepted formats include .pdf, .gif, .jpeg, .jpg and .png up to 25 MB. Learn how to upload your files with this Tutorial Video.",
+                "type": "file",
+                "required": true,
+                "constraints": {
+                  "maxFileSizeMB": 25,
+                  "allowedTypes": [
+                    "application/pdf",
+                    "image/jpeg",
+                    "image/jpg",
+                    "image/png",
+                    "image/gif"
+                  ]
+                },
+                "metadata": {
+                  "proofCategory": "Child Age",
+                  "multiple": false
+                }
+              }
+            ]
+          }
+        ]
+      },
+      {
+        "id": "review",
+        "title": "Review & Submit",
+        "type": "review",
+        "sections": []
+      }
+    ]
+  }
+}

--- a/test-form/public/data/childcare_form.en.json
+++ b/test-form/public/data/childcare_form.en.json
@@ -1,0 +1,2287 @@
+{
+  "form": {
+    "title": "Childcare Voucher Application",
+    "description": "Step-by-step form for applying for Childcare Assistance",
+    "layout": {
+      "stepperPosition": "left"
+    },
+    "steps": [
+      {
+        "id": "consent_step",
+        "title": "Consent",
+        "sections": [
+          {
+            "id": "mycity_consent_info",
+            "title": "ModelCity Consent",
+            "type": "info",
+            "ui": {
+              "markdown": true,
+              "collapsible": false,
+              "defaultCollapsed": false
+            },
+            "content": "In connection with this application for child care services, **ModelCity**:\\n\\n- Collects, processes, stores, and shares the information you submit to screen you when you apply for child care services;\\n- Receives, processes, and stores the information the City already knows about you to screen you when you apply for child care services;\\n- Uses your information to improve ModelCity; and\\n- Communicates with you about your ModelCity account.\\n\\n---\\n\\nIf you consent, the following information may be shared between child care services agencies:\\n\\n- Demographic and background information, including address, phone number, household composition.\\n- Housing information, including benefits awarded/received, current housing/shelter status.\\n- Benefits information, including public assistance awarded/received, child care program participation.\\n\\n---\\n\\nIf you choose not to consent, **you will not be denied** any benefits or services you are receiving or any benefits for which you are eligible.\\n\\nThe [ModelCity Privacy Policy](https://www.nyc.gov/privacy) details how ModelCity handles the information you submit through ModelCity."
+          }
+        ]
+      },
+      {
+        "id": "instructions_step",
+        "title": "Instructions",
+        "sections": [
+          {
+            "id": "application_instructions",
+            "title": "Application Instructions",
+            "type": "info",
+            "ui": {
+              "markdown": true,
+              "collapsible": false,
+              "defaultCollapsed": false
+            },
+            "content": "**Let’s get started on your application!**\\n\\nTo complete this application, you will be asked for information about:\\n\\n- Yourself\\n- Your household\\n- Your employment or reason for care\\n- Your income\\n\\nAll required fields are marked and must be filled out to move forward with the application. The pages of the application are shown on the right-hand side of the screen and will be highlighted as you move through the application.\\n\\nYour application will be saved automatically as you progress to each page.  \\nIf you need to pause at any time, click the **“Save for later”** button at the bottom of each page to save your application.  \\nYou can log back in to resume your application.\\n\\nWhen you’re ready to begin, click **“Next”** below.\\n\\n---\\n\\n⚠️ **Important:**  \\nTo keep your information current and safe, applications in draft status that you have not edited for **30 days** will be deleted.  \\nIf your draft application is deleted, you can still create and submit a new application when you're ready to apply."
+          },
+          {
+            "id": "new_york_city_residency",
+            "title": "New York City Residency",
+            "type": "info",
+            "ui": {
+              "markdown": true,
+              "collapsible": true,
+              "defaultCollapsed": true
+            },
+            "content": "You will need to upload **ONE** of the following documents to confirm your NYC residency:\\n\\n- IDNYC\\n- Driver’s License\\n- Utility Bill (dated within the last 60 days, with your address)\\n- Current lease, rent, or mortgage statement (dated within the last 60 days, with your address)\\n- Section 8 Award Letter\\n- NYCHA Certificate\\n- CFWB-027 Housing Attestation with address listed\\n- Shelter Residency Letter with address listed\\n\\nIf you do not have any of those documents, you must submit a **CFWB-067 Residency Attestation**."
+          },
+          {
+            "id": "children_documents",
+            "title": "Children Documents",
+            "type": "info",
+            "ui": {
+              "markdown": true,
+              "collapsible": true,
+              "defaultCollapsed": true
+            },
+            "content": "### Citizenship or Immigration Status\\nThese documents confirm the citizenship or immigration status of the children in your family for whom you’re applying for child care assistance. Please upload one of the following documents for each child needing care. *Do not upload these documents for children who do not need care.*\\n\\n- Birth Certificate from US state or territory\\n- Alien Registration Card including Permanent Resident or Green Card\\n- Passport\\n- FS-240 (Consular Report of Birth Abroad)\\n- Naturalization Certificate\\n- Other documentation that proves child’s immigration status\\n\\n### Child's Relationship to Applicant\\nThese documents confirm your relationship to the children in your household under age 18. Please upload one of the following documents for every child in the household under age 18, regardless of whether they need child care.\\n\\n- Birth certificate\\n- Adoption record\\n- Baptismal record\\n- Passport with parent's signature\\n- Court order for legal guardian with financial responsibility\\n- Letter of guardianship\\n- Other - CFWB-058 Caretaker Attestation\\n\\nIf you are not the child's parent or stepparent, you must submit a **CFWB-058 Caretaker Attestation Form**.\\n\\n### Age of Children\\nYou will need to upload **ONE** of the following documents for every child in the household under age 18, regardless of whether child care is needed for them:\\n\\n- Birth certificate\\n- Adoption record\\n- Baptismal record\\n- Alien Registration Card\\n- Passport\\n- Official hospital documentation of the child’s birth"
+          },
+          {
+            "id": "employment_income",
+            "title": "Employment & Income",
+            "type": "info",
+            "ui": {
+              "markdown": true,
+              "collapsible": true,
+              "defaultCollapsed": true
+            },
+            "content": "### Income\\nThese documents confirm your family’s income.\\n\\n---\\n\\n### If You Are Employed\\nIf you are employed and receive paystubs, you must submit them to confirm your income. The number of paystubs you must submit varies by how often you get paid and whether your payment amount is the same or different each time you are paid – see the table below for details. Submit the most recent paystub you have received, followed by others in consecutive order.\\n\\n**Income Information**\\n\\n| How Often Do You Get Paid? | Always the SAME Amount | DIFFERENT Amounts Each Time |\\n|----------------------------|-------------------------|------------------------------|\\n| Weekly (Every Week) | 4 most recent, consecutive pay stubs | 12 most recent, consecutive pay stubs |\\n| Bi-Weekly (Every Two Weeks) | 2 most recent, consecutive pay stubs | 6 most recent, consecutive pay stubs |\\n| Semi-Monthly (Two Times Per Month) | 2 most recent, consecutive pay stubs | 6 most recent, consecutive pay stubs |\\n| Monthly (One Time Per Month) | 3 most recent, consecutive pay stubs | 3 most recent, consecutive pay stubs |\\n\\nIf you do not have any paystubs, you must submit a **CFWB-015 Referral to Employer for Employee Income Information Form**.\\n\\n---\\n\\n### If You Are Self-Employed\\nIf you have been self-employed for **one year or more**, you must submit a current, complete and signed income tax package (e.g., 1040, 1065, Schedule C, SE for partnership, K-1, etc.).\\n\\nIf you have been self-employed for **less than one year**, you must submit a **CFWB-031 Self-Employment Income Information Attestation Form**.\\n\\n---\\n\\n### Other Income\\nIf you receive other types of income outside or instead of employment income, you must submit your most recent check, pay stub, or current award letter that indicates the amount you receive. If your other income fluctuates, **3 months of documentation is required**.\\n\\nThis includes, but is not limited to:\\n- Income from SSI, SSD\\n- Unemployment benefits\\n- Rental income\\n- Pensions\\n- Annuities\\n- Worker’s compensation\\n- Alimony\\n- Child support"
+          },
+          {
+            "id": "reason_for_care",
+            "title": "Reason for Care",
+            "type": "info",
+            "ui": {
+              "markdown": true,
+              "collapsible": true,
+              "defaultCollapsed": true
+            },
+            "content": "### Reason for Care\\nThese documents confirm your reason for care. Every applicant must have a qualified reason for care; in a two-parent household, parents or caretakers can have the same or different reasons for care. Only the documents related to your stated reasons for care need to be uploaded, and documentation must be uploaded for all parent or caretakers in the household.\\n\\n---\\n\\n### Working 10+ Hours Per Week\\nYour employment or self-employment income documents will cover this reason for care. You do not need to submit additional documentation.\\n\\n---\\n\\n### Participating in an Educational or Vocational Training Program\\nYou will need to upload **ONE** of the following documents to confirm your participation in vocational school, two-year college, or four-year college.\\n\\n- CFWB-005 Vocational, Education and Training Verification Form\\n- A letter from the educational or vocational training program on their official letterhead; this letter must contain all the information required in the CFWB-005 Vocational, Education and Training Verification Form.\\n\\n---\\n\\n### Looking for Work\\nYou will need to upload **ONE** of the following documents to confirm that you are looking for work.\\n\\n- CFWB-026 Work Search Record Form\\n- Approved work search plan from the NYS Dept. of Labor\\n- Proof of receipt of unemployment insurance\\n\\n---\\n\\n### Experiencing Homelessness\\nYou will need to upload **ONE** of the following documents to confirm that you are experiencing homelessness. This includes families who may be living in shelter or sharing the housing of others due to loss of housing, economic hardship, or similar reason.\\n\\n- Shelter Residency Letter (If living in Shelter, including Humanitarian Emergency Relief Centers)\\n- CFWB-027 Housing Attestation (If living doubled-up, in a place not meant for human habitation, in a hotel/motel, or in another living situation)\\n\\n---\\n\\n### Attending Services for Domestic Violence\\nYou will need to upload a referral for services from a domestic violence service provider to confirm that you are attending services for domestic violence.\\n\\n---\\n\\n### Attending Services for Substance Abuse Treatment\\nYou will need to upload a referral for a substance abuse treatment service provider to confirm that you are attending services for substance abuse treatment."
+          },
+          {
+            "id": "additional_details",
+            "title": "Additional Details",
+            "type": "info",
+            "ui": {
+              "markdown": true,
+              "collapsible": true,
+              "defaultCollapsed": true
+            },
+            "content": "### Application Scope\\nThis application is used to apply **only** for **Category 2 or 3 child care assistance** (for families not in receipt of cash assistance). To apply for **Cash Assistance** or other benefits, including **Category 1 Child Care Assistance** (for families in receipt of cash assistance), you must use the **New York State Application for Certain Benefits and Services (LDSS-2921)**.\\n\\n---\\n\\n### Exempt Applicants\\nThe following applicants may be eligible for child care assistance **without regard to income** and do not need to complete this application:\\n\\n- Foster parents who need child care assistance to allow them to work and are only applying for assistance for the foster children;\\n- Families in receipt of protective or preventive services.\\n\\n---\\n\\n### Application Completion\\nAll sections of this form must be filled out to be considered complete **unless the section is identified as optional**. If you do not complete all required sections of this form, you may not be considered for Child Care Assistance.\\n\\n---\\n\\n### Rights and Responsibilities\\nYou may obtain information about your rights and responsibilities [here](https://otda.ny.gov/programs/applications/). If you do not have access to the internet, you can call the **Administration for Children’s Services at 212-835-7610** to request that physical copies of the booklets which highlight your rights and responsibilities be mailed to you, including:\\n\\n- **LDSS-4148A**: What You Should Know About Your Rights and Responsibilities\\n- **LDSS-4148B**: What You Should Know About Social Services Programs\\n- **LDSS-4148C**: What You Should Know If You Have an Emergency"
+          }
+        ]
+      },
+      {
+        "id": "applicant",
+        "title": "Applicant",
+        "sections": [
+          {
+            "id": "personal_info",
+            "title": "Personal Information",
+            "fields": [
+              {
+                "id": "first_name",
+                "label": "First Name",
+                "type": "text",
+                "required": true
+              },
+              {
+                "id": "last_name",
+                "label": "Last Name",
+                "type": "text",
+                "required": true
+              },
+              {
+                "id": "mi",
+                "label": "Middle Initial",
+                "type": "text",
+                "required": false
+              },
+              {
+                "id": "date_of_birth",
+                "label": "Date of Birth",
+                "type": "date",
+                "required": true,
+                "tooltip": "To edit Date of Birth click on NYC ModelCity in the top-left corner then click on Account Settings."
+              },
+              {
+                "id": "sex",
+                "label": "Sex",
+                "type": "radio",
+                "required": true,
+                "ui": {
+                  "options": [
+                    "Male",
+                    "Female"
+                  ]
+                }
+              },
+              {
+                "id": "marital_status",
+                "label": "Marital Status",
+                "type": "select",
+                "required": true,
+                "tooltip": "Indicate your marital status (single, married, divorced, separated or widowed).",
+                "ui": {
+                  "options": [
+                    "",
+                    "Single",
+                    "Married",
+                    "Divorced",
+                    "Widowed",
+                    "Separated"
+                  ]
+                }
+              }
+            ]
+          },
+          {
+            "id": "contact_info",
+            "title": "Contact Information",
+            "fields": [
+              {
+                "id": "telephone_home",
+                "label": "Home Phone",
+                "type": "tel",
+                "required": false,
+                "constraints": {
+                  "pattern": "^\\\\(?[0-9]{3}\\\\)?[-. ]?[0-9]{3}[-. ]?[0-9]{4}$"
+                },
+                "ui": {
+                  "placeholder": "(123) 456-7890"
+                }
+              },
+              {
+                "id": "telephone_work",
+                "label": "Work Phone",
+                "type": "tel",
+                "required": false,
+                "constraints": {
+                  "pattern": "^\\\\(?[0-9]{3}\\\\)?[-. ]?[0-9]{3}[-. ]?[0-9]{4}$"
+                },
+                "ui": {
+                  "placeholder": "(123) 456-7890"
+                }
+              },
+              {
+                "id": "telephone_mobile_or_other",
+                "label": "Mobile or Other Phone",
+                "type": "tel",
+                "required": false,
+                "tooltip": "To edit Telephone (Cell or Other) click on NYC ModelCity in the top-left corner then click on Account Settings and then click on Contact.",
+                "constraints": {
+                  "pattern": "^\\\\(?[0-9]{3}\\\\)?[-. ]?[0-9]{3}[-. ]?[0-9]{4}$"
+                },
+                "ui": {
+                  "placeholder": "(123) 456-7890"
+                }
+              },
+              {
+                "id": "email",
+                "label": "Email",
+                "type": "email",
+                "required": true,
+                "tooltip": "To edit email, go to NYC ID Profile tab by clicking your name at the top right corner"
+              }
+            ]
+          },
+          {
+            "id": "address_info",
+            "title": "Address",
+            "tooltip": "To edit home address click on NYC ModelCity in the top-left corner then click on Account Settings.",
+            "ui": {
+              "autocomplete": "street",
+              "placeholder": "Start typing your street address",
+              "overrideComponent": "AddressAutocomplete"
+            },
+            "metadata": {
+              "integration": {
+                "provider": "Google",
+                "feature": "AddressAutocomplete"
+              },
+              "autofillTargets": [
+                {
+                  "fieldId": "city",
+                  "source": "locality",
+                  "fallbackSources": [
+                    "postal_town",
+                    "sublocality_level_1",
+                    "administrative_area_level_2"
+                  ]
+                },
+                {
+                  "fieldId": "borough",
+                  "source": "sublocality_level_1",
+                  "fallbackSources": [
+                    "administrative_area_level_2"
+                  ],
+                  "mapping": "boroughMap"
+                },
+                { "fieldId": "state", "source": "administrative_area_level_1" },
+                { "fieldId": "zip_code", "source": "postal_code" },
+                { "fieldId": "latitude", "source": "location.latitude" },
+                { "fieldId": "longitude", "source": "location.longitude" }
+              ]
+            },
+            "fields": [
+              {
+                "id": "street",
+                "label": "Street Address",
+                "type": "text",
+                "required": true,
+                "tooltip": "To edit home address click on NYC ModelCity in the top-left corner then click on Account Settings."
+              },
+              {
+                "id": "apt",
+                "label": "Apt #",
+                "type": "text",
+                "required": false
+              },
+              {
+                "id": "city",
+                "label": "City",
+                "type": "text",
+                "required": true
+              },
+              {
+                "id": "borough",
+                "label": "Borough",
+                "type": "select",
+                "required": true,
+                "ui": {
+                  "options": [
+                    "",
+                    "Bronx",
+                    "Brooklyn",
+                    "Manhattan",
+                    "Queens",
+                    "Staten Island"
+                  ]
+                }
+              },
+              {
+                "id": "state",
+                "label": "State",
+                "type": "text",
+                "required": true
+              },
+              {
+                "id": "zip_code",
+                "label": "Zip Code",
+                "type": "text",
+                "required": true
+              },
+              {
+                "id": "latitude",
+                "label": "Latitude",
+                "type": "number",
+                "required": false
+              },
+              {
+                "id": "longitude",
+                "label": "Longitude",
+                "type": "number",
+                "required": false
+              },
+              {
+                "id": "is_temporary_address",
+                "label": "Is Temporary Address",
+                "type": "radio",
+                "required": true,
+                "tooltip": "Check YES if you are currently living in a homeless shelter, doubled-up with another family, in a hotel/motel, in a car/ bus/ train, in a park/campsite, or other temporary accomodation.",
+                "ui": {
+                  "options": [
+                    "Yes",
+                    "No"
+                  ]
+                }
+              },
+              {
+                "id": "currently_living_in",
+                "label": "Currently Living In",
+                "type": "select",
+                "required": false,
+                "requiredCondition": {
+                  "field": "is_temporary_address",
+                  "operator": "equals",
+                  "value": "Yes"
+                },
+                "ui": {
+                  "options": [
+                    "",
+                    "Homeless Shelter",
+                    "Doubled-up with another Family",
+                    "Hotel/Motel",
+                    "Car, Bus, Train",
+                    "Park",
+                    "Campsite",
+                    "Other"
+                  ]
+                }
+              }
+            ]
+          },
+          {
+            "id": "demographics",
+            "title": "Demographics",
+            "fields": [
+              {
+                "id": "ethnicity",
+                "label": "Ethnicity",
+                "type": "select",
+                "required": false,
+                "ui": {
+                  "options": [
+                    "",
+                    "Hispanic",
+                    "Latino",
+                    "No",
+                    "Prefer not to answer"
+                  ]
+                }
+              },
+              {
+                "id": "race",
+                "label": "Race",
+                "type": "checkbox",
+                "required": false,
+                "tooltip": "You may choose multiple race categories. Providing race information is voluntary and will not affect your eligibility for Child Care Assistance or the amount of assistance that you will be given by this agency.",
+                "ui": {
+                  "options": [
+                    {
+                      "value": "AI",
+                      "label": "American Indian or Alaska Native"
+                    },
+                    {
+                      "value": "AS",
+                      "label": "Asian"
+                    },
+                    {
+                      "value": "BL",
+                      "label": "Black or African American"
+                    },
+                    {
+                      "value": "HP",
+                      "label": "Native Hawaiian or Pacific Islander"
+                    },
+                    {
+                      "value": "WH",
+                      "label": "White"
+                    }
+                  ]
+                },
+                "metadata": {
+                  "multiple": true
+                }
+              },
+              {
+                "id": "ssn",
+                "label": "Social Security Number",
+                "type": "text",
+                "tooltip": "To edit social security number click on NYC ModelCity in the top-left corner then click on Account Settings.",
+                "required": false,
+                "constraints": {
+                  "pattern": "^\\\\d{3}-\\\\d{2}-\\\\d{4}$"
+                },
+                "ui": {
+                  "placeholder": "123-45-6789"
+                }
+              }
+            ]
+          },
+          {
+            "id": "language_info",
+            "title": "Language Preferences",
+            "fields": [
+              {
+                "id": "primary_language",
+                "label": "Primary Language",
+                "type": "radio",
+                "required": true,
+                "tooltip": "Select the language that is spoken most often in your household. If “other”, provide the name of the language.",
+                "ui": {
+                  "options": [
+                    "English",
+                    "Spanish",
+                    "Other"
+                  ]
+                }
+              },
+              {
+                "id": "preferred_language",
+                "label": "Preferred Language",
+                "type": "radio",
+                "required": true,
+                "tooltip": "Select the language you prefer to communicate in. If “other”, provide the name of the language.",
+                "ui": {
+                  "options": [
+                    "English",
+                    "Spanish",
+                    "Other"
+                  ]
+                }
+              },
+              {
+                "id": "other_primary_language",
+                "label": "Other Primary Language",
+                "type": "text",
+                "required": false,
+                "requiredCondition": {
+                  "field": "primary_language",
+                  "operator": "equals",
+                  "value": "Other"
+                }
+              },
+              {
+                "id": "other_preferred_language",
+                "label": "Other Preferred Language",
+                "type": "text",
+                "required": false,
+                "requiredCondition": {
+                  "field": "preferred_language",
+                  "operator": "equals",
+                  "value": "Other"
+                }
+              }
+            ]
+          },
+          {
+            "id": "cash_assistance",
+            "title": "Cash Assistance",
+            "fields": [
+              {
+                "id": "has_cash_assistance",
+                "label": "Do you receive Cash Assistance?",
+                "type": "radio",
+                "required": false,
+                "ui": {
+                  "options": [
+                    "Yes",
+                    "No"
+                  ]
+                }
+              },
+              {
+                "id": "ca_number",
+                "label": "Cash Assistance Number",
+                "type": "text",
+                "required": false,
+                "requiredCondition": {
+                  "condition": {
+                    "field": "has_cash_assistance",
+                    "operator": "equals",
+                    "value": "Yes"
+                  }
+                }
+              }
+            ]
+          }
+        ]
+      },
+      {
+        "id": "children_needing_care",
+        "title": "Children Needing Care",
+        "sections": [
+          {
+            "id": "child_details",
+            "title": "Child Details",
+            "required": true,
+            "fields": [
+              {
+                "id": "children",
+                "label": "Children Needing Care",
+                "type": "group",
+                "metadata": {
+                  "multiple": true,
+                  "tableColumns": [
+                  "first_name",
+                  "last_name",
+                  "date_of_birth",
+                  "relationship_to_applicant"
+                  ]
+                },
+                "fields": [
+                  {
+                    "id": "first_name",
+                    "label": "First Name",
+                    "type": "text",
+                    "required": true,
+                    "tooltip": "Provide the first name, last name, and middle initial of each child you are applying for child care assistance for."
+                  },
+                  {
+                    "id": "last_name",
+                    "label": "Last Name",
+                    "type": "text",
+                    "required": true
+                  },
+                  {
+                    "id": "mi",
+                    "label": "Middle Initial",
+                    "type": "text",
+                    "required": false
+                  },
+                  {
+                    "id": "relationship_to_applicant",
+                    "label": "Relationship to Applicant",
+                    "type": "select",
+                    "required": true,
+                    "ui": {
+                      "options": [
+                        "",
+                        "Child",
+                        "Grandchild",
+                        "Foster Child",
+                        "Other"
+                      ]
+                    }
+                  },
+                  {
+                    "id": "date_of_birth",
+                    "label": "Date of Birth",
+                    "type": "date",
+                    "required": true,
+                    "tooltip": "Provide the date of birth."
+                  },
+                  {
+                    "id": "sex",
+                    "label": "Sex",
+                    "type": "radio",
+                    "required": true,
+                    "tooltip": "Select to indicate the sex.",
+                    "ui": {
+                      "options": [
+                        "Male",
+                        "Female"
+                      ]
+                    }
+                  },
+                  {
+                    "id": "ethnicity",
+                    "label": "Ethnicity Hispanic or Latino",
+                    "type": "select",
+                    "required": false,
+                    "tooltip": "Check “YES” or “NO” to indicate if each child in need of child care is Hispanic or Latino or not. Providing ethnicity information is voluntary and will not affect your eligibility for child care assistance or the amount of assistance that you will be given by this agency.",
+                    "ui": {
+                      "options": [
+                        "",
+                        "Yes",
+                        "No",
+                        "Prefer not to answer"
+                      ]
+                    }
+                  },
+                  {
+                    "id": "race",
+                    "label": "Race",
+                    "type": "checkbox",
+                    "required": false,
+                    "tooltip": "You may choose multiple race categories for a single child. Providing race information is voluntary and will not affect your eligibility for Child Care Assistance or the amount of assistance that you will be given by this agency.",
+                    "ui": {
+                      "options": [
+                        {
+                          "value": "AI",
+                          "label": "American Indian or Alaska Native"
+                        },
+                        {
+                          "value": "AS",
+                          "label": "Asian"
+                        },
+                        {
+                          "value": "BL",
+                          "label": "Black or African American"
+                        },
+                        {
+                          "value": "HP",
+                          "label": "Native Hawaiian or Pacific Islander"
+                        },
+                        {
+                          "value": "WH",
+                          "label": "White"
+                        }
+                      ]
+                    },
+                    "metadata": {
+                      "multiple": true
+                    }
+                  },
+                  {
+                    "id": "ssn",
+                    "label": "Social Security Number",
+                    "type": "text",
+                    "required": false,
+                    "tooltip": "Provide each child’s Social Security Number (SSN). You are not required to provide SSNs. They may be used by federal, state, and local agencies to prevent duplication of services and fraud, and for Federal Reporting.",
+                    "constraints": {
+                      "pattern": "^\\\\d{3}-\\\\d{2}-\\\\d{4}$"
+                    },
+                    "ui": {
+                      "placeholder": "123-45-6789"
+                    }
+                  },
+                  {
+                    "id": "do_both_parents_reside_in_home",
+                    "label": "Do both parents reside in the home?",
+                    "type": "radio",
+                    "required": true,
+                    "tooltip": "Check “YES” or “NO” to indicate whether both of the child’s parents live in the home.",
+                    "ui": {
+                      "options": [
+                        "Yes",
+                        "No"
+                      ]
+                    }
+                  },
+                  {
+                    "id": "has_disability",
+                    "label": "Does the child have a disability?",
+                    "type": "radio",
+                    "required": true,
+                    "tooltip": "Check “YES” or “NO” to indicate whether the child needing child care has a disability.",
+                    "ui": {
+                      "options": [
+                        "Yes",
+                        "No"
+                      ]
+                    }
+                  },
+                  {
+                    "id": "is_immigration_status_satisfactory",
+                    "label": "Is child U.S. Citizen, U.S. National, or person with satisfactory immigration status?",
+                    "type": "radio",
+                    "required": true,
+                    "tooltip": "You will only be asked about the immigration status of the children in need of care. Other members of the family will not need to state or prove their immigration status. Your child will be eligible for care if they are a U.S. citizen, a legal permanent resident (green card holder), a refugee, or an asylee; have a T-visa; or hold another qualified immigration status. Please select “Yes” if your child holds one of these statuses.",
+                    "ui": {
+                      "options": [
+                        "Yes",
+                        "No"
+                      ]
+                    }
+                  }
+                ]
+              }
+            ]
+          }
+        ]
+      },
+      {
+        "id": "family_members",
+        "title": "Family Members",
+        "sections": [
+          {
+            "id": "household_members_info",
+            "title": "Household Members Information",
+            "type": "info",
+            "ui": {
+              "markdown": true,
+              "collapsible": false,
+              "defaultCollapsed": false
+            },
+            "content": "**List the household members who do _not_ need child care.**\\n\\nIf applicable, list:\\n\\n- Your **spouse**, your child’s **second parent**, **caretaker**, or **step-parent**\\n- Any other **adult with whom you share a child**, if they live in your home\\n\\nThen, if applicable, list:\\n\\n- Any **siblings under the age of 18** who live in your home\\n\\n> **Only list other household members** — such as **aunts, uncles, cousins, grandparents, or friends** — _if they have financial responsibility_ for the child.\\n\\nA household member with financial responsibility, other than a parent or step-parent, is one who has a **letter or order of guardianship**.\\n\\n**Otherwise, do not include them.**"
+          },
+          {
+            "id": "family_member_details",
+            "title": "Household Member Details",
+            "description": "Include household members who do not need child care assistance (e.g., spouse, partner, other children).",
+            "fields": [
+              {
+                "id": "familymember",
+                "label": "Family Members",
+                "type": "group",
+                "requiredCondition": {
+                  "repeatingGroup": "children",
+                  "operator": "ANY",
+                  "condition": { "field": "do_both_parents_reside_in_home", "operator": "equals", "value": "Yes" }
+                },  
+                "metadata": {
+                  "multiple": true,
+                  "tableColumns": [
+                    "first_name",
+                    "last_name",
+                    "relationship_to_applicant",
+                    "date_of_birth"
+                  ]
+                },
+                "fields": [
+                  {
+                    "id": "first_name",
+                    "label": "First Name",
+                    "type": "text",
+                    "required": true,
+                    "tooltip": "Provide last and first name, and middle initial if applicable."
+                  },
+                  {
+                    "id": "last_name",
+                    "label": "Last Name",
+                    "type": "text",
+                    "required": true
+                  },
+                  {
+                    "id": "mi",
+                    "label": "Middle Initial",
+                    "type": "text",
+                    "required": false
+                  },
+                  {
+                    "id": "relationship_to_applicant",
+                    "label": "Relationship to Applicant",
+                    "type": "select",
+                    "required": true,
+                    "tooltip": "Provide each person’s relationship to you (e.g. spouse, partner, child, foster parent, other).",
+                    "ui": {
+                      "options": [
+                        "",
+                        "Spouse",
+                        "Partner",
+                        "Foster Parent",
+                        "Child",
+                        "Other"
+                      ]
+                    }
+                  },
+                  {
+                    "id": "date_of_birth",
+                    "label": "Date of Birth",
+                    "type": "date",
+                    "required": true,
+                    "tooltip": "Provide the family member's date of birth."
+                  },
+                  {
+                    "id": "sex",
+                    "label": "Sex",
+                    "type": "radio",
+                    "required": true,
+                    "tooltip": "Indicate the sex for each family member listed.",
+                    "ui": {
+                      "options": [
+                        "Male",
+                        "Female"
+                      ]
+                    }
+                  },
+                  {
+                    "id": "ethnicity",
+                    "label": "Ethnicity Hispanic or Latino",
+                    "type": "select",
+                    "required": false,
+                    "tooltip": "Check “YES” or “NO” to indicate if each member in the household is Hispanic or Latino or not. Providing ethnicity information is voluntary and will not affect your eligibility for Child Care Assistance or the amount of assistance that you will be given by this agency.",
+                    "ui": {
+                      "options": [
+                        "",
+                        "Yes",
+                        "No",
+                        "Prefer not to answer"
+                      ]
+                    }
+                  },
+                  {
+                    "id": "race",
+                    "label": "Race",
+                    "type": "checkbox",
+                    "required": false,
+                    "tooltip": "You may choose multiple race categories for a single person. Providing race information is voluntary and will not affect your eligibility for Child Care Assistance or the amount of assistance that you will be given by this agency.",
+                    "ui": {
+                      "options": [
+                        {
+                          "value": "AI",
+                          "label": "American Indian or Alaska Native"
+                        },
+                        {
+                          "value": "AS",
+                          "label": "Asian"
+                        },
+                        {
+                          "value": "BL",
+                          "label": "Black or African American"
+                        },
+                        {
+                          "value": "HP",
+                          "label": "Native Hawaiian or Pacific Islander"
+                        },
+                        {
+                          "value": "WH",
+                          "label": "White"
+                        }
+                      ]
+                    },
+                    "metadata": {
+                      "multiple": true
+                    }
+                  },
+                  {
+                    "id": "ssn",
+                    "label": "Social Security Number",
+                    "type": "text",
+                    "required": false,
+                    "tooltip": "Fill in the Social Security Number (SSN) for your family members. SSN is optional. SSN may be used by federal, state, and local agencies to prevent duplication of services and fraud, and for Federal Reporting.",
+                    "constraints": {
+                      "pattern": "^\\\\d{3}-\\\\d{2}-\\\\d{4}$"
+                    },
+                    "ui": {
+                      "placeholder": "123-45-6789"
+                    }
+                  }
+                ]
+              }
+            ]
+          }
+        ]
+      },
+      {
+        "id": "child_family_needs",
+        "title": "Child / Family Needs",
+        "sections": [
+          {
+            "id": "assistance_reason",
+            "title": "Reason for Child Care Assistance",
+            "description": "Select one or two reasons you are requesting Child Care Assistance.",
+            "tooltip": "Select one reason. In a two-parent household, parents/caretakers can have the same or different reasons for needing child care. Both parents/caretakers will be required to submit documentation in support of their own reason. If you are living in temporary housing, please select Homelessness even if you have another reason that applies to you.",
+            "fields": [
+              {
+                "id": "assistance_reason",
+                "label": "Reason(s) for Assistance",
+                "type": "select",
+                "required": true,
+                "ui": {
+                  "options": [
+                    "",
+                    "Employment",
+                    "Looking for Work",
+                    "Vocational Training/Educational Activities",
+                    "Receiving Domestic Violence Services",
+                    "Homelessness"
+                  ]
+                },
+                "constraints": {
+                  "minSelections": 1,
+                  "maxSelections": 2
+                },
+                "metadata": {
+                  "multiple": true
+                }
+              }
+            ]
+          },
+          {
+            "id": "military_status",
+            "title": "Military and Parental Availability",
+            "description": "Provide information about parental military status and availability for child care.",
+            "fields": [
+              {
+                "id": "is_parent_currently_active_in_military",
+                "label": "Is a Parent Currently Active Full-Time in the U.S. Military?",
+                "tooltip": "Check “YES” or “NO” to indicate whether a parent is currently active full-time in the U.S. Military.",
+                "type": "radio",
+                "required": true,
+                "ui": {
+                  "options": [
+                    "Yes",
+                    "No"
+                  ]
+                }
+              },
+              {
+                "id": "is_parent_mem_of_guard_or_mru",
+                "label": "Is a Parent a Member of National Guard or Military Reserve Unit?",
+                "tooltip": "Check “YES” or “NO” to indicate whether a parent is currently a member of a National Guard or Military Reserve Unit.",
+                "type": "radio",
+                "required": true,
+                "ui": {
+                  "options": [
+                    "Yes",
+                    "No"
+                  ]
+                }
+              },
+              {
+                "id": "is_non_custodial_parent_available",
+                "label": "Is the Non-Custodial Parent Available to Provide Care?",
+                "tooltip": "Check “YES” or “NO” to indicate whether there is a non-custodial parent available to provide child care.",
+                "type": "radio",
+                "required": true,
+                "ui": {
+                  "options": [
+                    "Yes",
+                    "No"
+                  ]
+                }
+              }
+            ]
+          },
+          {
+            "id": "duplicate_application",
+            "title": "Other Applications",
+            "description": "Indicate if you are also applying for or receiving child care from other agencies.",
+            "tooltip": "Indicate whether you are currently receiving or have applied for child care assistance with one of the agencies or organizations listed below. Note: If you are receiving Cash Assistance and are interested in child care assistance, you must apply through the Human Resources Administration. Reach out to your Benefits Access Center or visit the Human Resources Administration webpage.",
+            "fields": [
+              {
+                "id": "duplicate_app",
+                "label": "Are You Receiving or Applying for Child Care Through Another Agency?",
+                "type": "select",
+                "required": false,
+                "ui": {
+                  "options": [
+                    "",
+                    "Not Applicable",
+                    "Department of Education (DOE)",
+                    "Human Resources Administration (HRA)",
+                    "Department of Youth and Community Development (DYCD)",
+                    "Department of Homeless Services (DHS)",
+                    "Consortium for Worker Education (CWE)",
+                    "Administration for Children's Services (ACS)"
+                  ]
+                }
+              }
+            ]
+          }
+        ]
+      },
+      {
+        "id": "employment",
+        "title": "Employment",
+        "sections": [
+          {
+            "id": "employment_precheck",
+            "title": "Tell us about your employment",
+            "description": "Tell us about your employment",
+            "fields": [
+              {
+                "id": "applicant_emp_income_indicator",
+                "label": "Does applicant earn any income/ wages from employment? ",
+                "type": "radio",
+                "required": false,
+                "ui": {
+                  "options": [
+                    "Yes",
+                    "No"
+                  ]
+                }
+              },
+              {
+                "id": "coparent_emp_income_indicator",
+                "label": "Does Coparent/2nd Guardian earn any income/ wages from employment? ",
+                "type": "radio",
+                "required": false,
+                "ui": {
+                  "options": [
+                    "Yes",
+                    "No"
+                  ]
+                }
+              }
+            ]
+          },
+          {
+            "id": "applicant_jobs",
+            "title": "Applicant Employment Information",
+            "description": "Enter details for up to two jobs held by the applicant.",
+            "visibilityCondition": {
+              "field": "applicant_emp_income_indicator",
+              "operator": "equals",
+              "value": "Yes"
+            },
+            "fields": [
+              {
+                "id": "applicant_1st_job_start_date",
+                "label": "1st Job - Start Date",
+                "type": "date",
+                "required": false,
+                "ui": {
+                  "group": "1st Job"
+                }
+              },
+              {
+                "id": "applicant_1st_job_rotating_shift",
+                "label": "1st Job - Has Rotating Shift?",
+                "type": "radio",
+                "required": false,
+                "ui": {
+                  "options": [
+                    "Yes",
+                    "No"
+                  ],
+                  "group": "1st Job"
+                }
+              },
+              {
+                "id": "applicant_1st_job_requires_overtime",
+                "label": "1st Job - Requires Overtime?",
+                "type": "radio",
+                "required": false,
+                "ui": {
+                  "options": [
+                    "Yes",
+                    "No"
+                  ],
+                  "group": "1st Job"
+                }
+              },
+              {
+                "id": "applicant_1st_job_employer_name",
+                "label": "1st Job - Employer Name",
+                "type": "text",
+                "required": false,
+                "ui": {
+                  "group": "1st Job"
+                }
+              },
+              {
+                "id": "applicant_1st_job_employer_phone",
+                "label": "1st Job - Employer Phone",
+                "type": "tel",
+                "required": false,
+                "ui": {
+                  "group": "1st Job"
+                }
+              },
+              {
+                "id": "applicant_1st_job_employer_street",
+                "label": "1st Job - Employer Street Address",
+                "type": "text",
+                "required": false,
+                "ui": {
+                  "group": "1st Job"
+                }
+              },
+              {
+                "id": "applicant_1st_job_employer_city",
+                "label": "1st Job - Employer City",
+                "type": "text",
+                "required": false,
+                "ui": {
+                  "group": "1st Job"
+                }
+              },
+              {
+                "id": "applicant_1st_job_employer_state",
+                "label": "1st Job - Employer State",
+                "type": "text",
+                "required": false,
+                "ui": {
+                  "group": "1st Job"
+                }
+              },
+              {
+                "id": "applicant_1st_job_employer_zipcode",
+                "label": "1st Job - Employer ZIP Code",
+                "type": "text",
+                "required": false,
+                "ui": {
+                  "group": "1st Job"
+                }
+              },
+              {
+                "id": "applicant_2nd_job_start_date",
+                "label": "2nd Job - Start Date",
+                "type": "date",
+                "required": false,
+                "ui": {
+                  "group": "2nd Job"
+                }
+              },
+              {
+                "id": "applicant_2nd_job_rotating_shift",
+                "label": "2nd Job - Has Rotating Shift?",
+                "type": "radio",
+                "required": false,
+                "ui": {
+                  "options": [
+                    "Yes",
+                    "No"
+                  ],
+                  "group": "2nd Job"
+                }
+              },
+              {
+                "id": "applicant_2nd_job_requires_overtime",
+                "label": "2nd Job - Requires Overtime?",
+                "type": "radio",
+                "required": false,
+                "ui": {
+                  "options": [
+                    "Yes",
+                    "No"
+                  ],
+                  "group": "2nd Job"
+                }
+              },
+              {
+                "id": "applicant_2nd_job_employer_name",
+                "label": "2nd Job - Employer Name",
+                "type": "text",
+                "required": false,
+                "ui": {
+                  "group": "2nd Job"
+                }
+              },
+              {
+                "id": "applicant_2nd_job_employer_phone",
+                "label": "2nd Job - Employer Phone",
+                "type": "tel",
+                "required": false,
+                "ui": {
+                  "group": "2nd Job"
+                }
+              },
+              {
+                "id": "applicant_2nd_job_employer_street",
+                "label": "2nd Job - Employer Street Address",
+                "type": "text",
+                "required": false,
+                "ui": {
+                  "group": "2nd Job"
+                }
+              },
+              {
+                "id": "applicant_2nd_job_employer_city",
+                "label": "2nd Job - Employer City",
+                "type": "text",
+                "required": false,
+                "ui": {
+                  "group": "2nd Job"
+                }
+              },
+              {
+                "id": "applicant_2nd_job_employer_state",
+                "label": "2nd Job - Employer State",
+                "type": "text",
+                "required": false,
+                "ui": {
+                  "group": "2nd Job"
+                }
+              },
+              {
+                "id": "applicant_2nd_job_employer_zipcode",
+                "label": "2nd Job - Employer ZIP Code",
+                "type": "text",
+                "required": false,
+                "ui": {
+                  "group": "2nd Job"
+                }
+              }
+            ]
+          },
+          {
+            "id": "second_parent_jobs",
+            "title": "Second Parent Employment Information",
+            "description": "Enter details for up to two jobs held by the second parent (if applicable).",
+            "visibilityCondition": {
+              "field": "coparent_emp_income_indicator",
+              "operator": "equals",
+              "value": "Yes"
+            },
+            "fields": [
+              {
+                "id": "second_parent_1st_job_start_date",
+                "label": "1st Job - Start Date",
+                "type": "date",
+                "required": false
+              },
+              {
+                "id": "second_parent_1st_job_rotating_shift",
+                "label": "1st Job - Has Rotating Shift?",
+                "type": "radio",
+                "required": false,
+                "ui": {
+                  "options": [
+                    "Yes",
+                    "No"
+                  ]
+                }
+              },
+              {
+                "id": "second_parent_1st_job_requires_overtime",
+                "label": "1st Job - Requires Overtime?",
+                "type": "radio",
+                "required": false,
+                "ui": {
+                  "options": [
+                    "Yes",
+                    "No"
+                  ]
+                }
+              },
+              {
+                "id": "second_parent_1st_job_employer_name",
+                "label": "1st Job - Employer Name",
+                "type": "text",
+                "required": false
+              },
+              {
+                "id": "second_parent_1st_job_employer_phone",
+                "label": "1st Job - Employer Phone",
+                "type": "tel",
+                "required": false
+              },
+              {
+                "id": "second_parent_1st_job_employer_street",
+                "label": "1st Job - Employer Street Address",
+                "type": "text",
+                "required": false
+              },
+              {
+                "id": "second_parent_1st_job_employer_city",
+                "label": "1st Job - Employer City",
+                "type": "text",
+                "required": false
+              },
+              {
+                "id": "second_parent_1st_job_employer_state",
+                "label": "1st Job - Employer State",
+                "type": "text",
+                "required": false
+              },
+              {
+                "id": "second_parent_1st_job_employer_zipcode",
+                "label": "1st Job - Employer ZIP Code",
+                "type": "text",
+                "required": false
+              },
+              {
+                "id": "second_parent_2nd_job_start_date",
+                "label": "2nd Job - Start Date",
+                "type": "date",
+                "required": false
+              },
+              {
+                "id": "second_parent_2nd_job_rotating_shift",
+                "label": "2nd Job - Has Rotating Shift?",
+                "type": "radio",
+                "required": false,
+                "ui": {
+                  "options": [
+                    "Yes",
+                    "No"
+                  ]
+                }
+              },
+              {
+                "id": "second_parent_2nd_job_requires_overtime",
+                "label": "2nd Job - Requires Overtime?",
+                "type": "radio",
+                "required": false,
+                "ui": {
+                  "options": [
+                    "Yes",
+                    "No"
+                  ]
+                }
+              },
+              {
+                "id": "second_parent_2nd_job_employer_name",
+                "label": "2nd Job - Employer Name",
+                "type": "text",
+                "required": false
+              },
+              {
+                "id": "second_parent_2nd_job_employer_phone",
+                "label": "2nd Job - Employer Phone",
+                "type": "tel",
+                "required": false
+              },
+              {
+                "id": "second_parent_2nd_job_employer_street",
+                "label": "2nd Job - Employer Street Address",
+                "type": "text",
+                "required": false
+              },
+              {
+                "id": "second_parent_2nd_job_employer_city",
+                "label": "2nd Job - Employer City",
+                "type": "text",
+                "required": false
+              },
+              {
+                "id": "second_parent_2nd_job_employer_state",
+                "label": "2nd Job - Employer State",
+                "type": "text",
+                "required": false
+              },
+              {
+                "id": "second_parent_2nd_job_employer_zipcode",
+                "label": "2nd Job - Employer ZIP Code",
+                "type": "text",
+                "required": false
+              }
+            ]
+          }
+        ]
+      },
+      {
+        "id": "schedule",
+        "title": "Work/Activity/Travel Time Schedule",
+        "sections": [
+          {
+            "id": "schedule_section_info",
+            "title": "Schedule Information",
+            "type": "info",
+            "ui": {
+              "markdown": true,
+              "collapsible": false,
+              "defaultCollapsed": false
+            },
+            "content": "Please indicate what days and hours you will need child care for based on your reason for care.\\n\\n- **Employed**: Indicate the hours you attend work\\n- **Educational or Vocational Program**: Indicate the hours you attend school or your program\\n- **Looking for Work**: Indicate the hours you spend looking for work\\n- **Homeless**: Indicate the hours you spend looking for housing\\n- **Attending Services for Domestic Violence**: Indicate the hours you attend services.\\n- **Attending Services for Substance Abuse Treatment**: Indicate the hours you attend services."
+          },
+          {
+            "id": "first_parent_activity_schedule",
+            "title": "First Parent Activity Schedule",
+            "description": "Enter the start and end times for each day of the week for the first parent's activities.",
+            "ui": {
+              "layout": "table",
+              "columns": [
+                "Start Time",
+                "End Time"
+              ],
+              "rowCopy": {
+                "enableUserPickSource": true,
+                "rowIdentifier": "ui.rowGroup",
+                "fieldsToCopy": [
+                  1,
+                  2
+                ],
+                "targetRowValues": [
+                  "Monday",
+                  "Tuesday",
+                  "Wednesday",
+                  "Thursday",
+                  "Friday"
+                ],
+                "copyControlLabel": "Apply selected schedule to other weekdays",
+                "sourceOptions": [
+                  "Monday",
+                  "Tuesday",
+                  "Wednesday",
+                  "Thursday",
+                  "Friday",
+                  "Saturday",
+                  "Sunday"
+                ]
+              }
+            },
+            "fields": [
+              {
+                "id": "fp_monday_from",
+                "label": "Monday From",
+                "type": "time",
+                "ui": {
+                  "rowGroup": "Monday",
+                  "column": 1
+                }
+              },
+              {
+                "id": "fp_monday_to",
+                "label": "Monday To",
+                "type": "time",
+                "ui": {
+                  "rowGroup": "Monday",
+                  "column": 2
+                }
+              },
+              {
+                "id": "fp_tuesday_from",
+                "label": "Tuesday From",
+                "type": "time",
+                "ui": {
+                  "rowGroup": "Tuesday",
+                  "column": 1
+                }
+              },
+              {
+                "id": "fp_tuesday_to",
+                "label": "Tuesday To",
+                "type": "time",
+                "ui": {
+                  "rowGroup": "Tuesday",
+                  "column": 2
+                }
+              },
+              {
+                "id": "fp_wednesday_from",
+                "label": "Wednesday From",
+                "type": "time",
+                "ui": {
+                  "rowGroup": "Wednesday",
+                  "column": 1
+                }
+              },
+              {
+                "id": "fp_wednesday_to",
+                "label": "Wednesday To",
+                "type": "time",
+                "ui": {
+                  "rowGroup": "Wednesday",
+                  "column": 2
+                }
+              },
+              {
+                "id": "fp_thursday_from",
+                "label": "Thursday From",
+                "type": "time",
+                "ui": {
+                  "rowGroup": "Thursday",
+                  "column": 1
+                }
+              },
+              {
+                "id": "fp_thursday_to",
+                "label": "Thursday To",
+                "type": "time",
+                "ui": {
+                  "rowGroup": "Thursday",
+                  "column": 2
+                }
+              },
+              {
+                "id": "fp_friday_from",
+                "label": "Friday From",
+                "type": "time",
+                "ui": {
+                  "rowGroup": "Friday",
+                  "column": 1
+                }
+              },
+              {
+                "id": "fp_friday_to",
+                "label": "Friday To",
+                "type": "time",
+                "ui": {
+                  "rowGroup": "Friday",
+                  "column": 2
+                }
+              },
+              {
+                "id": "fp_saturday_from",
+                "label": "Saturday From",
+                "type": "time",
+                "ui": {
+                  "rowGroup": "Saturday",
+                  "column": 1
+                }
+              },
+              {
+                "id": "fp_saturday_to",
+                "label": "Saturday To",
+                "type": "time",
+                "ui": {
+                  "rowGroup": "Saturday",
+                  "column": 2
+                }
+              },
+              {
+                "id": "fp_sunday_from",
+                "label": "Sunday From",
+                "type": "time",
+                "ui": {
+                  "rowGroup": "Sunday",
+                  "column": 1
+                }
+              },
+              {
+                "id": "fp_sunday_to",
+                "label": "Sunday To",
+                "type": "time",
+                "ui": {
+                  "rowGroup": "Sunday",
+                  "column": 2
+                }
+              }
+            ]
+          },
+          {
+            "id": "second_parent_activity_schedule",
+            "title": "Second Parent Activity Schedule",
+            "description": "Enter the start and end times for each day of the week for the second parent's activities.",
+            "ui": {
+              "layout": "table",
+              "columns": [
+                "Start Time",
+                "End Time"
+              ],
+              "rowCopy": {
+                "enableUserPickSource": true,
+                "rowIdentifier": "ui.rowGroup",
+                "fieldsToCopy": [
+                  1,
+                  2
+                ],
+                "targetRowValues": [
+                  "Monday",
+                  "Tuesday",
+                  "Wednesday",
+                  "Thursday",
+                  "Friday"
+                ],
+                "copyControlLabel": "Apply selected schedule to other weekdays",
+                "sourceOptions": [
+                  "Monday",
+                  "Tuesday",
+                  "Wednesday",
+                  "Thursday",
+                  "Friday",
+                  "Saturday",
+                  "Sunday"
+                ]
+              }
+            },
+            "fields": [
+              {
+                "id": "sp_monday_from",
+                "label": "Monday From",
+                "type": "time",
+                "ui": {
+                  "rowGroup": "Monday",
+                  "column": 1
+                }
+              },
+              {
+                "id": "sp_monday_to",
+                "label": "Monday To",
+                "type": "time",
+                "ui": {
+                  "rowGroup": "Monday",
+                  "column": 2
+                }
+              },
+              {
+                "id": "sp_tuesday_from",
+                "label": "Tuesday From",
+                "type": "time",
+                "ui": {
+                  "rowGroup": "Tuesday",
+                  "column": 1
+                }
+              },
+              {
+                "id": "sp_tuesday_to",
+                "label": "Tuesday To",
+                "type": "time",
+                "ui": {
+                  "rowGroup": "Tuesday",
+                  "column": 2
+                }
+              },
+              {
+                "id": "sp_wednesday_from",
+                "label": "Wednesday From",
+                "type": "time",
+                "ui": {
+                  "rowGroup": "Wednesday",
+                  "column": 1
+                }
+              },
+              {
+                "id": "sp_wednesday_to",
+                "label": "Wednesday To",
+                "type": "time",
+                "ui": {
+                  "rowGroup": "Wednesday",
+                  "column": 2
+                }
+              },
+              {
+                "id": "sp_thursday_from",
+                "label": "Thursday From",
+                "type": "time",
+                "ui": {
+                  "rowGroup": "Thursday",
+                  "column": 1
+                }
+              },
+              {
+                "id": "sp_thursday_to",
+                "label": "Thursday To",
+                "type": "time",
+                "ui": {
+                  "rowGroup": "Thursday",
+                  "column": 2
+                }
+              },
+              {
+                "id": "sp_friday_from",
+                "label": "Friday From",
+                "type": "time",
+                "ui": {
+                  "rowGroup": "Friday",
+                  "column": 1
+                }
+              },
+              {
+                "id": "sp_friday_to",
+                "label": "Friday To",
+                "type": "time",
+                "ui": {
+                  "rowGroup": "Friday",
+                  "column": 2
+                }
+              },
+              {
+                "id": "sp_saturday_from",
+                "label": "Saturday From",
+                "type": "time",
+                "ui": {
+                  "rowGroup": "Saturday",
+                  "column": 1
+                }
+              },
+              {
+                "id": "sp_saturday_to",
+                "label": "Saturday To",
+                "type": "time",
+                "ui": {
+                  "rowGroup": "Saturday",
+                  "column": 2
+                }
+              },
+              {
+                "id": "sp_sunday_from",
+                "label": "Sunday From",
+                "type": "time",
+                "ui": {
+                  "rowGroup": "Sunday",
+                  "column": 1
+                }
+              },
+              {
+                "id": "sp_sunday_to",
+                "label": "Sunday To",
+                "type": "time",
+                "ui": {
+                  "rowGroup": "Sunday",
+                  "column": 2
+                }
+              }
+            ]
+          },
+          {
+            "id": "first_parent_travel_time",
+            "title": "First Parent Travel Time",
+            "description": "Enter the travel times and method of transport for the first parent.",
+            "fields": [
+              {
+                "id": "fp_dropoff_travel_time",
+                "label": "Drop-off Travel Time",
+                "type": "select",
+                "tooltip": "Select your typical travel time from work/activity to your child care provider",
+                "ui": {
+                  "options": [
+                    "",
+                    "15 min",
+                    "30 min",
+                    "45 min",
+                    "1 hour",
+                    "More than 1 hour"
+                  ]
+                }
+              },
+              {
+                "id": "fp_dropoff_time_gt_1hr",
+                "label": "Drop-off Time (if > 1 hour)",
+                "type": "text",
+                "requiredCondition": {
+                  "field": "fp_dropoff_travel_time",
+                  "operator": "equals",
+                  "value": "More than 1 hour"
+                }
+              },
+              {
+                "id": "fp_pickup_travel_time",
+                "label": "Pick-up Travel Time",
+                "type": "select",
+                "tooltip": "Select your typical travel time from work/activity to your child care provider",
+                "ui": {
+                  "options": [
+                    "",
+                    "15 min",
+                    "30 min",
+                    "45 min",
+                    "1 hour",
+                    "More than 1 hour"
+                  ]
+                }
+              },
+              {
+                "id": "fp_pickup_time_gt_1hr",
+                "label": "Pick-up Time (if > 1 hour)",
+                "type": "text",
+                "requiredCondition": {
+                  "field": "fp_pickup_travel_time",
+                  "operator": "equals",
+                  "value": "More than 1 hour"
+                }
+              },
+              {
+                "id": "fp_public_transport_dropoff",
+                "label": "Public Transport for Drop-off?",
+                "type": "radio",
+                "tooltip": "Indicate if the applicant uses public transportation to travel to and from work/activity to provider.",
+                "ui": {
+                  "options": [
+                    "Yes",
+                    "No"
+                  ]
+                }
+              },
+              {
+                "id": "fp_public_transport_pickup",
+                "label": "Public Transport for Pick-up?",
+                "tooltip": "Indicate if the applicant uses public transportation to travel to and from work/activity to provider.",
+                "type": "radio",
+                "ui": {
+                  "options": [
+                    "Yes",
+                    "No"
+                  ]
+                }
+              }
+            ]
+          },
+          {
+            "id": "second_parent_travel_time",
+            "title": "Second Parent Travel Time",
+            "description": "Enter the travel times and method of transport for the second parent.",
+            "fields": [
+              {
+                "id": "sp_dropoff_travel_time",
+                "label": "Drop-off Travel Time",
+                "type": "select",
+                "ui": {
+                  "options": [
+                    "",
+                    "15 min",
+                    "30 min",
+                    "45 min",
+                    "1 hour",
+                    "More than 1 hour"
+                  ]
+                }
+              },
+              {
+                "id": "sp_pickup_travel_time",
+                "label": "Pick-up Travel Time",
+                "type": "select",
+                "ui": {
+                  "options": [
+                    "",
+                    "15 min",
+                    "30 min",
+                    "45 min",
+                    "1 hour",
+                    "More than 1 hour"
+                  ]
+                }
+              },
+              {
+                "id": "sp_dropoff_time_gt_1hr",
+                "label": "Drop-off Time (if > 1 hour)",
+                "type": "text",
+                "requiredCondition": {
+                  "field": "sp_dropoff_travel_time",
+                  "operator": "equals",
+                  "value": "More than 1 hour"
+                }
+              },
+              {
+                "id": "sp_pickup_time_gt_1hr",
+                "label": "Pick-up Time (if > 1 hour)",
+                "type": "text",
+                "requiredCondition": {
+                  "field": "sp_pickup_travel_time",
+                  "operator": "equals",
+                  "value": "More than 1 hour"
+                }
+              },
+              {
+                "id": "sp_public_transport_dropoff",
+                "label": "Public Transport for Drop-off?",
+                "type": "radio",
+                "ui": {
+                  "options": [
+                    "Yes",
+                    "No"
+                  ]
+                }
+              },
+              {
+                "id": "sp_public_transport_pickup",
+                "label": "Public Transport for Pick-up?",
+                "type": "radio",
+                "ui": {
+                  "options": [
+                    "Yes",
+                    "No"
+                  ]
+                }
+              }
+            ]
+          }
+        ]
+      },
+      {
+        "id": "income",
+        "title": "Income Information",
+        "sections": [
+          {
+            "id": "income_step_info",
+            "title": "Instructions",
+            "type": "info",
+            "ui": {
+              "markdown": true,
+              "collapsible": false,
+              "defaultCollapsed": false
+            },
+            "content": "Please include income/benefits information for yourself and, if applicable, your spouse, your child’s second caretaker, and/or any other adult with whom you share a child, if they live in your home.\\n\\nIndicate if you receive money from the following sources by selecting “Yes” or “No.” If you select “Yes,” you will be asked for additional information.\\n\\nIf the second caretaker in the household also receives the same income source, add a separate line for their income."
+          },
+          {
+            "id": "income_sources",
+            "title": "Income Sources",
+            "description": "Provide details about all income sources applicable to the applicant or household.",
+            "fields": [
+              {
+                "id": "income_sources",
+                "label": "List of Income Sources",
+                "type": "group",
+                "metadata": {
+                  "multiple": true,
+                  "tableColumns": [
+                    "name_ref",
+                    "how_often",
+                    "recipient",
+                    "monthly_amount"
+                  ]
+                },
+                "fields": [
+                  {
+                    "id": "name_ref",
+                    "label": "Income Source Type",
+                    "type": "select",
+                    "required": true,
+                    "ui": {
+                      "options": [
+                        "",
+                        "ApplicantWages",
+                        "SecondParentWages",
+                        "SelfEmployment",
+                        "ChildSupport",
+                        "Alimony",
+                        "Unemployment",
+                        "SocialSecurity",
+                        "Disability",
+                        "Rental",
+                        "Dividends",
+                        "Retirement",
+                        "CashAssistance",
+                        "Other"
+                      ]
+                    }
+                  },
+                  {
+                    "id": "other_source_text",
+                    "label": "Other Source (If applicable)",
+                    "type": "text",
+                    "visibilityCondition": {
+                      "field": "name_ref",
+                      "operator": "equals",
+                      "value": "Other"
+                    },
+                    "requiredCondition": {
+                      "condition": {
+                        "field": "name_ref",
+                        "operator": "equals",
+                        "value": "Other"
+                      }
+                    }
+                  },
+                  {
+                    "id": "is_source_applicable",
+                    "label": "Is this Source Applicable?",
+                    "type": "radio",
+                    "required": true,
+                    "ui": {
+                      "options": [
+                        "Yes",
+                        "No"
+                      ]
+                    }
+                  },
+                  {
+                    "id": "gross_amount",
+                    "label": "Gross Amount ($)",
+                    "type": "number",
+                    "required": true
+                  },
+                  {
+                    "id": "how_often",
+                    "label": "Frequency of Income",
+                    "type": "radio",
+                    "required": true,
+                    "ui": {
+                      "options": [
+                        "Weekly",
+                        "Bi-weekly",
+                        "Monthly",
+                        "Other"
+                      ]
+                    }
+                  },
+                  {
+                    "id": "recipient",
+                    "label": "Recipient of Income",
+                    "type": "text",
+                    "required": true
+                  },
+                  {
+                    "id": "monthly_amount",
+                    "label": "Monthly Amount ($)",
+                    "type": "number",
+                    "required": true
+                  }
+                ]
+              }
+            ]
+          },
+          {
+            "id": "total_income",
+            "title": "Total Household Income",
+            "description": "Sum of all monthly income across sources.",
+            "fields": [
+              {
+                "id": "total_income",
+                "label": "Total Monthly Income ($)",
+                "type": "number",
+                "required": true
+              }
+            ]
+          },
+          {
+            "id": "income_proof_section",
+            "title": "Income Proof",
+            "fields": [
+              {
+                "id": "income_proof",
+                "label": "Upload Income Proof",
+                "type": "file",
+                "requiredCondition": {
+                  "condition": {
+                    "field": "assistance_reason",
+                    "operator": "includes",
+                    "value": "Employment"
+                  }
+                },
+                "constraints": {
+                  "maxFileSizeMB": 5,
+                  "allowedTypes": [
+                    "application/pdf",
+                    "image/jpeg"
+                  ],
+                  "imageResolution": {
+                    "minWidth": 800,
+                    "minHeight": 600
+                  }
+                },
+                "metadata": {
+                  "proofCategory": "Income Verification",
+                  "examples": [
+                    "Pay Stub",
+                    "W-2"
+                  ],
+                  "multiple": true
+                }
+              }
+            ]
+          }
+        ]
+      },
+      {
+        "id": "provider",
+        "title": "Provider",
+        "sections": [
+          {
+            "id": "provider_step_info",
+            "title": "Instructions",
+            "type": "info",
+            "ui": {
+              "markdown": true,
+              "collapsible": false,
+              "defaultCollapsed": false
+            },
+            "content": "If you are found eligible for child care assistance, you can choose center-based or home-based care from a licensed, registered, or legally exempt provider. If you choose a provider that is not licensed or registered, the provider must be enrolled as a legally exempt provider.\\n\\nIf you know which child care providers you would like your child to attend, provide the names and addresses of your choice of providers. You can leave this section blank if you do not know (it will not impact your eligibility and you will have an opportunity to select a provider if determined eligible)."
+          },
+          {
+            "id": "provider_choices",
+            "title": "Provider Choices",
+            "description": "Specify details of the provider where you intend to enroll the child(ren).",
+            "fields": [
+              {
+                "id": "provider_choices",
+                "label": "List of Providers",
+                "type": "group",
+                "metadata": {
+                  "multiple": true,
+                  "tableColumns": [
+                    "provider_name",
+                    "program_number",
+                    "provider_zip_code"
+                  ]
+                },
+                "fields": [
+                  {
+                    "id": "provider_name",
+                    "label": "Provider Name",
+                    "type": "text",
+                    "required": true
+                  },
+                  {
+                    "id": "program_number",
+                    "label": "Program Number (If Applicable)",
+                    "type": "text",
+                    "required": false
+                  },
+                  {
+                    "id": "provider_street",
+                    "label": "Street Address",
+                    "type": "text",
+                    "required": true
+                  },
+                  {
+                    "id": "provider_city",
+                    "label": "City",
+                    "type": "text",
+                    "required": true
+                  },
+                  {
+                    "id": "provider_state",
+                    "label": "State",
+                    "type": "text",
+                    "required": true
+                  },
+                  {
+                    "id": "provider_zip_code",
+                    "label": "Zip Code",
+                    "type": "text",
+                    "required": true
+                  }
+                ]
+              }
+            ]
+          }
+        ]
+      },
+      {
+        "id": "document_upload_step",
+        "title": "Document Upload",
+        "description": "The Application for Child Care Assistance (CFWB-012) must include supporting documentation. Check to ensure that documentation is provided for each requirement of subsidy eligibility.",
+        "sections": [
+          {
+            "id": "nyc_residency",
+            "title": "New York City Residency",
+            "description": "These documents confirm that you live in New York City. Please upload one of the following documents.",
+            "fields": [
+              {
+                "id": "nyc_residency_type",
+                "label": "Select one of the following:",
+                "type": "radio",
+                "required": true,
+                "ui": {
+                  "options": [
+                    "IDNYC",
+                    "Utility Bill",
+                    "Section 8 Award Letter",
+                    "Driver’s License",
+                    "Rent Receipt",
+                    "NYCHA Certificate",
+                    "CFWB-067 Residency Attestation",
+                    "CFWB-027 Housing Attestation with address listed",
+                    "Shelter Residency Letter with address listed",
+                    "Other"
+                  ]
+                }
+              },
+              {
+                "id": "nyc_residency_file",
+                "label": "Upload Residency Proof Document",
+                "description": "To add a document to your application, you can upload an image or scanned file from your phone or device. Accepted formats include .pdf, .gif, .jpeg, .jpg and .png up to 25 MB. Learn how to upload your files with this Tutorial Video.",
+                "type": "file",
+                "required": true, 
+                "constraints": {
+                  "maxFileSizeMB": 25,
+                  "allowedTypes": [
+                    "application/pdf",
+                    "image/jpeg",
+                    "image/jpg",
+                    "image/png",
+                    "image/gif"
+                  ]
+                },
+                "metadata": {
+                  "proofCategory": "NYC Residency",
+                  "multiple": false
+                }
+              }
+            ]
+          },
+          {
+            "id": "citizenship_status",
+            "title": "Citizenship or Immigration Status",
+            "description": "These documents confirm the citizenship/immigration status of the children in your family for whom you’re applying for child care assistance. Please upload one of the following documents for ONLY each child needing care.",
+            "fields": [
+              {
+                "id": "citizenship_doc_type",
+                "label": "Select one of the following:",
+                "type": "radio",
+                "required": true,
+                "ui": {
+                  "options": [
+                    "US Birth Certificate",
+                    "Alien Registration Card including Permanent Resident or Green Card",
+                    "Passport",
+                    "FS-240 (Report of Birth Abroad of a U.S. Citizen)",
+                    "Naturalization Certificate",
+                    "Other"
+                  ]
+                }
+              },
+              {
+                "id": "citizenship_doc_file",
+                "label": "Upload Citizenship/Immigration Document",
+                "description": "To add a document to your application, you can upload an image or scanned file from your phone or device. Accepted formats include .pdf, .gif, .jpeg, .jpg and .png up to 25 MB. Learn how to upload your files with this Tutorial Video.",
+                "type": "file",
+                "required": true,
+                "constraints": {
+                  "maxFileSizeMB": 25,
+                  "allowedTypes": [
+                    "application/pdf",
+                    "image/jpeg",
+                    "image/jpg",
+                    "image/png",
+                    "image/gif"
+                  ]
+                },
+                "metadata": {
+                  "proofCategory": "Citizenship/Immigration Status",
+                  "multiple": false
+                }
+              }
+            ]
+          },
+          {
+            "id": "child_relationship",
+            "title": "Child’s Relationship to Parent/Applicant",
+            "description": "These documents confirm your relationship to the children in your household under age 18. Please upload one of the following documents for every child in the household under age 18, regardless of whether child care is needed for them or not. If you are a legal guardian with financial responsibility, you must upload a Court order OR a letter of guardianship.",
+            "fields": [
+              {
+                "id": "relationship_doc_type",
+                "label": "Select one of the following:",
+                "type": "radio",
+                "required": true,
+                "ui": {
+                  "options": [
+                    "Birth Certificate",
+                    "Adoption record",
+                    "Baptismal record",
+                    "Passport with parent's signature",
+                    "Court order for legal guardian with financial responsibility",
+                    "Letter of Guardianship",
+                    "Other - CFWB-058 Caretaker Attestation"
+                  ]
+                }
+              },
+              {
+                "id": "relationship_doc_file",
+                "label": "Upload Relationship Document",
+                "description": "To add a document to your application, you can upload an image or scanned file from your phone or device. Accepted formats include .pdf, .gif, .jpeg, .jpg and .png up to 25 MB. Learn how to upload your files with this Tutorial Video.",
+                "type": "file",
+                "required": true,
+                "constraints": {
+                  "maxFileSizeMB": 25,
+                  "allowedTypes": [
+                    "application/pdf",
+                    "image/jpeg",
+                    "image/jpg",
+                    "image/png",
+                    "image/gif"
+                  ]
+                },
+                "metadata": {
+                  "proofCategory": "Child Relationship",
+                  "multiple": false
+                }
+              }
+            ]
+          },
+          {
+            "id": "age_proof",
+            "title": "Age",
+            "description": "These documents confirm the age of the children in your household. Please upload one of the following documents for every child in the household under age 18, regardless of whether child care is needed for them:",
+            "fields": [
+              {
+                "id": "age_doc_type",
+                "label": "Select one of the following:",
+                "type": "radio",
+                "required": true,
+                "ui": {
+                  "options": [
+                    "Birth Certificate",
+                    "Adoption record",
+                    "Baptismal record",
+                    "Alien Registration Card",
+                    "Passport",
+                    "Official hospital documentation of the child’s birth"
+                  ]
+                }
+              },
+              {
+                "id": "age_doc_file",
+                "label": "Upload Age Proof Document",
+                "description": "To add a document to your application, you can upload an image or scanned file from your phone or device. Accepted formats include .pdf, .gif, .jpeg, .jpg and .png up to 25 MB. Learn how to upload your files with this Tutorial Video.",
+                "type": "file",
+                "required": true,
+                "constraints": {
+                  "maxFileSizeMB": 25,
+                  "allowedTypes": [
+                    "application/pdf",
+                    "image/jpeg",
+                    "image/jpg",
+                    "image/png",
+                    "image/gif"
+                  ]
+                },
+                "metadata": {
+                  "proofCategory": "Child Age",
+                  "multiple": false
+                }
+              }
+            ]
+          }
+        ]
+      },
+      {
+        "id": "review",
+        "title": "Review & Submit",
+        "type": "review",
+        "sections": []
+      }
+    ]
+  }
+}

--- a/test-form/public/data/childcare_form.es.json
+++ b/test-form/public/data/childcare_form.es.json
@@ -1,0 +1,2287 @@
+{
+  "form": {
+    "title": "Childcare Voucher Application",
+    "description": "Step-by-step form for applying for Childcare Assistance",
+    "layout": {
+      "stepperPosition": "left"
+    },
+    "steps": [
+      {
+        "id": "consent_step",
+        "title": "Consent",
+        "sections": [
+          {
+            "id": "mycity_consent_info",
+            "title": "ModelCity Consent",
+            "type": "info",
+            "ui": {
+              "markdown": true,
+              "collapsible": false,
+              "defaultCollapsed": false
+            },
+            "content": "In connection with this application for child care services, **ModelCity**:\\n\\n- Collects, processes, stores, and shares the information you submit to screen you when you apply for child care services;\\n- Receives, processes, and stores the information the City already knows about you to screen you when you apply for child care services;\\n- Uses your information to improve ModelCity; and\\n- Communicates with you about your ModelCity account.\\n\\n---\\n\\nIf you consent, the following information may be shared between child care services agencies:\\n\\n- Demographic and background information, including address, phone number, household composition.\\n- Housing information, including benefits awarded/received, current housing/shelter status.\\n- Benefits information, including public assistance awarded/received, child care program participation.\\n\\n---\\n\\nIf you choose not to consent, **you will not be denied** any benefits or services you are receiving or any benefits for which you are eligible.\\n\\nThe [ModelCity Privacy Policy](https://www.nyc.gov/privacy) details how ModelCity handles the information you submit through ModelCity."
+          }
+        ]
+      },
+      {
+        "id": "instructions_step",
+        "title": "Instructions",
+        "sections": [
+          {
+            "id": "application_instructions",
+            "title": "Application Instructions",
+            "type": "info",
+            "ui": {
+              "markdown": true,
+              "collapsible": false,
+              "defaultCollapsed": false
+            },
+            "content": "**Let’s get started on your application!**\\n\\nTo complete this application, you will be asked for information about:\\n\\n- Yourself\\n- Your household\\n- Your employment or reason for care\\n- Your income\\n\\nAll required fields are marked and must be filled out to move forward with the application. The pages of the application are shown on the right-hand side of the screen and will be highlighted as you move through the application.\\n\\nYour application will be saved automatically as you progress to each page.  \\nIf you need to pause at any time, click the **“Save for later”** button at the bottom of each page to save your application.  \\nYou can log back in to resume your application.\\n\\nWhen you’re ready to begin, click **“Next”** below.\\n\\n---\\n\\n⚠️ **Important:**  \\nTo keep your information current and safe, applications in draft status that you have not edited for **30 days** will be deleted.  \\nIf your draft application is deleted, you can still create and submit a new application when you're ready to apply."
+          },
+          {
+            "id": "new_york_city_residency",
+            "title": "New York City Residency",
+            "type": "info",
+            "ui": {
+              "markdown": true,
+              "collapsible": true,
+              "defaultCollapsed": true
+            },
+            "content": "You will need to upload **ONE** of the following documents to confirm your NYC residency:\\n\\n- IDNYC\\n- Driver’s License\\n- Utility Bill (dated within the last 60 days, with your address)\\n- Current lease, rent, or mortgage statement (dated within the last 60 days, with your address)\\n- Section 8 Award Letter\\n- NYCHA Certificate\\n- CFWB-027 Housing Attestation with address listed\\n- Shelter Residency Letter with address listed\\n\\nIf you do not have any of those documents, you must submit a **CFWB-067 Residency Attestation**."
+          },
+          {
+            "id": "children_documents",
+            "title": "Children Documents",
+            "type": "info",
+            "ui": {
+              "markdown": true,
+              "collapsible": true,
+              "defaultCollapsed": true
+            },
+            "content": "### Citizenship or Immigration Status\\nThese documents confirm the citizenship or immigration status of the children in your family for whom you’re applying for child care assistance. Please upload one of the following documents for each child needing care. *Do not upload these documents for children who do not need care.*\\n\\n- Birth Certificate from US state or territory\\n- Alien Registration Card including Permanent Resident or Green Card\\n- Passport\\n- FS-240 (Consular Report of Birth Abroad)\\n- Naturalization Certificate\\n- Other documentation that proves child’s immigration status\\n\\n### Child's Relationship to Applicant\\nThese documents confirm your relationship to the children in your household under age 18. Please upload one of the following documents for every child in the household under age 18, regardless of whether they need child care.\\n\\n- Birth certificate\\n- Adoption record\\n- Baptismal record\\n- Passport with parent's signature\\n- Court order for legal guardian with financial responsibility\\n- Letter of guardianship\\n- Other - CFWB-058 Caretaker Attestation\\n\\nIf you are not the child's parent or stepparent, you must submit a **CFWB-058 Caretaker Attestation Form**.\\n\\n### Age of Children\\nYou will need to upload **ONE** of the following documents for every child in the household under age 18, regardless of whether child care is needed for them:\\n\\n- Birth certificate\\n- Adoption record\\n- Baptismal record\\n- Alien Registration Card\\n- Passport\\n- Official hospital documentation of the child’s birth"
+          },
+          {
+            "id": "employment_income",
+            "title": "Employment & Income",
+            "type": "info",
+            "ui": {
+              "markdown": true,
+              "collapsible": true,
+              "defaultCollapsed": true
+            },
+            "content": "### Income\\nThese documents confirm your family’s income.\\n\\n---\\n\\n### If You Are Employed\\nIf you are employed and receive paystubs, you must submit them to confirm your income. The number of paystubs you must submit varies by how often you get paid and whether your payment amount is the same or different each time you are paid – see the table below for details. Submit the most recent paystub you have received, followed by others in consecutive order.\\n\\n**Income Information**\\n\\n| How Often Do You Get Paid? | Always the SAME Amount | DIFFERENT Amounts Each Time |\\n|----------------------------|-------------------------|------------------------------|\\n| Weekly (Every Week) | 4 most recent, consecutive pay stubs | 12 most recent, consecutive pay stubs |\\n| Bi-Weekly (Every Two Weeks) | 2 most recent, consecutive pay stubs | 6 most recent, consecutive pay stubs |\\n| Semi-Monthly (Two Times Per Month) | 2 most recent, consecutive pay stubs | 6 most recent, consecutive pay stubs |\\n| Monthly (One Time Per Month) | 3 most recent, consecutive pay stubs | 3 most recent, consecutive pay stubs |\\n\\nIf you do not have any paystubs, you must submit a **CFWB-015 Referral to Employer for Employee Income Information Form**.\\n\\n---\\n\\n### If You Are Self-Employed\\nIf you have been self-employed for **one year or more**, you must submit a current, complete and signed income tax package (e.g., 1040, 1065, Schedule C, SE for partnership, K-1, etc.).\\n\\nIf you have been self-employed for **less than one year**, you must submit a **CFWB-031 Self-Employment Income Information Attestation Form**.\\n\\n---\\n\\n### Other Income\\nIf you receive other types of income outside or instead of employment income, you must submit your most recent check, pay stub, or current award letter that indicates the amount you receive. If your other income fluctuates, **3 months of documentation is required**.\\n\\nThis includes, but is not limited to:\\n- Income from SSI, SSD\\n- Unemployment benefits\\n- Rental income\\n- Pensions\\n- Annuities\\n- Worker’s compensation\\n- Alimony\\n- Child support"
+          },
+          {
+            "id": "reason_for_care",
+            "title": "Reason for Care",
+            "type": "info",
+            "ui": {
+              "markdown": true,
+              "collapsible": true,
+              "defaultCollapsed": true
+            },
+            "content": "### Reason for Care\\nThese documents confirm your reason for care. Every applicant must have a qualified reason for care; in a two-parent household, parents or caretakers can have the same or different reasons for care. Only the documents related to your stated reasons for care need to be uploaded, and documentation must be uploaded for all parent or caretakers in the household.\\n\\n---\\n\\n### Working 10+ Hours Per Week\\nYour employment or self-employment income documents will cover this reason for care. You do not need to submit additional documentation.\\n\\n---\\n\\n### Participating in an Educational or Vocational Training Program\\nYou will need to upload **ONE** of the following documents to confirm your participation in vocational school, two-year college, or four-year college.\\n\\n- CFWB-005 Vocational, Education and Training Verification Form\\n- A letter from the educational or vocational training program on their official letterhead; this letter must contain all the information required in the CFWB-005 Vocational, Education and Training Verification Form.\\n\\n---\\n\\n### Looking for Work\\nYou will need to upload **ONE** of the following documents to confirm that you are looking for work.\\n\\n- CFWB-026 Work Search Record Form\\n- Approved work search plan from the NYS Dept. of Labor\\n- Proof of receipt of unemployment insurance\\n\\n---\\n\\n### Experiencing Homelessness\\nYou will need to upload **ONE** of the following documents to confirm that you are experiencing homelessness. This includes families who may be living in shelter or sharing the housing of others due to loss of housing, economic hardship, or similar reason.\\n\\n- Shelter Residency Letter (If living in Shelter, including Humanitarian Emergency Relief Centers)\\n- CFWB-027 Housing Attestation (If living doubled-up, in a place not meant for human habitation, in a hotel/motel, or in another living situation)\\n\\n---\\n\\n### Attending Services for Domestic Violence\\nYou will need to upload a referral for services from a domestic violence service provider to confirm that you are attending services for domestic violence.\\n\\n---\\n\\n### Attending Services for Substance Abuse Treatment\\nYou will need to upload a referral for a substance abuse treatment service provider to confirm that you are attending services for substance abuse treatment."
+          },
+          {
+            "id": "additional_details",
+            "title": "Additional Details",
+            "type": "info",
+            "ui": {
+              "markdown": true,
+              "collapsible": true,
+              "defaultCollapsed": true
+            },
+            "content": "### Application Scope\\nThis application is used to apply **only** for **Category 2 or 3 child care assistance** (for families not in receipt of cash assistance). To apply for **Cash Assistance** or other benefits, including **Category 1 Child Care Assistance** (for families in receipt of cash assistance), you must use the **New York State Application for Certain Benefits and Services (LDSS-2921)**.\\n\\n---\\n\\n### Exempt Applicants\\nThe following applicants may be eligible for child care assistance **without regard to income** and do not need to complete this application:\\n\\n- Foster parents who need child care assistance to allow them to work and are only applying for assistance for the foster children;\\n- Families in receipt of protective or preventive services.\\n\\n---\\n\\n### Application Completion\\nAll sections of this form must be filled out to be considered complete **unless the section is identified as optional**. If you do not complete all required sections of this form, you may not be considered for Child Care Assistance.\\n\\n---\\n\\n### Rights and Responsibilities\\nYou may obtain information about your rights and responsibilities [here](https://otda.ny.gov/programs/applications/). If you do not have access to the internet, you can call the **Administration for Children’s Services at 212-835-7610** to request that physical copies of the booklets which highlight your rights and responsibilities be mailed to you, including:\\n\\n- **LDSS-4148A**: What You Should Know About Your Rights and Responsibilities\\n- **LDSS-4148B**: What You Should Know About Social Services Programs\\n- **LDSS-4148C**: What You Should Know If You Have an Emergency"
+          }
+        ]
+      },
+      {
+        "id": "applicant",
+        "title": "Applicant",
+        "sections": [
+          {
+            "id": "personal_info",
+            "title": "Personal Information",
+            "fields": [
+              {
+                "id": "first_name",
+                "label": "First Name",
+                "type": "text",
+                "required": true
+              },
+              {
+                "id": "last_name",
+                "label": "Last Name",
+                "type": "text",
+                "required": true
+              },
+              {
+                "id": "mi",
+                "label": "Middle Initial",
+                "type": "text",
+                "required": false
+              },
+              {
+                "id": "date_of_birth",
+                "label": "Date of Birth",
+                "type": "date",
+                "required": true,
+                "tooltip": "To edit Date of Birth click on NYC ModelCity in the top-left corner then click on Account Settings."
+              },
+              {
+                "id": "sex",
+                "label": "Sex",
+                "type": "radio",
+                "required": true,
+                "ui": {
+                  "options": [
+                    "Male",
+                    "Female"
+                  ]
+                }
+              },
+              {
+                "id": "marital_status",
+                "label": "Marital Status",
+                "type": "select",
+                "required": true,
+                "tooltip": "Indicate your marital status (single, married, divorced, separated or widowed).",
+                "ui": {
+                  "options": [
+                    "",
+                    "Single",
+                    "Married",
+                    "Divorced",
+                    "Widowed",
+                    "Separated"
+                  ]
+                }
+              }
+            ]
+          },
+          {
+            "id": "contact_info",
+            "title": "Contact Information",
+            "fields": [
+              {
+                "id": "telephone_home",
+                "label": "Home Phone",
+                "type": "tel",
+                "required": false,
+                "constraints": {
+                  "pattern": "^\\\\(?[0-9]{3}\\\\)?[-. ]?[0-9]{3}[-. ]?[0-9]{4}$"
+                },
+                "ui": {
+                  "placeholder": "(123) 456-7890"
+                }
+              },
+              {
+                "id": "telephone_work",
+                "label": "Work Phone",
+                "type": "tel",
+                "required": false,
+                "constraints": {
+                  "pattern": "^\\\\(?[0-9]{3}\\\\)?[-. ]?[0-9]{3}[-. ]?[0-9]{4}$"
+                },
+                "ui": {
+                  "placeholder": "(123) 456-7890"
+                }
+              },
+              {
+                "id": "telephone_mobile_or_other",
+                "label": "Mobile or Other Phone",
+                "type": "tel",
+                "required": false,
+                "tooltip": "To edit Telephone (Cell or Other) click on NYC ModelCity in the top-left corner then click on Account Settings and then click on Contact.",
+                "constraints": {
+                  "pattern": "^\\\\(?[0-9]{3}\\\\)?[-. ]?[0-9]{3}[-. ]?[0-9]{4}$"
+                },
+                "ui": {
+                  "placeholder": "(123) 456-7890"
+                }
+              },
+              {
+                "id": "email",
+                "label": "Email",
+                "type": "email",
+                "required": true,
+                "tooltip": "To edit email, go to NYC ID Profile tab by clicking your name at the top right corner"
+              }
+            ]
+          },
+          {
+            "id": "address_info",
+            "title": "Address",
+            "tooltip": "To edit home address click on NYC ModelCity in the top-left corner then click on Account Settings.",
+            "ui": {
+              "autocomplete": "street",
+              "placeholder": "Start typing your street address",
+              "overrideComponent": "AddressAutocomplete"
+            },
+            "metadata": {
+              "integration": {
+                "provider": "Google",
+                "feature": "AddressAutocomplete"
+              },
+              "autofillTargets": [
+                {
+                  "fieldId": "city",
+                  "source": "locality",
+                  "fallbackSources": [
+                    "postal_town",
+                    "sublocality_level_1",
+                    "administrative_area_level_2"
+                  ]
+                },
+                {
+                  "fieldId": "borough",
+                  "source": "sublocality_level_1",
+                  "fallbackSources": [
+                    "administrative_area_level_2"
+                  ],
+                  "mapping": "boroughMap"
+                },
+                { "fieldId": "state", "source": "administrative_area_level_1" },
+                { "fieldId": "zip_code", "source": "postal_code" },
+                { "fieldId": "latitude", "source": "location.latitude" },
+                { "fieldId": "longitude", "source": "location.longitude" }
+              ]
+            },
+            "fields": [
+              {
+                "id": "street",
+                "label": "Street Address",
+                "type": "text",
+                "required": true,
+                "tooltip": "To edit home address click on NYC ModelCity in the top-left corner then click on Account Settings."
+              },
+              {
+                "id": "apt",
+                "label": "Apt #",
+                "type": "text",
+                "required": false
+              },
+              {
+                "id": "city",
+                "label": "City",
+                "type": "text",
+                "required": true
+              },
+              {
+                "id": "borough",
+                "label": "Borough",
+                "type": "select",
+                "required": true,
+                "ui": {
+                  "options": [
+                    "",
+                    "Bronx",
+                    "Brooklyn",
+                    "Manhattan",
+                    "Queens",
+                    "Staten Island"
+                  ]
+                }
+              },
+              {
+                "id": "state",
+                "label": "State",
+                "type": "text",
+                "required": true
+              },
+              {
+                "id": "zip_code",
+                "label": "Zip Code",
+                "type": "text",
+                "required": true
+              },
+              {
+                "id": "latitude",
+                "label": "Latitude",
+                "type": "number",
+                "required": false
+              },
+              {
+                "id": "longitude",
+                "label": "Longitude",
+                "type": "number",
+                "required": false
+              },
+              {
+                "id": "is_temporary_address",
+                "label": "Is Temporary Address",
+                "type": "radio",
+                "required": true,
+                "tooltip": "Check YES if you are currently living in a homeless shelter, doubled-up with another family, in a hotel/motel, in a car/ bus/ train, in a park/campsite, or other temporary accomodation.",
+                "ui": {
+                  "options": [
+                    "Yes",
+                    "No"
+                  ]
+                }
+              },
+              {
+                "id": "currently_living_in",
+                "label": "Currently Living In",
+                "type": "select",
+                "required": false,
+                "requiredCondition": {
+                  "field": "is_temporary_address",
+                  "operator": "equals",
+                  "value": "Yes"
+                },
+                "ui": {
+                  "options": [
+                    "",
+                    "Homeless Shelter",
+                    "Doubled-up with another Family",
+                    "Hotel/Motel",
+                    "Car, Bus, Train",
+                    "Park",
+                    "Campsite",
+                    "Other"
+                  ]
+                }
+              }
+            ]
+          },
+          {
+            "id": "demographics",
+            "title": "Demographics",
+            "fields": [
+              {
+                "id": "ethnicity",
+                "label": "Ethnicity",
+                "type": "select",
+                "required": false,
+                "ui": {
+                  "options": [
+                    "",
+                    "Hispanic",
+                    "Latino",
+                    "No",
+                    "Prefer not to answer"
+                  ]
+                }
+              },
+              {
+                "id": "race",
+                "label": "Race",
+                "type": "checkbox",
+                "required": false,
+                "tooltip": "You may choose multiple race categories. Providing race information is voluntary and will not affect your eligibility for Child Care Assistance or the amount of assistance that you will be given by this agency.",
+                "ui": {
+                  "options": [
+                    {
+                      "value": "AI",
+                      "label": "American Indian or Alaska Native"
+                    },
+                    {
+                      "value": "AS",
+                      "label": "Asian"
+                    },
+                    {
+                      "value": "BL",
+                      "label": "Black or African American"
+                    },
+                    {
+                      "value": "HP",
+                      "label": "Native Hawaiian or Pacific Islander"
+                    },
+                    {
+                      "value": "WH",
+                      "label": "White"
+                    }
+                  ]
+                },
+                "metadata": {
+                  "multiple": true
+                }
+              },
+              {
+                "id": "ssn",
+                "label": "Social Security Number",
+                "type": "text",
+                "tooltip": "To edit social security number click on NYC ModelCity in the top-left corner then click on Account Settings.",
+                "required": false,
+                "constraints": {
+                  "pattern": "^\\\\d{3}-\\\\d{2}-\\\\d{4}$"
+                },
+                "ui": {
+                  "placeholder": "123-45-6789"
+                }
+              }
+            ]
+          },
+          {
+            "id": "language_info",
+            "title": "Language Preferences",
+            "fields": [
+              {
+                "id": "primary_language",
+                "label": "Primary Language",
+                "type": "radio",
+                "required": true,
+                "tooltip": "Select the language that is spoken most often in your household. If “other”, provide the name of the language.",
+                "ui": {
+                  "options": [
+                    "English",
+                    "Spanish",
+                    "Other"
+                  ]
+                }
+              },
+              {
+                "id": "preferred_language",
+                "label": "Preferred Language",
+                "type": "radio",
+                "required": true,
+                "tooltip": "Select the language you prefer to communicate in. If “other”, provide the name of the language.",
+                "ui": {
+                  "options": [
+                    "English",
+                    "Spanish",
+                    "Other"
+                  ]
+                }
+              },
+              {
+                "id": "other_primary_language",
+                "label": "Other Primary Language",
+                "type": "text",
+                "required": false,
+                "requiredCondition": {
+                  "field": "primary_language",
+                  "operator": "equals",
+                  "value": "Other"
+                }
+              },
+              {
+                "id": "other_preferred_language",
+                "label": "Other Preferred Language",
+                "type": "text",
+                "required": false,
+                "requiredCondition": {
+                  "field": "preferred_language",
+                  "operator": "equals",
+                  "value": "Other"
+                }
+              }
+            ]
+          },
+          {
+            "id": "cash_assistance",
+            "title": "Cash Assistance",
+            "fields": [
+              {
+                "id": "has_cash_assistance",
+                "label": "Do you receive Cash Assistance?",
+                "type": "radio",
+                "required": false,
+                "ui": {
+                  "options": [
+                    "Yes",
+                    "No"
+                  ]
+                }
+              },
+              {
+                "id": "ca_number",
+                "label": "Cash Assistance Number",
+                "type": "text",
+                "required": false,
+                "requiredCondition": {
+                  "condition": {
+                    "field": "has_cash_assistance",
+                    "operator": "equals",
+                    "value": "Yes"
+                  }
+                }
+              }
+            ]
+          }
+        ]
+      },
+      {
+        "id": "children_needing_care",
+        "title": "Children Needing Care",
+        "sections": [
+          {
+            "id": "child_details",
+            "title": "Child Details",
+            "required": true,
+            "fields": [
+              {
+                "id": "children",
+                "label": "Children Needing Care",
+                "type": "group",
+                "metadata": {
+                  "multiple": true,
+                  "tableColumns": [
+                  "first_name",
+                  "last_name",
+                  "date_of_birth",
+                  "relationship_to_applicant"
+                  ]
+                },
+                "fields": [
+                  {
+                    "id": "first_name",
+                    "label": "First Name",
+                    "type": "text",
+                    "required": true,
+                    "tooltip": "Provide the first name, last name, and middle initial of each child you are applying for child care assistance for."
+                  },
+                  {
+                    "id": "last_name",
+                    "label": "Last Name",
+                    "type": "text",
+                    "required": true
+                  },
+                  {
+                    "id": "mi",
+                    "label": "Middle Initial",
+                    "type": "text",
+                    "required": false
+                  },
+                  {
+                    "id": "relationship_to_applicant",
+                    "label": "Relationship to Applicant",
+                    "type": "select",
+                    "required": true,
+                    "ui": {
+                      "options": [
+                        "",
+                        "Child",
+                        "Grandchild",
+                        "Foster Child",
+                        "Other"
+                      ]
+                    }
+                  },
+                  {
+                    "id": "date_of_birth",
+                    "label": "Date of Birth",
+                    "type": "date",
+                    "required": true,
+                    "tooltip": "Provide the date of birth."
+                  },
+                  {
+                    "id": "sex",
+                    "label": "Sex",
+                    "type": "radio",
+                    "required": true,
+                    "tooltip": "Select to indicate the sex.",
+                    "ui": {
+                      "options": [
+                        "Male",
+                        "Female"
+                      ]
+                    }
+                  },
+                  {
+                    "id": "ethnicity",
+                    "label": "Ethnicity Hispanic or Latino",
+                    "type": "select",
+                    "required": false,
+                    "tooltip": "Check “YES” or “NO” to indicate if each child in need of child care is Hispanic or Latino or not. Providing ethnicity information is voluntary and will not affect your eligibility for child care assistance or the amount of assistance that you will be given by this agency.",
+                    "ui": {
+                      "options": [
+                        "",
+                        "Yes",
+                        "No",
+                        "Prefer not to answer"
+                      ]
+                    }
+                  },
+                  {
+                    "id": "race",
+                    "label": "Race",
+                    "type": "checkbox",
+                    "required": false,
+                    "tooltip": "You may choose multiple race categories for a single child. Providing race information is voluntary and will not affect your eligibility for Child Care Assistance or the amount of assistance that you will be given by this agency.",
+                    "ui": {
+                      "options": [
+                        {
+                          "value": "AI",
+                          "label": "American Indian or Alaska Native"
+                        },
+                        {
+                          "value": "AS",
+                          "label": "Asian"
+                        },
+                        {
+                          "value": "BL",
+                          "label": "Black or African American"
+                        },
+                        {
+                          "value": "HP",
+                          "label": "Native Hawaiian or Pacific Islander"
+                        },
+                        {
+                          "value": "WH",
+                          "label": "White"
+                        }
+                      ]
+                    },
+                    "metadata": {
+                      "multiple": true
+                    }
+                  },
+                  {
+                    "id": "ssn",
+                    "label": "Social Security Number",
+                    "type": "text",
+                    "required": false,
+                    "tooltip": "Provide each child’s Social Security Number (SSN). You are not required to provide SSNs. They may be used by federal, state, and local agencies to prevent duplication of services and fraud, and for Federal Reporting.",
+                    "constraints": {
+                      "pattern": "^\\\\d{3}-\\\\d{2}-\\\\d{4}$"
+                    },
+                    "ui": {
+                      "placeholder": "123-45-6789"
+                    }
+                  },
+                  {
+                    "id": "do_both_parents_reside_in_home",
+                    "label": "Do both parents reside in the home?",
+                    "type": "radio",
+                    "required": true,
+                    "tooltip": "Check “YES” or “NO” to indicate whether both of the child’s parents live in the home.",
+                    "ui": {
+                      "options": [
+                        "Yes",
+                        "No"
+                      ]
+                    }
+                  },
+                  {
+                    "id": "has_disability",
+                    "label": "Does the child have a disability?",
+                    "type": "radio",
+                    "required": true,
+                    "tooltip": "Check “YES” or “NO” to indicate whether the child needing child care has a disability.",
+                    "ui": {
+                      "options": [
+                        "Yes",
+                        "No"
+                      ]
+                    }
+                  },
+                  {
+                    "id": "is_immigration_status_satisfactory",
+                    "label": "Is child U.S. Citizen, U.S. National, or person with satisfactory immigration status?",
+                    "type": "radio",
+                    "required": true,
+                    "tooltip": "You will only be asked about the immigration status of the children in need of care. Other members of the family will not need to state or prove their immigration status. Your child will be eligible for care if they are a U.S. citizen, a legal permanent resident (green card holder), a refugee, or an asylee; have a T-visa; or hold another qualified immigration status. Please select “Yes” if your child holds one of these statuses.",
+                    "ui": {
+                      "options": [
+                        "Yes",
+                        "No"
+                      ]
+                    }
+                  }
+                ]
+              }
+            ]
+          }
+        ]
+      },
+      {
+        "id": "family_members",
+        "title": "Family Members",
+        "sections": [
+          {
+            "id": "household_members_info",
+            "title": "Household Members Information",
+            "type": "info",
+            "ui": {
+              "markdown": true,
+              "collapsible": false,
+              "defaultCollapsed": false
+            },
+            "content": "**List the household members who do _not_ need child care.**\\n\\nIf applicable, list:\\n\\n- Your **spouse**, your child’s **second parent**, **caretaker**, or **step-parent**\\n- Any other **adult with whom you share a child**, if they live in your home\\n\\nThen, if applicable, list:\\n\\n- Any **siblings under the age of 18** who live in your home\\n\\n> **Only list other household members** — such as **aunts, uncles, cousins, grandparents, or friends** — _if they have financial responsibility_ for the child.\\n\\nA household member with financial responsibility, other than a parent or step-parent, is one who has a **letter or order of guardianship**.\\n\\n**Otherwise, do not include them.**"
+          },
+          {
+            "id": "family_member_details",
+            "title": "Household Member Details",
+            "description": "Include household members who do not need child care assistance (e.g., spouse, partner, other children).",
+            "fields": [
+              {
+                "id": "familymember",
+                "label": "Family Members",
+                "type": "group",
+                "requiredCondition": {
+                  "repeatingGroup": "children",
+                  "operator": "ANY",
+                  "condition": { "field": "do_both_parents_reside_in_home", "operator": "equals", "value": "Yes" }
+                },  
+                "metadata": {
+                  "multiple": true,
+                  "tableColumns": [
+                    "first_name",
+                    "last_name",
+                    "relationship_to_applicant",
+                    "date_of_birth"
+                  ]
+                },
+                "fields": [
+                  {
+                    "id": "first_name",
+                    "label": "First Name",
+                    "type": "text",
+                    "required": true,
+                    "tooltip": "Provide last and first name, and middle initial if applicable."
+                  },
+                  {
+                    "id": "last_name",
+                    "label": "Last Name",
+                    "type": "text",
+                    "required": true
+                  },
+                  {
+                    "id": "mi",
+                    "label": "Middle Initial",
+                    "type": "text",
+                    "required": false
+                  },
+                  {
+                    "id": "relationship_to_applicant",
+                    "label": "Relationship to Applicant",
+                    "type": "select",
+                    "required": true,
+                    "tooltip": "Provide each person’s relationship to you (e.g. spouse, partner, child, foster parent, other).",
+                    "ui": {
+                      "options": [
+                        "",
+                        "Spouse",
+                        "Partner",
+                        "Foster Parent",
+                        "Child",
+                        "Other"
+                      ]
+                    }
+                  },
+                  {
+                    "id": "date_of_birth",
+                    "label": "Date of Birth",
+                    "type": "date",
+                    "required": true,
+                    "tooltip": "Provide the family member's date of birth."
+                  },
+                  {
+                    "id": "sex",
+                    "label": "Sex",
+                    "type": "radio",
+                    "required": true,
+                    "tooltip": "Indicate the sex for each family member listed.",
+                    "ui": {
+                      "options": [
+                        "Male",
+                        "Female"
+                      ]
+                    }
+                  },
+                  {
+                    "id": "ethnicity",
+                    "label": "Ethnicity Hispanic or Latino",
+                    "type": "select",
+                    "required": false,
+                    "tooltip": "Check “YES” or “NO” to indicate if each member in the household is Hispanic or Latino or not. Providing ethnicity information is voluntary and will not affect your eligibility for Child Care Assistance or the amount of assistance that you will be given by this agency.",
+                    "ui": {
+                      "options": [
+                        "",
+                        "Yes",
+                        "No",
+                        "Prefer not to answer"
+                      ]
+                    }
+                  },
+                  {
+                    "id": "race",
+                    "label": "Race",
+                    "type": "checkbox",
+                    "required": false,
+                    "tooltip": "You may choose multiple race categories for a single person. Providing race information is voluntary and will not affect your eligibility for Child Care Assistance or the amount of assistance that you will be given by this agency.",
+                    "ui": {
+                      "options": [
+                        {
+                          "value": "AI",
+                          "label": "American Indian or Alaska Native"
+                        },
+                        {
+                          "value": "AS",
+                          "label": "Asian"
+                        },
+                        {
+                          "value": "BL",
+                          "label": "Black or African American"
+                        },
+                        {
+                          "value": "HP",
+                          "label": "Native Hawaiian or Pacific Islander"
+                        },
+                        {
+                          "value": "WH",
+                          "label": "White"
+                        }
+                      ]
+                    },
+                    "metadata": {
+                      "multiple": true
+                    }
+                  },
+                  {
+                    "id": "ssn",
+                    "label": "Social Security Number",
+                    "type": "text",
+                    "required": false,
+                    "tooltip": "Fill in the Social Security Number (SSN) for your family members. SSN is optional. SSN may be used by federal, state, and local agencies to prevent duplication of services and fraud, and for Federal Reporting.",
+                    "constraints": {
+                      "pattern": "^\\\\d{3}-\\\\d{2}-\\\\d{4}$"
+                    },
+                    "ui": {
+                      "placeholder": "123-45-6789"
+                    }
+                  }
+                ]
+              }
+            ]
+          }
+        ]
+      },
+      {
+        "id": "child_family_needs",
+        "title": "Child / Family Needs",
+        "sections": [
+          {
+            "id": "assistance_reason",
+            "title": "Reason for Child Care Assistance",
+            "description": "Select one or two reasons you are requesting Child Care Assistance.",
+            "tooltip": "Select one reason. In a two-parent household, parents/caretakers can have the same or different reasons for needing child care. Both parents/caretakers will be required to submit documentation in support of their own reason. If you are living in temporary housing, please select Homelessness even if you have another reason that applies to you.",
+            "fields": [
+              {
+                "id": "assistance_reason",
+                "label": "Reason(s) for Assistance",
+                "type": "select",
+                "required": true,
+                "ui": {
+                  "options": [
+                    "",
+                    "Employment",
+                    "Looking for Work",
+                    "Vocational Training/Educational Activities",
+                    "Receiving Domestic Violence Services",
+                    "Homelessness"
+                  ]
+                },
+                "constraints": {
+                  "minSelections": 1,
+                  "maxSelections": 2
+                },
+                "metadata": {
+                  "multiple": true
+                }
+              }
+            ]
+          },
+          {
+            "id": "military_status",
+            "title": "Military and Parental Availability",
+            "description": "Provide information about parental military status and availability for child care.",
+            "fields": [
+              {
+                "id": "is_parent_currently_active_in_military",
+                "label": "Is a Parent Currently Active Full-Time in the U.S. Military?",
+                "tooltip": "Check “YES” or “NO” to indicate whether a parent is currently active full-time in the U.S. Military.",
+                "type": "radio",
+                "required": true,
+                "ui": {
+                  "options": [
+                    "Yes",
+                    "No"
+                  ]
+                }
+              },
+              {
+                "id": "is_parent_mem_of_guard_or_mru",
+                "label": "Is a Parent a Member of National Guard or Military Reserve Unit?",
+                "tooltip": "Check “YES” or “NO” to indicate whether a parent is currently a member of a National Guard or Military Reserve Unit.",
+                "type": "radio",
+                "required": true,
+                "ui": {
+                  "options": [
+                    "Yes",
+                    "No"
+                  ]
+                }
+              },
+              {
+                "id": "is_non_custodial_parent_available",
+                "label": "Is the Non-Custodial Parent Available to Provide Care?",
+                "tooltip": "Check “YES” or “NO” to indicate whether there is a non-custodial parent available to provide child care.",
+                "type": "radio",
+                "required": true,
+                "ui": {
+                  "options": [
+                    "Yes",
+                    "No"
+                  ]
+                }
+              }
+            ]
+          },
+          {
+            "id": "duplicate_application",
+            "title": "Other Applications",
+            "description": "Indicate if you are also applying for or receiving child care from other agencies.",
+            "tooltip": "Indicate whether you are currently receiving or have applied for child care assistance with one of the agencies or organizations listed below. Note: If you are receiving Cash Assistance and are interested in child care assistance, you must apply through the Human Resources Administration. Reach out to your Benefits Access Center or visit the Human Resources Administration webpage.",
+            "fields": [
+              {
+                "id": "duplicate_app",
+                "label": "Are You Receiving or Applying for Child Care Through Another Agency?",
+                "type": "select",
+                "required": false,
+                "ui": {
+                  "options": [
+                    "",
+                    "Not Applicable",
+                    "Department of Education (DOE)",
+                    "Human Resources Administration (HRA)",
+                    "Department of Youth and Community Development (DYCD)",
+                    "Department of Homeless Services (DHS)",
+                    "Consortium for Worker Education (CWE)",
+                    "Administration for Children's Services (ACS)"
+                  ]
+                }
+              }
+            ]
+          }
+        ]
+      },
+      {
+        "id": "employment",
+        "title": "Employment",
+        "sections": [
+          {
+            "id": "employment_precheck",
+            "title": "Tell us about your employment",
+            "description": "Tell us about your employment",
+            "fields": [
+              {
+                "id": "applicant_emp_income_indicator",
+                "label": "Does applicant earn any income/ wages from employment? ",
+                "type": "radio",
+                "required": false,
+                "ui": {
+                  "options": [
+                    "Yes",
+                    "No"
+                  ]
+                }
+              },
+              {
+                "id": "coparent_emp_income_indicator",
+                "label": "Does Coparent/2nd Guardian earn any income/ wages from employment? ",
+                "type": "radio",
+                "required": false,
+                "ui": {
+                  "options": [
+                    "Yes",
+                    "No"
+                  ]
+                }
+              }
+            ]
+          },
+          {
+            "id": "applicant_jobs",
+            "title": "Applicant Employment Information",
+            "description": "Enter details for up to two jobs held by the applicant.",
+            "visibilityCondition": {
+              "field": "applicant_emp_income_indicator",
+              "operator": "equals",
+              "value": "Yes"
+            },
+            "fields": [
+              {
+                "id": "applicant_1st_job_start_date",
+                "label": "1st Job - Start Date",
+                "type": "date",
+                "required": false,
+                "ui": {
+                  "group": "1st Job"
+                }
+              },
+              {
+                "id": "applicant_1st_job_rotating_shift",
+                "label": "1st Job - Has Rotating Shift?",
+                "type": "radio",
+                "required": false,
+                "ui": {
+                  "options": [
+                    "Yes",
+                    "No"
+                  ],
+                  "group": "1st Job"
+                }
+              },
+              {
+                "id": "applicant_1st_job_requires_overtime",
+                "label": "1st Job - Requires Overtime?",
+                "type": "radio",
+                "required": false,
+                "ui": {
+                  "options": [
+                    "Yes",
+                    "No"
+                  ],
+                  "group": "1st Job"
+                }
+              },
+              {
+                "id": "applicant_1st_job_employer_name",
+                "label": "1st Job - Employer Name",
+                "type": "text",
+                "required": false,
+                "ui": {
+                  "group": "1st Job"
+                }
+              },
+              {
+                "id": "applicant_1st_job_employer_phone",
+                "label": "1st Job - Employer Phone",
+                "type": "tel",
+                "required": false,
+                "ui": {
+                  "group": "1st Job"
+                }
+              },
+              {
+                "id": "applicant_1st_job_employer_street",
+                "label": "1st Job - Employer Street Address",
+                "type": "text",
+                "required": false,
+                "ui": {
+                  "group": "1st Job"
+                }
+              },
+              {
+                "id": "applicant_1st_job_employer_city",
+                "label": "1st Job - Employer City",
+                "type": "text",
+                "required": false,
+                "ui": {
+                  "group": "1st Job"
+                }
+              },
+              {
+                "id": "applicant_1st_job_employer_state",
+                "label": "1st Job - Employer State",
+                "type": "text",
+                "required": false,
+                "ui": {
+                  "group": "1st Job"
+                }
+              },
+              {
+                "id": "applicant_1st_job_employer_zipcode",
+                "label": "1st Job - Employer ZIP Code",
+                "type": "text",
+                "required": false,
+                "ui": {
+                  "group": "1st Job"
+                }
+              },
+              {
+                "id": "applicant_2nd_job_start_date",
+                "label": "2nd Job - Start Date",
+                "type": "date",
+                "required": false,
+                "ui": {
+                  "group": "2nd Job"
+                }
+              },
+              {
+                "id": "applicant_2nd_job_rotating_shift",
+                "label": "2nd Job - Has Rotating Shift?",
+                "type": "radio",
+                "required": false,
+                "ui": {
+                  "options": [
+                    "Yes",
+                    "No"
+                  ],
+                  "group": "2nd Job"
+                }
+              },
+              {
+                "id": "applicant_2nd_job_requires_overtime",
+                "label": "2nd Job - Requires Overtime?",
+                "type": "radio",
+                "required": false,
+                "ui": {
+                  "options": [
+                    "Yes",
+                    "No"
+                  ],
+                  "group": "2nd Job"
+                }
+              },
+              {
+                "id": "applicant_2nd_job_employer_name",
+                "label": "2nd Job - Employer Name",
+                "type": "text",
+                "required": false,
+                "ui": {
+                  "group": "2nd Job"
+                }
+              },
+              {
+                "id": "applicant_2nd_job_employer_phone",
+                "label": "2nd Job - Employer Phone",
+                "type": "tel",
+                "required": false,
+                "ui": {
+                  "group": "2nd Job"
+                }
+              },
+              {
+                "id": "applicant_2nd_job_employer_street",
+                "label": "2nd Job - Employer Street Address",
+                "type": "text",
+                "required": false,
+                "ui": {
+                  "group": "2nd Job"
+                }
+              },
+              {
+                "id": "applicant_2nd_job_employer_city",
+                "label": "2nd Job - Employer City",
+                "type": "text",
+                "required": false,
+                "ui": {
+                  "group": "2nd Job"
+                }
+              },
+              {
+                "id": "applicant_2nd_job_employer_state",
+                "label": "2nd Job - Employer State",
+                "type": "text",
+                "required": false,
+                "ui": {
+                  "group": "2nd Job"
+                }
+              },
+              {
+                "id": "applicant_2nd_job_employer_zipcode",
+                "label": "2nd Job - Employer ZIP Code",
+                "type": "text",
+                "required": false,
+                "ui": {
+                  "group": "2nd Job"
+                }
+              }
+            ]
+          },
+          {
+            "id": "second_parent_jobs",
+            "title": "Second Parent Employment Information",
+            "description": "Enter details for up to two jobs held by the second parent (if applicable).",
+            "visibilityCondition": {
+              "field": "coparent_emp_income_indicator",
+              "operator": "equals",
+              "value": "Yes"
+            },
+            "fields": [
+              {
+                "id": "second_parent_1st_job_start_date",
+                "label": "1st Job - Start Date",
+                "type": "date",
+                "required": false
+              },
+              {
+                "id": "second_parent_1st_job_rotating_shift",
+                "label": "1st Job - Has Rotating Shift?",
+                "type": "radio",
+                "required": false,
+                "ui": {
+                  "options": [
+                    "Yes",
+                    "No"
+                  ]
+                }
+              },
+              {
+                "id": "second_parent_1st_job_requires_overtime",
+                "label": "1st Job - Requires Overtime?",
+                "type": "radio",
+                "required": false,
+                "ui": {
+                  "options": [
+                    "Yes",
+                    "No"
+                  ]
+                }
+              },
+              {
+                "id": "second_parent_1st_job_employer_name",
+                "label": "1st Job - Employer Name",
+                "type": "text",
+                "required": false
+              },
+              {
+                "id": "second_parent_1st_job_employer_phone",
+                "label": "1st Job - Employer Phone",
+                "type": "tel",
+                "required": false
+              },
+              {
+                "id": "second_parent_1st_job_employer_street",
+                "label": "1st Job - Employer Street Address",
+                "type": "text",
+                "required": false
+              },
+              {
+                "id": "second_parent_1st_job_employer_city",
+                "label": "1st Job - Employer City",
+                "type": "text",
+                "required": false
+              },
+              {
+                "id": "second_parent_1st_job_employer_state",
+                "label": "1st Job - Employer State",
+                "type": "text",
+                "required": false
+              },
+              {
+                "id": "second_parent_1st_job_employer_zipcode",
+                "label": "1st Job - Employer ZIP Code",
+                "type": "text",
+                "required": false
+              },
+              {
+                "id": "second_parent_2nd_job_start_date",
+                "label": "2nd Job - Start Date",
+                "type": "date",
+                "required": false
+              },
+              {
+                "id": "second_parent_2nd_job_rotating_shift",
+                "label": "2nd Job - Has Rotating Shift?",
+                "type": "radio",
+                "required": false,
+                "ui": {
+                  "options": [
+                    "Yes",
+                    "No"
+                  ]
+                }
+              },
+              {
+                "id": "second_parent_2nd_job_requires_overtime",
+                "label": "2nd Job - Requires Overtime?",
+                "type": "radio",
+                "required": false,
+                "ui": {
+                  "options": [
+                    "Yes",
+                    "No"
+                  ]
+                }
+              },
+              {
+                "id": "second_parent_2nd_job_employer_name",
+                "label": "2nd Job - Employer Name",
+                "type": "text",
+                "required": false
+              },
+              {
+                "id": "second_parent_2nd_job_employer_phone",
+                "label": "2nd Job - Employer Phone",
+                "type": "tel",
+                "required": false
+              },
+              {
+                "id": "second_parent_2nd_job_employer_street",
+                "label": "2nd Job - Employer Street Address",
+                "type": "text",
+                "required": false
+              },
+              {
+                "id": "second_parent_2nd_job_employer_city",
+                "label": "2nd Job - Employer City",
+                "type": "text",
+                "required": false
+              },
+              {
+                "id": "second_parent_2nd_job_employer_state",
+                "label": "2nd Job - Employer State",
+                "type": "text",
+                "required": false
+              },
+              {
+                "id": "second_parent_2nd_job_employer_zipcode",
+                "label": "2nd Job - Employer ZIP Code",
+                "type": "text",
+                "required": false
+              }
+            ]
+          }
+        ]
+      },
+      {
+        "id": "schedule",
+        "title": "Work/Activity/Travel Time Schedule",
+        "sections": [
+          {
+            "id": "schedule_section_info",
+            "title": "Schedule Information",
+            "type": "info",
+            "ui": {
+              "markdown": true,
+              "collapsible": false,
+              "defaultCollapsed": false
+            },
+            "content": "Please indicate what days and hours you will need child care for based on your reason for care.\\n\\n- **Employed**: Indicate the hours you attend work\\n- **Educational or Vocational Program**: Indicate the hours you attend school or your program\\n- **Looking for Work**: Indicate the hours you spend looking for work\\n- **Homeless**: Indicate the hours you spend looking for housing\\n- **Attending Services for Domestic Violence**: Indicate the hours you attend services.\\n- **Attending Services for Substance Abuse Treatment**: Indicate the hours you attend services."
+          },
+          {
+            "id": "first_parent_activity_schedule",
+            "title": "First Parent Activity Schedule",
+            "description": "Enter the start and end times for each day of the week for the first parent's activities.",
+            "ui": {
+              "layout": "table",
+              "columns": [
+                "Start Time",
+                "End Time"
+              ],
+              "rowCopy": {
+                "enableUserPickSource": true,
+                "rowIdentifier": "ui.rowGroup",
+                "fieldsToCopy": [
+                  1,
+                  2
+                ],
+                "targetRowValues": [
+                  "Monday",
+                  "Tuesday",
+                  "Wednesday",
+                  "Thursday",
+                  "Friday"
+                ],
+                "copyControlLabel": "Apply selected schedule to other weekdays",
+                "sourceOptions": [
+                  "Monday",
+                  "Tuesday",
+                  "Wednesday",
+                  "Thursday",
+                  "Friday",
+                  "Saturday",
+                  "Sunday"
+                ]
+              }
+            },
+            "fields": [
+              {
+                "id": "fp_monday_from",
+                "label": "Monday From",
+                "type": "time",
+                "ui": {
+                  "rowGroup": "Monday",
+                  "column": 1
+                }
+              },
+              {
+                "id": "fp_monday_to",
+                "label": "Monday To",
+                "type": "time",
+                "ui": {
+                  "rowGroup": "Monday",
+                  "column": 2
+                }
+              },
+              {
+                "id": "fp_tuesday_from",
+                "label": "Tuesday From",
+                "type": "time",
+                "ui": {
+                  "rowGroup": "Tuesday",
+                  "column": 1
+                }
+              },
+              {
+                "id": "fp_tuesday_to",
+                "label": "Tuesday To",
+                "type": "time",
+                "ui": {
+                  "rowGroup": "Tuesday",
+                  "column": 2
+                }
+              },
+              {
+                "id": "fp_wednesday_from",
+                "label": "Wednesday From",
+                "type": "time",
+                "ui": {
+                  "rowGroup": "Wednesday",
+                  "column": 1
+                }
+              },
+              {
+                "id": "fp_wednesday_to",
+                "label": "Wednesday To",
+                "type": "time",
+                "ui": {
+                  "rowGroup": "Wednesday",
+                  "column": 2
+                }
+              },
+              {
+                "id": "fp_thursday_from",
+                "label": "Thursday From",
+                "type": "time",
+                "ui": {
+                  "rowGroup": "Thursday",
+                  "column": 1
+                }
+              },
+              {
+                "id": "fp_thursday_to",
+                "label": "Thursday To",
+                "type": "time",
+                "ui": {
+                  "rowGroup": "Thursday",
+                  "column": 2
+                }
+              },
+              {
+                "id": "fp_friday_from",
+                "label": "Friday From",
+                "type": "time",
+                "ui": {
+                  "rowGroup": "Friday",
+                  "column": 1
+                }
+              },
+              {
+                "id": "fp_friday_to",
+                "label": "Friday To",
+                "type": "time",
+                "ui": {
+                  "rowGroup": "Friday",
+                  "column": 2
+                }
+              },
+              {
+                "id": "fp_saturday_from",
+                "label": "Saturday From",
+                "type": "time",
+                "ui": {
+                  "rowGroup": "Saturday",
+                  "column": 1
+                }
+              },
+              {
+                "id": "fp_saturday_to",
+                "label": "Saturday To",
+                "type": "time",
+                "ui": {
+                  "rowGroup": "Saturday",
+                  "column": 2
+                }
+              },
+              {
+                "id": "fp_sunday_from",
+                "label": "Sunday From",
+                "type": "time",
+                "ui": {
+                  "rowGroup": "Sunday",
+                  "column": 1
+                }
+              },
+              {
+                "id": "fp_sunday_to",
+                "label": "Sunday To",
+                "type": "time",
+                "ui": {
+                  "rowGroup": "Sunday",
+                  "column": 2
+                }
+              }
+            ]
+          },
+          {
+            "id": "second_parent_activity_schedule",
+            "title": "Second Parent Activity Schedule",
+            "description": "Enter the start and end times for each day of the week for the second parent's activities.",
+            "ui": {
+              "layout": "table",
+              "columns": [
+                "Start Time",
+                "End Time"
+              ],
+              "rowCopy": {
+                "enableUserPickSource": true,
+                "rowIdentifier": "ui.rowGroup",
+                "fieldsToCopy": [
+                  1,
+                  2
+                ],
+                "targetRowValues": [
+                  "Monday",
+                  "Tuesday",
+                  "Wednesday",
+                  "Thursday",
+                  "Friday"
+                ],
+                "copyControlLabel": "Apply selected schedule to other weekdays",
+                "sourceOptions": [
+                  "Monday",
+                  "Tuesday",
+                  "Wednesday",
+                  "Thursday",
+                  "Friday",
+                  "Saturday",
+                  "Sunday"
+                ]
+              }
+            },
+            "fields": [
+              {
+                "id": "sp_monday_from",
+                "label": "Monday From",
+                "type": "time",
+                "ui": {
+                  "rowGroup": "Monday",
+                  "column": 1
+                }
+              },
+              {
+                "id": "sp_monday_to",
+                "label": "Monday To",
+                "type": "time",
+                "ui": {
+                  "rowGroup": "Monday",
+                  "column": 2
+                }
+              },
+              {
+                "id": "sp_tuesday_from",
+                "label": "Tuesday From",
+                "type": "time",
+                "ui": {
+                  "rowGroup": "Tuesday",
+                  "column": 1
+                }
+              },
+              {
+                "id": "sp_tuesday_to",
+                "label": "Tuesday To",
+                "type": "time",
+                "ui": {
+                  "rowGroup": "Tuesday",
+                  "column": 2
+                }
+              },
+              {
+                "id": "sp_wednesday_from",
+                "label": "Wednesday From",
+                "type": "time",
+                "ui": {
+                  "rowGroup": "Wednesday",
+                  "column": 1
+                }
+              },
+              {
+                "id": "sp_wednesday_to",
+                "label": "Wednesday To",
+                "type": "time",
+                "ui": {
+                  "rowGroup": "Wednesday",
+                  "column": 2
+                }
+              },
+              {
+                "id": "sp_thursday_from",
+                "label": "Thursday From",
+                "type": "time",
+                "ui": {
+                  "rowGroup": "Thursday",
+                  "column": 1
+                }
+              },
+              {
+                "id": "sp_thursday_to",
+                "label": "Thursday To",
+                "type": "time",
+                "ui": {
+                  "rowGroup": "Thursday",
+                  "column": 2
+                }
+              },
+              {
+                "id": "sp_friday_from",
+                "label": "Friday From",
+                "type": "time",
+                "ui": {
+                  "rowGroup": "Friday",
+                  "column": 1
+                }
+              },
+              {
+                "id": "sp_friday_to",
+                "label": "Friday To",
+                "type": "time",
+                "ui": {
+                  "rowGroup": "Friday",
+                  "column": 2
+                }
+              },
+              {
+                "id": "sp_saturday_from",
+                "label": "Saturday From",
+                "type": "time",
+                "ui": {
+                  "rowGroup": "Saturday",
+                  "column": 1
+                }
+              },
+              {
+                "id": "sp_saturday_to",
+                "label": "Saturday To",
+                "type": "time",
+                "ui": {
+                  "rowGroup": "Saturday",
+                  "column": 2
+                }
+              },
+              {
+                "id": "sp_sunday_from",
+                "label": "Sunday From",
+                "type": "time",
+                "ui": {
+                  "rowGroup": "Sunday",
+                  "column": 1
+                }
+              },
+              {
+                "id": "sp_sunday_to",
+                "label": "Sunday To",
+                "type": "time",
+                "ui": {
+                  "rowGroup": "Sunday",
+                  "column": 2
+                }
+              }
+            ]
+          },
+          {
+            "id": "first_parent_travel_time",
+            "title": "First Parent Travel Time",
+            "description": "Enter the travel times and method of transport for the first parent.",
+            "fields": [
+              {
+                "id": "fp_dropoff_travel_time",
+                "label": "Drop-off Travel Time",
+                "type": "select",
+                "tooltip": "Select your typical travel time from work/activity to your child care provider",
+                "ui": {
+                  "options": [
+                    "",
+                    "15 min",
+                    "30 min",
+                    "45 min",
+                    "1 hour",
+                    "More than 1 hour"
+                  ]
+                }
+              },
+              {
+                "id": "fp_dropoff_time_gt_1hr",
+                "label": "Drop-off Time (if > 1 hour)",
+                "type": "text",
+                "requiredCondition": {
+                  "field": "fp_dropoff_travel_time",
+                  "operator": "equals",
+                  "value": "More than 1 hour"
+                }
+              },
+              {
+                "id": "fp_pickup_travel_time",
+                "label": "Pick-up Travel Time",
+                "type": "select",
+                "tooltip": "Select your typical travel time from work/activity to your child care provider",
+                "ui": {
+                  "options": [
+                    "",
+                    "15 min",
+                    "30 min",
+                    "45 min",
+                    "1 hour",
+                    "More than 1 hour"
+                  ]
+                }
+              },
+              {
+                "id": "fp_pickup_time_gt_1hr",
+                "label": "Pick-up Time (if > 1 hour)",
+                "type": "text",
+                "requiredCondition": {
+                  "field": "fp_pickup_travel_time",
+                  "operator": "equals",
+                  "value": "More than 1 hour"
+                }
+              },
+              {
+                "id": "fp_public_transport_dropoff",
+                "label": "Public Transport for Drop-off?",
+                "type": "radio",
+                "tooltip": "Indicate if the applicant uses public transportation to travel to and from work/activity to provider.",
+                "ui": {
+                  "options": [
+                    "Yes",
+                    "No"
+                  ]
+                }
+              },
+              {
+                "id": "fp_public_transport_pickup",
+                "label": "Public Transport for Pick-up?",
+                "tooltip": "Indicate if the applicant uses public transportation to travel to and from work/activity to provider.",
+                "type": "radio",
+                "ui": {
+                  "options": [
+                    "Yes",
+                    "No"
+                  ]
+                }
+              }
+            ]
+          },
+          {
+            "id": "second_parent_travel_time",
+            "title": "Second Parent Travel Time",
+            "description": "Enter the travel times and method of transport for the second parent.",
+            "fields": [
+              {
+                "id": "sp_dropoff_travel_time",
+                "label": "Drop-off Travel Time",
+                "type": "select",
+                "ui": {
+                  "options": [
+                    "",
+                    "15 min",
+                    "30 min",
+                    "45 min",
+                    "1 hour",
+                    "More than 1 hour"
+                  ]
+                }
+              },
+              {
+                "id": "sp_pickup_travel_time",
+                "label": "Pick-up Travel Time",
+                "type": "select",
+                "ui": {
+                  "options": [
+                    "",
+                    "15 min",
+                    "30 min",
+                    "45 min",
+                    "1 hour",
+                    "More than 1 hour"
+                  ]
+                }
+              },
+              {
+                "id": "sp_dropoff_time_gt_1hr",
+                "label": "Drop-off Time (if > 1 hour)",
+                "type": "text",
+                "requiredCondition": {
+                  "field": "sp_dropoff_travel_time",
+                  "operator": "equals",
+                  "value": "More than 1 hour"
+                }
+              },
+              {
+                "id": "sp_pickup_time_gt_1hr",
+                "label": "Pick-up Time (if > 1 hour)",
+                "type": "text",
+                "requiredCondition": {
+                  "field": "sp_pickup_travel_time",
+                  "operator": "equals",
+                  "value": "More than 1 hour"
+                }
+              },
+              {
+                "id": "sp_public_transport_dropoff",
+                "label": "Public Transport for Drop-off?",
+                "type": "radio",
+                "ui": {
+                  "options": [
+                    "Yes",
+                    "No"
+                  ]
+                }
+              },
+              {
+                "id": "sp_public_transport_pickup",
+                "label": "Public Transport for Pick-up?",
+                "type": "radio",
+                "ui": {
+                  "options": [
+                    "Yes",
+                    "No"
+                  ]
+                }
+              }
+            ]
+          }
+        ]
+      },
+      {
+        "id": "income",
+        "title": "Income Information",
+        "sections": [
+          {
+            "id": "income_step_info",
+            "title": "Instructions",
+            "type": "info",
+            "ui": {
+              "markdown": true,
+              "collapsible": false,
+              "defaultCollapsed": false
+            },
+            "content": "Please include income/benefits information for yourself and, if applicable, your spouse, your child’s second caretaker, and/or any other adult with whom you share a child, if they live in your home.\\n\\nIndicate if you receive money from the following sources by selecting “Yes” or “No.” If you select “Yes,” you will be asked for additional information.\\n\\nIf the second caretaker in the household also receives the same income source, add a separate line for their income."
+          },
+          {
+            "id": "income_sources",
+            "title": "Income Sources",
+            "description": "Provide details about all income sources applicable to the applicant or household.",
+            "fields": [
+              {
+                "id": "income_sources",
+                "label": "List of Income Sources",
+                "type": "group",
+                "metadata": {
+                  "multiple": true,
+                  "tableColumns": [
+                    "name_ref",
+                    "how_often",
+                    "recipient",
+                    "monthly_amount"
+                  ]
+                },
+                "fields": [
+                  {
+                    "id": "name_ref",
+                    "label": "Income Source Type",
+                    "type": "select",
+                    "required": true,
+                    "ui": {
+                      "options": [
+                        "",
+                        "ApplicantWages",
+                        "SecondParentWages",
+                        "SelfEmployment",
+                        "ChildSupport",
+                        "Alimony",
+                        "Unemployment",
+                        "SocialSecurity",
+                        "Disability",
+                        "Rental",
+                        "Dividends",
+                        "Retirement",
+                        "CashAssistance",
+                        "Other"
+                      ]
+                    }
+                  },
+                  {
+                    "id": "other_source_text",
+                    "label": "Other Source (If applicable)",
+                    "type": "text",
+                    "visibilityCondition": {
+                      "field": "name_ref",
+                      "operator": "equals",
+                      "value": "Other"
+                    },
+                    "requiredCondition": {
+                      "condition": {
+                        "field": "name_ref",
+                        "operator": "equals",
+                        "value": "Other"
+                      }
+                    }
+                  },
+                  {
+                    "id": "is_source_applicable",
+                    "label": "Is this Source Applicable?",
+                    "type": "radio",
+                    "required": true,
+                    "ui": {
+                      "options": [
+                        "Yes",
+                        "No"
+                      ]
+                    }
+                  },
+                  {
+                    "id": "gross_amount",
+                    "label": "Gross Amount ($)",
+                    "type": "number",
+                    "required": true
+                  },
+                  {
+                    "id": "how_often",
+                    "label": "Frequency of Income",
+                    "type": "radio",
+                    "required": true,
+                    "ui": {
+                      "options": [
+                        "Weekly",
+                        "Bi-weekly",
+                        "Monthly",
+                        "Other"
+                      ]
+                    }
+                  },
+                  {
+                    "id": "recipient",
+                    "label": "Recipient of Income",
+                    "type": "text",
+                    "required": true
+                  },
+                  {
+                    "id": "monthly_amount",
+                    "label": "Monthly Amount ($)",
+                    "type": "number",
+                    "required": true
+                  }
+                ]
+              }
+            ]
+          },
+          {
+            "id": "total_income",
+            "title": "Total Household Income",
+            "description": "Sum of all monthly income across sources.",
+            "fields": [
+              {
+                "id": "total_income",
+                "label": "Total Monthly Income ($)",
+                "type": "number",
+                "required": true
+              }
+            ]
+          },
+          {
+            "id": "income_proof_section",
+            "title": "Income Proof",
+            "fields": [
+              {
+                "id": "income_proof",
+                "label": "Upload Income Proof",
+                "type": "file",
+                "requiredCondition": {
+                  "condition": {
+                    "field": "assistance_reason",
+                    "operator": "includes",
+                    "value": "Employment"
+                  }
+                },
+                "constraints": {
+                  "maxFileSizeMB": 5,
+                  "allowedTypes": [
+                    "application/pdf",
+                    "image/jpeg"
+                  ],
+                  "imageResolution": {
+                    "minWidth": 800,
+                    "minHeight": 600
+                  }
+                },
+                "metadata": {
+                  "proofCategory": "Income Verification",
+                  "examples": [
+                    "Pay Stub",
+                    "W-2"
+                  ],
+                  "multiple": true
+                }
+              }
+            ]
+          }
+        ]
+      },
+      {
+        "id": "provider",
+        "title": "Provider",
+        "sections": [
+          {
+            "id": "provider_step_info",
+            "title": "Instructions",
+            "type": "info",
+            "ui": {
+              "markdown": true,
+              "collapsible": false,
+              "defaultCollapsed": false
+            },
+            "content": "If you are found eligible for child care assistance, you can choose center-based or home-based care from a licensed, registered, or legally exempt provider. If you choose a provider that is not licensed or registered, the provider must be enrolled as a legally exempt provider.\\n\\nIf you know which child care providers you would like your child to attend, provide the names and addresses of your choice of providers. You can leave this section blank if you do not know (it will not impact your eligibility and you will have an opportunity to select a provider if determined eligible)."
+          },
+          {
+            "id": "provider_choices",
+            "title": "Provider Choices",
+            "description": "Specify details of the provider where you intend to enroll the child(ren).",
+            "fields": [
+              {
+                "id": "provider_choices",
+                "label": "List of Providers",
+                "type": "group",
+                "metadata": {
+                  "multiple": true,
+                  "tableColumns": [
+                    "provider_name",
+                    "program_number",
+                    "provider_zip_code"
+                  ]
+                },
+                "fields": [
+                  {
+                    "id": "provider_name",
+                    "label": "Provider Name",
+                    "type": "text",
+                    "required": true
+                  },
+                  {
+                    "id": "program_number",
+                    "label": "Program Number (If Applicable)",
+                    "type": "text",
+                    "required": false
+                  },
+                  {
+                    "id": "provider_street",
+                    "label": "Street Address",
+                    "type": "text",
+                    "required": true
+                  },
+                  {
+                    "id": "provider_city",
+                    "label": "City",
+                    "type": "text",
+                    "required": true
+                  },
+                  {
+                    "id": "provider_state",
+                    "label": "State",
+                    "type": "text",
+                    "required": true
+                  },
+                  {
+                    "id": "provider_zip_code",
+                    "label": "Zip Code",
+                    "type": "text",
+                    "required": true
+                  }
+                ]
+              }
+            ]
+          }
+        ]
+      },
+      {
+        "id": "document_upload_step",
+        "title": "Document Upload",
+        "description": "The Application for Child Care Assistance (CFWB-012) must include supporting documentation. Check to ensure that documentation is provided for each requirement of subsidy eligibility.",
+        "sections": [
+          {
+            "id": "nyc_residency",
+            "title": "New York City Residency",
+            "description": "These documents confirm that you live in New York City. Please upload one of the following documents.",
+            "fields": [
+              {
+                "id": "nyc_residency_type",
+                "label": "Select one of the following:",
+                "type": "radio",
+                "required": true,
+                "ui": {
+                  "options": [
+                    "IDNYC",
+                    "Utility Bill",
+                    "Section 8 Award Letter",
+                    "Driver’s License",
+                    "Rent Receipt",
+                    "NYCHA Certificate",
+                    "CFWB-067 Residency Attestation",
+                    "CFWB-027 Housing Attestation with address listed",
+                    "Shelter Residency Letter with address listed",
+                    "Other"
+                  ]
+                }
+              },
+              {
+                "id": "nyc_residency_file",
+                "label": "Upload Residency Proof Document",
+                "description": "To add a document to your application, you can upload an image or scanned file from your phone or device. Accepted formats include .pdf, .gif, .jpeg, .jpg and .png up to 25 MB. Learn how to upload your files with this Tutorial Video.",
+                "type": "file",
+                "required": true, 
+                "constraints": {
+                  "maxFileSizeMB": 25,
+                  "allowedTypes": [
+                    "application/pdf",
+                    "image/jpeg",
+                    "image/jpg",
+                    "image/png",
+                    "image/gif"
+                  ]
+                },
+                "metadata": {
+                  "proofCategory": "NYC Residency",
+                  "multiple": false
+                }
+              }
+            ]
+          },
+          {
+            "id": "citizenship_status",
+            "title": "Citizenship or Immigration Status",
+            "description": "These documents confirm the citizenship/immigration status of the children in your family for whom you’re applying for child care assistance. Please upload one of the following documents for ONLY each child needing care.",
+            "fields": [
+              {
+                "id": "citizenship_doc_type",
+                "label": "Select one of the following:",
+                "type": "radio",
+                "required": true,
+                "ui": {
+                  "options": [
+                    "US Birth Certificate",
+                    "Alien Registration Card including Permanent Resident or Green Card",
+                    "Passport",
+                    "FS-240 (Report of Birth Abroad of a U.S. Citizen)",
+                    "Naturalization Certificate",
+                    "Other"
+                  ]
+                }
+              },
+              {
+                "id": "citizenship_doc_file",
+                "label": "Upload Citizenship/Immigration Document",
+                "description": "To add a document to your application, you can upload an image or scanned file from your phone or device. Accepted formats include .pdf, .gif, .jpeg, .jpg and .png up to 25 MB. Learn how to upload your files with this Tutorial Video.",
+                "type": "file",
+                "required": true,
+                "constraints": {
+                  "maxFileSizeMB": 25,
+                  "allowedTypes": [
+                    "application/pdf",
+                    "image/jpeg",
+                    "image/jpg",
+                    "image/png",
+                    "image/gif"
+                  ]
+                },
+                "metadata": {
+                  "proofCategory": "Citizenship/Immigration Status",
+                  "multiple": false
+                }
+              }
+            ]
+          },
+          {
+            "id": "child_relationship",
+            "title": "Child’s Relationship to Parent/Applicant",
+            "description": "These documents confirm your relationship to the children in your household under age 18. Please upload one of the following documents for every child in the household under age 18, regardless of whether child care is needed for them or not. If you are a legal guardian with financial responsibility, you must upload a Court order OR a letter of guardianship.",
+            "fields": [
+              {
+                "id": "relationship_doc_type",
+                "label": "Select one of the following:",
+                "type": "radio",
+                "required": true,
+                "ui": {
+                  "options": [
+                    "Birth Certificate",
+                    "Adoption record",
+                    "Baptismal record",
+                    "Passport with parent's signature",
+                    "Court order for legal guardian with financial responsibility",
+                    "Letter of Guardianship",
+                    "Other - CFWB-058 Caretaker Attestation"
+                  ]
+                }
+              },
+              {
+                "id": "relationship_doc_file",
+                "label": "Upload Relationship Document",
+                "description": "To add a document to your application, you can upload an image or scanned file from your phone or device. Accepted formats include .pdf, .gif, .jpeg, .jpg and .png up to 25 MB. Learn how to upload your files with this Tutorial Video.",
+                "type": "file",
+                "required": true,
+                "constraints": {
+                  "maxFileSizeMB": 25,
+                  "allowedTypes": [
+                    "application/pdf",
+                    "image/jpeg",
+                    "image/jpg",
+                    "image/png",
+                    "image/gif"
+                  ]
+                },
+                "metadata": {
+                  "proofCategory": "Child Relationship",
+                  "multiple": false
+                }
+              }
+            ]
+          },
+          {
+            "id": "age_proof",
+            "title": "Age",
+            "description": "These documents confirm the age of the children in your household. Please upload one of the following documents for every child in the household under age 18, regardless of whether child care is needed for them:",
+            "fields": [
+              {
+                "id": "age_doc_type",
+                "label": "Select one of the following:",
+                "type": "radio",
+                "required": true,
+                "ui": {
+                  "options": [
+                    "Birth Certificate",
+                    "Adoption record",
+                    "Baptismal record",
+                    "Alien Registration Card",
+                    "Passport",
+                    "Official hospital documentation of the child’s birth"
+                  ]
+                }
+              },
+              {
+                "id": "age_doc_file",
+                "label": "Upload Age Proof Document",
+                "description": "To add a document to your application, you can upload an image or scanned file from your phone or device. Accepted formats include .pdf, .gif, .jpeg, .jpg and .png up to 25 MB. Learn how to upload your files with this Tutorial Video.",
+                "type": "file",
+                "required": true,
+                "constraints": {
+                  "maxFileSizeMB": 25,
+                  "allowedTypes": [
+                    "application/pdf",
+                    "image/jpeg",
+                    "image/jpg",
+                    "image/png",
+                    "image/gif"
+                  ]
+                },
+                "metadata": {
+                  "proofCategory": "Child Age",
+                  "multiple": false
+                }
+              }
+            ]
+          }
+        ]
+      },
+      {
+        "id": "review",
+        "title": "Review & Submit",
+        "type": "review",
+        "sections": []
+      }
+    ]
+  }
+}

--- a/test-form/public/data/childcare_form.fr.json
+++ b/test-form/public/data/childcare_form.fr.json
@@ -1,0 +1,2287 @@
+{
+  "form": {
+    "title": "Childcare Voucher Application",
+    "description": "Step-by-step form for applying for Childcare Assistance",
+    "layout": {
+      "stepperPosition": "left"
+    },
+    "steps": [
+      {
+        "id": "consent_step",
+        "title": "Consent",
+        "sections": [
+          {
+            "id": "mycity_consent_info",
+            "title": "ModelCity Consent",
+            "type": "info",
+            "ui": {
+              "markdown": true,
+              "collapsible": false,
+              "defaultCollapsed": false
+            },
+            "content": "In connection with this application for child care services, **ModelCity**:\\n\\n- Collects, processes, stores, and shares the information you submit to screen you when you apply for child care services;\\n- Receives, processes, and stores the information the City already knows about you to screen you when you apply for child care services;\\n- Uses your information to improve ModelCity; and\\n- Communicates with you about your ModelCity account.\\n\\n---\\n\\nIf you consent, the following information may be shared between child care services agencies:\\n\\n- Demographic and background information, including address, phone number, household composition.\\n- Housing information, including benefits awarded/received, current housing/shelter status.\\n- Benefits information, including public assistance awarded/received, child care program participation.\\n\\n---\\n\\nIf you choose not to consent, **you will not be denied** any benefits or services you are receiving or any benefits for which you are eligible.\\n\\nThe [ModelCity Privacy Policy](https://www.nyc.gov/privacy) details how ModelCity handles the information you submit through ModelCity."
+          }
+        ]
+      },
+      {
+        "id": "instructions_step",
+        "title": "Instructions",
+        "sections": [
+          {
+            "id": "application_instructions",
+            "title": "Application Instructions",
+            "type": "info",
+            "ui": {
+              "markdown": true,
+              "collapsible": false,
+              "defaultCollapsed": false
+            },
+            "content": "**Let’s get started on your application!**\\n\\nTo complete this application, you will be asked for information about:\\n\\n- Yourself\\n- Your household\\n- Your employment or reason for care\\n- Your income\\n\\nAll required fields are marked and must be filled out to move forward with the application. The pages of the application are shown on the right-hand side of the screen and will be highlighted as you move through the application.\\n\\nYour application will be saved automatically as you progress to each page.  \\nIf you need to pause at any time, click the **“Save for later”** button at the bottom of each page to save your application.  \\nYou can log back in to resume your application.\\n\\nWhen you’re ready to begin, click **“Next”** below.\\n\\n---\\n\\n⚠️ **Important:**  \\nTo keep your information current and safe, applications in draft status that you have not edited for **30 days** will be deleted.  \\nIf your draft application is deleted, you can still create and submit a new application when you're ready to apply."
+          },
+          {
+            "id": "new_york_city_residency",
+            "title": "New York City Residency",
+            "type": "info",
+            "ui": {
+              "markdown": true,
+              "collapsible": true,
+              "defaultCollapsed": true
+            },
+            "content": "You will need to upload **ONE** of the following documents to confirm your NYC residency:\\n\\n- IDNYC\\n- Driver’s License\\n- Utility Bill (dated within the last 60 days, with your address)\\n- Current lease, rent, or mortgage statement (dated within the last 60 days, with your address)\\n- Section 8 Award Letter\\n- NYCHA Certificate\\n- CFWB-027 Housing Attestation with address listed\\n- Shelter Residency Letter with address listed\\n\\nIf you do not have any of those documents, you must submit a **CFWB-067 Residency Attestation**."
+          },
+          {
+            "id": "children_documents",
+            "title": "Children Documents",
+            "type": "info",
+            "ui": {
+              "markdown": true,
+              "collapsible": true,
+              "defaultCollapsed": true
+            },
+            "content": "### Citizenship or Immigration Status\\nThese documents confirm the citizenship or immigration status of the children in your family for whom you’re applying for child care assistance. Please upload one of the following documents for each child needing care. *Do not upload these documents for children who do not need care.*\\n\\n- Birth Certificate from US state or territory\\n- Alien Registration Card including Permanent Resident or Green Card\\n- Passport\\n- FS-240 (Consular Report of Birth Abroad)\\n- Naturalization Certificate\\n- Other documentation that proves child’s immigration status\\n\\n### Child's Relationship to Applicant\\nThese documents confirm your relationship to the children in your household under age 18. Please upload one of the following documents for every child in the household under age 18, regardless of whether they need child care.\\n\\n- Birth certificate\\n- Adoption record\\n- Baptismal record\\n- Passport with parent's signature\\n- Court order for legal guardian with financial responsibility\\n- Letter of guardianship\\n- Other - CFWB-058 Caretaker Attestation\\n\\nIf you are not the child's parent or stepparent, you must submit a **CFWB-058 Caretaker Attestation Form**.\\n\\n### Age of Children\\nYou will need to upload **ONE** of the following documents for every child in the household under age 18, regardless of whether child care is needed for them:\\n\\n- Birth certificate\\n- Adoption record\\n- Baptismal record\\n- Alien Registration Card\\n- Passport\\n- Official hospital documentation of the child’s birth"
+          },
+          {
+            "id": "employment_income",
+            "title": "Employment & Income",
+            "type": "info",
+            "ui": {
+              "markdown": true,
+              "collapsible": true,
+              "defaultCollapsed": true
+            },
+            "content": "### Income\\nThese documents confirm your family’s income.\\n\\n---\\n\\n### If You Are Employed\\nIf you are employed and receive paystubs, you must submit them to confirm your income. The number of paystubs you must submit varies by how often you get paid and whether your payment amount is the same or different each time you are paid – see the table below for details. Submit the most recent paystub you have received, followed by others in consecutive order.\\n\\n**Income Information**\\n\\n| How Often Do You Get Paid? | Always the SAME Amount | DIFFERENT Amounts Each Time |\\n|----------------------------|-------------------------|------------------------------|\\n| Weekly (Every Week) | 4 most recent, consecutive pay stubs | 12 most recent, consecutive pay stubs |\\n| Bi-Weekly (Every Two Weeks) | 2 most recent, consecutive pay stubs | 6 most recent, consecutive pay stubs |\\n| Semi-Monthly (Two Times Per Month) | 2 most recent, consecutive pay stubs | 6 most recent, consecutive pay stubs |\\n| Monthly (One Time Per Month) | 3 most recent, consecutive pay stubs | 3 most recent, consecutive pay stubs |\\n\\nIf you do not have any paystubs, you must submit a **CFWB-015 Referral to Employer for Employee Income Information Form**.\\n\\n---\\n\\n### If You Are Self-Employed\\nIf you have been self-employed for **one year or more**, you must submit a current, complete and signed income tax package (e.g., 1040, 1065, Schedule C, SE for partnership, K-1, etc.).\\n\\nIf you have been self-employed for **less than one year**, you must submit a **CFWB-031 Self-Employment Income Information Attestation Form**.\\n\\n---\\n\\n### Other Income\\nIf you receive other types of income outside or instead of employment income, you must submit your most recent check, pay stub, or current award letter that indicates the amount you receive. If your other income fluctuates, **3 months of documentation is required**.\\n\\nThis includes, but is not limited to:\\n- Income from SSI, SSD\\n- Unemployment benefits\\n- Rental income\\n- Pensions\\n- Annuities\\n- Worker’s compensation\\n- Alimony\\n- Child support"
+          },
+          {
+            "id": "reason_for_care",
+            "title": "Reason for Care",
+            "type": "info",
+            "ui": {
+              "markdown": true,
+              "collapsible": true,
+              "defaultCollapsed": true
+            },
+            "content": "### Reason for Care\\nThese documents confirm your reason for care. Every applicant must have a qualified reason for care; in a two-parent household, parents or caretakers can have the same or different reasons for care. Only the documents related to your stated reasons for care need to be uploaded, and documentation must be uploaded for all parent or caretakers in the household.\\n\\n---\\n\\n### Working 10+ Hours Per Week\\nYour employment or self-employment income documents will cover this reason for care. You do not need to submit additional documentation.\\n\\n---\\n\\n### Participating in an Educational or Vocational Training Program\\nYou will need to upload **ONE** of the following documents to confirm your participation in vocational school, two-year college, or four-year college.\\n\\n- CFWB-005 Vocational, Education and Training Verification Form\\n- A letter from the educational or vocational training program on their official letterhead; this letter must contain all the information required in the CFWB-005 Vocational, Education and Training Verification Form.\\n\\n---\\n\\n### Looking for Work\\nYou will need to upload **ONE** of the following documents to confirm that you are looking for work.\\n\\n- CFWB-026 Work Search Record Form\\n- Approved work search plan from the NYS Dept. of Labor\\n- Proof of receipt of unemployment insurance\\n\\n---\\n\\n### Experiencing Homelessness\\nYou will need to upload **ONE** of the following documents to confirm that you are experiencing homelessness. This includes families who may be living in shelter or sharing the housing of others due to loss of housing, economic hardship, or similar reason.\\n\\n- Shelter Residency Letter (If living in Shelter, including Humanitarian Emergency Relief Centers)\\n- CFWB-027 Housing Attestation (If living doubled-up, in a place not meant for human habitation, in a hotel/motel, or in another living situation)\\n\\n---\\n\\n### Attending Services for Domestic Violence\\nYou will need to upload a referral for services from a domestic violence service provider to confirm that you are attending services for domestic violence.\\n\\n---\\n\\n### Attending Services for Substance Abuse Treatment\\nYou will need to upload a referral for a substance abuse treatment service provider to confirm that you are attending services for substance abuse treatment."
+          },
+          {
+            "id": "additional_details",
+            "title": "Additional Details",
+            "type": "info",
+            "ui": {
+              "markdown": true,
+              "collapsible": true,
+              "defaultCollapsed": true
+            },
+            "content": "### Application Scope\\nThis application is used to apply **only** for **Category 2 or 3 child care assistance** (for families not in receipt of cash assistance). To apply for **Cash Assistance** or other benefits, including **Category 1 Child Care Assistance** (for families in receipt of cash assistance), you must use the **New York State Application for Certain Benefits and Services (LDSS-2921)**.\\n\\n---\\n\\n### Exempt Applicants\\nThe following applicants may be eligible for child care assistance **without regard to income** and do not need to complete this application:\\n\\n- Foster parents who need child care assistance to allow them to work and are only applying for assistance for the foster children;\\n- Families in receipt of protective or preventive services.\\n\\n---\\n\\n### Application Completion\\nAll sections of this form must be filled out to be considered complete **unless the section is identified as optional**. If you do not complete all required sections of this form, you may not be considered for Child Care Assistance.\\n\\n---\\n\\n### Rights and Responsibilities\\nYou may obtain information about your rights and responsibilities [here](https://otda.ny.gov/programs/applications/). If you do not have access to the internet, you can call the **Administration for Children’s Services at 212-835-7610** to request that physical copies of the booklets which highlight your rights and responsibilities be mailed to you, including:\\n\\n- **LDSS-4148A**: What You Should Know About Your Rights and Responsibilities\\n- **LDSS-4148B**: What You Should Know About Social Services Programs\\n- **LDSS-4148C**: What You Should Know If You Have an Emergency"
+          }
+        ]
+      },
+      {
+        "id": "applicant",
+        "title": "Applicant",
+        "sections": [
+          {
+            "id": "personal_info",
+            "title": "Personal Information",
+            "fields": [
+              {
+                "id": "first_name",
+                "label": "First Name",
+                "type": "text",
+                "required": true
+              },
+              {
+                "id": "last_name",
+                "label": "Last Name",
+                "type": "text",
+                "required": true
+              },
+              {
+                "id": "mi",
+                "label": "Middle Initial",
+                "type": "text",
+                "required": false
+              },
+              {
+                "id": "date_of_birth",
+                "label": "Date of Birth",
+                "type": "date",
+                "required": true,
+                "tooltip": "To edit Date of Birth click on NYC ModelCity in the top-left corner then click on Account Settings."
+              },
+              {
+                "id": "sex",
+                "label": "Sex",
+                "type": "radio",
+                "required": true,
+                "ui": {
+                  "options": [
+                    "Male",
+                    "Female"
+                  ]
+                }
+              },
+              {
+                "id": "marital_status",
+                "label": "Marital Status",
+                "type": "select",
+                "required": true,
+                "tooltip": "Indicate your marital status (single, married, divorced, separated or widowed).",
+                "ui": {
+                  "options": [
+                    "",
+                    "Single",
+                    "Married",
+                    "Divorced",
+                    "Widowed",
+                    "Separated"
+                  ]
+                }
+              }
+            ]
+          },
+          {
+            "id": "contact_info",
+            "title": "Contact Information",
+            "fields": [
+              {
+                "id": "telephone_home",
+                "label": "Home Phone",
+                "type": "tel",
+                "required": false,
+                "constraints": {
+                  "pattern": "^\\\\(?[0-9]{3}\\\\)?[-. ]?[0-9]{3}[-. ]?[0-9]{4}$"
+                },
+                "ui": {
+                  "placeholder": "(123) 456-7890"
+                }
+              },
+              {
+                "id": "telephone_work",
+                "label": "Work Phone",
+                "type": "tel",
+                "required": false,
+                "constraints": {
+                  "pattern": "^\\\\(?[0-9]{3}\\\\)?[-. ]?[0-9]{3}[-. ]?[0-9]{4}$"
+                },
+                "ui": {
+                  "placeholder": "(123) 456-7890"
+                }
+              },
+              {
+                "id": "telephone_mobile_or_other",
+                "label": "Mobile or Other Phone",
+                "type": "tel",
+                "required": false,
+                "tooltip": "To edit Telephone (Cell or Other) click on NYC ModelCity in the top-left corner then click on Account Settings and then click on Contact.",
+                "constraints": {
+                  "pattern": "^\\\\(?[0-9]{3}\\\\)?[-. ]?[0-9]{3}[-. ]?[0-9]{4}$"
+                },
+                "ui": {
+                  "placeholder": "(123) 456-7890"
+                }
+              },
+              {
+                "id": "email",
+                "label": "Email",
+                "type": "email",
+                "required": true,
+                "tooltip": "To edit email, go to NYC ID Profile tab by clicking your name at the top right corner"
+              }
+            ]
+          },
+          {
+            "id": "address_info",
+            "title": "Address",
+            "tooltip": "To edit home address click on NYC ModelCity in the top-left corner then click on Account Settings.",
+            "ui": {
+              "autocomplete": "street",
+              "placeholder": "Start typing your street address",
+              "overrideComponent": "AddressAutocomplete"
+            },
+            "metadata": {
+              "integration": {
+                "provider": "Google",
+                "feature": "AddressAutocomplete"
+              },
+              "autofillTargets": [
+                {
+                  "fieldId": "city",
+                  "source": "locality",
+                  "fallbackSources": [
+                    "postal_town",
+                    "sublocality_level_1",
+                    "administrative_area_level_2"
+                  ]
+                },
+                {
+                  "fieldId": "borough",
+                  "source": "sublocality_level_1",
+                  "fallbackSources": [
+                    "administrative_area_level_2"
+                  ],
+                  "mapping": "boroughMap"
+                },
+                { "fieldId": "state", "source": "administrative_area_level_1" },
+                { "fieldId": "zip_code", "source": "postal_code" },
+                { "fieldId": "latitude", "source": "location.latitude" },
+                { "fieldId": "longitude", "source": "location.longitude" }
+              ]
+            },
+            "fields": [
+              {
+                "id": "street",
+                "label": "Street Address",
+                "type": "text",
+                "required": true,
+                "tooltip": "To edit home address click on NYC ModelCity in the top-left corner then click on Account Settings."
+              },
+              {
+                "id": "apt",
+                "label": "Apt #",
+                "type": "text",
+                "required": false
+              },
+              {
+                "id": "city",
+                "label": "City",
+                "type": "text",
+                "required": true
+              },
+              {
+                "id": "borough",
+                "label": "Borough",
+                "type": "select",
+                "required": true,
+                "ui": {
+                  "options": [
+                    "",
+                    "Bronx",
+                    "Brooklyn",
+                    "Manhattan",
+                    "Queens",
+                    "Staten Island"
+                  ]
+                }
+              },
+              {
+                "id": "state",
+                "label": "State",
+                "type": "text",
+                "required": true
+              },
+              {
+                "id": "zip_code",
+                "label": "Zip Code",
+                "type": "text",
+                "required": true
+              },
+              {
+                "id": "latitude",
+                "label": "Latitude",
+                "type": "number",
+                "required": false
+              },
+              {
+                "id": "longitude",
+                "label": "Longitude",
+                "type": "number",
+                "required": false
+              },
+              {
+                "id": "is_temporary_address",
+                "label": "Is Temporary Address",
+                "type": "radio",
+                "required": true,
+                "tooltip": "Check YES if you are currently living in a homeless shelter, doubled-up with another family, in a hotel/motel, in a car/ bus/ train, in a park/campsite, or other temporary accomodation.",
+                "ui": {
+                  "options": [
+                    "Yes",
+                    "No"
+                  ]
+                }
+              },
+              {
+                "id": "currently_living_in",
+                "label": "Currently Living In",
+                "type": "select",
+                "required": false,
+                "requiredCondition": {
+                  "field": "is_temporary_address",
+                  "operator": "equals",
+                  "value": "Yes"
+                },
+                "ui": {
+                  "options": [
+                    "",
+                    "Homeless Shelter",
+                    "Doubled-up with another Family",
+                    "Hotel/Motel",
+                    "Car, Bus, Train",
+                    "Park",
+                    "Campsite",
+                    "Other"
+                  ]
+                }
+              }
+            ]
+          },
+          {
+            "id": "demographics",
+            "title": "Demographics",
+            "fields": [
+              {
+                "id": "ethnicity",
+                "label": "Ethnicity",
+                "type": "select",
+                "required": false,
+                "ui": {
+                  "options": [
+                    "",
+                    "Hispanic",
+                    "Latino",
+                    "No",
+                    "Prefer not to answer"
+                  ]
+                }
+              },
+              {
+                "id": "race",
+                "label": "Race",
+                "type": "checkbox",
+                "required": false,
+                "tooltip": "You may choose multiple race categories. Providing race information is voluntary and will not affect your eligibility for Child Care Assistance or the amount of assistance that you will be given by this agency.",
+                "ui": {
+                  "options": [
+                    {
+                      "value": "AI",
+                      "label": "American Indian or Alaska Native"
+                    },
+                    {
+                      "value": "AS",
+                      "label": "Asian"
+                    },
+                    {
+                      "value": "BL",
+                      "label": "Black or African American"
+                    },
+                    {
+                      "value": "HP",
+                      "label": "Native Hawaiian or Pacific Islander"
+                    },
+                    {
+                      "value": "WH",
+                      "label": "White"
+                    }
+                  ]
+                },
+                "metadata": {
+                  "multiple": true
+                }
+              },
+              {
+                "id": "ssn",
+                "label": "Social Security Number",
+                "type": "text",
+                "tooltip": "To edit social security number click on NYC ModelCity in the top-left corner then click on Account Settings.",
+                "required": false,
+                "constraints": {
+                  "pattern": "^\\\\d{3}-\\\\d{2}-\\\\d{4}$"
+                },
+                "ui": {
+                  "placeholder": "123-45-6789"
+                }
+              }
+            ]
+          },
+          {
+            "id": "language_info",
+            "title": "Language Preferences",
+            "fields": [
+              {
+                "id": "primary_language",
+                "label": "Primary Language",
+                "type": "radio",
+                "required": true,
+                "tooltip": "Select the language that is spoken most often in your household. If “other”, provide the name of the language.",
+                "ui": {
+                  "options": [
+                    "English",
+                    "Spanish",
+                    "Other"
+                  ]
+                }
+              },
+              {
+                "id": "preferred_language",
+                "label": "Preferred Language",
+                "type": "radio",
+                "required": true,
+                "tooltip": "Select the language you prefer to communicate in. If “other”, provide the name of the language.",
+                "ui": {
+                  "options": [
+                    "English",
+                    "Spanish",
+                    "Other"
+                  ]
+                }
+              },
+              {
+                "id": "other_primary_language",
+                "label": "Other Primary Language",
+                "type": "text",
+                "required": false,
+                "requiredCondition": {
+                  "field": "primary_language",
+                  "operator": "equals",
+                  "value": "Other"
+                }
+              },
+              {
+                "id": "other_preferred_language",
+                "label": "Other Preferred Language",
+                "type": "text",
+                "required": false,
+                "requiredCondition": {
+                  "field": "preferred_language",
+                  "operator": "equals",
+                  "value": "Other"
+                }
+              }
+            ]
+          },
+          {
+            "id": "cash_assistance",
+            "title": "Cash Assistance",
+            "fields": [
+              {
+                "id": "has_cash_assistance",
+                "label": "Do you receive Cash Assistance?",
+                "type": "radio",
+                "required": false,
+                "ui": {
+                  "options": [
+                    "Yes",
+                    "No"
+                  ]
+                }
+              },
+              {
+                "id": "ca_number",
+                "label": "Cash Assistance Number",
+                "type": "text",
+                "required": false,
+                "requiredCondition": {
+                  "condition": {
+                    "field": "has_cash_assistance",
+                    "operator": "equals",
+                    "value": "Yes"
+                  }
+                }
+              }
+            ]
+          }
+        ]
+      },
+      {
+        "id": "children_needing_care",
+        "title": "Children Needing Care",
+        "sections": [
+          {
+            "id": "child_details",
+            "title": "Child Details",
+            "required": true,
+            "fields": [
+              {
+                "id": "children",
+                "label": "Children Needing Care",
+                "type": "group",
+                "metadata": {
+                  "multiple": true,
+                  "tableColumns": [
+                  "first_name",
+                  "last_name",
+                  "date_of_birth",
+                  "relationship_to_applicant"
+                  ]
+                },
+                "fields": [
+                  {
+                    "id": "first_name",
+                    "label": "First Name",
+                    "type": "text",
+                    "required": true,
+                    "tooltip": "Provide the first name, last name, and middle initial of each child you are applying for child care assistance for."
+                  },
+                  {
+                    "id": "last_name",
+                    "label": "Last Name",
+                    "type": "text",
+                    "required": true
+                  },
+                  {
+                    "id": "mi",
+                    "label": "Middle Initial",
+                    "type": "text",
+                    "required": false
+                  },
+                  {
+                    "id": "relationship_to_applicant",
+                    "label": "Relationship to Applicant",
+                    "type": "select",
+                    "required": true,
+                    "ui": {
+                      "options": [
+                        "",
+                        "Child",
+                        "Grandchild",
+                        "Foster Child",
+                        "Other"
+                      ]
+                    }
+                  },
+                  {
+                    "id": "date_of_birth",
+                    "label": "Date of Birth",
+                    "type": "date",
+                    "required": true,
+                    "tooltip": "Provide the date of birth."
+                  },
+                  {
+                    "id": "sex",
+                    "label": "Sex",
+                    "type": "radio",
+                    "required": true,
+                    "tooltip": "Select to indicate the sex.",
+                    "ui": {
+                      "options": [
+                        "Male",
+                        "Female"
+                      ]
+                    }
+                  },
+                  {
+                    "id": "ethnicity",
+                    "label": "Ethnicity Hispanic or Latino",
+                    "type": "select",
+                    "required": false,
+                    "tooltip": "Check “YES” or “NO” to indicate if each child in need of child care is Hispanic or Latino or not. Providing ethnicity information is voluntary and will not affect your eligibility for child care assistance or the amount of assistance that you will be given by this agency.",
+                    "ui": {
+                      "options": [
+                        "",
+                        "Yes",
+                        "No",
+                        "Prefer not to answer"
+                      ]
+                    }
+                  },
+                  {
+                    "id": "race",
+                    "label": "Race",
+                    "type": "checkbox",
+                    "required": false,
+                    "tooltip": "You may choose multiple race categories for a single child. Providing race information is voluntary and will not affect your eligibility for Child Care Assistance or the amount of assistance that you will be given by this agency.",
+                    "ui": {
+                      "options": [
+                        {
+                          "value": "AI",
+                          "label": "American Indian or Alaska Native"
+                        },
+                        {
+                          "value": "AS",
+                          "label": "Asian"
+                        },
+                        {
+                          "value": "BL",
+                          "label": "Black or African American"
+                        },
+                        {
+                          "value": "HP",
+                          "label": "Native Hawaiian or Pacific Islander"
+                        },
+                        {
+                          "value": "WH",
+                          "label": "White"
+                        }
+                      ]
+                    },
+                    "metadata": {
+                      "multiple": true
+                    }
+                  },
+                  {
+                    "id": "ssn",
+                    "label": "Social Security Number",
+                    "type": "text",
+                    "required": false,
+                    "tooltip": "Provide each child’s Social Security Number (SSN). You are not required to provide SSNs. They may be used by federal, state, and local agencies to prevent duplication of services and fraud, and for Federal Reporting.",
+                    "constraints": {
+                      "pattern": "^\\\\d{3}-\\\\d{2}-\\\\d{4}$"
+                    },
+                    "ui": {
+                      "placeholder": "123-45-6789"
+                    }
+                  },
+                  {
+                    "id": "do_both_parents_reside_in_home",
+                    "label": "Do both parents reside in the home?",
+                    "type": "radio",
+                    "required": true,
+                    "tooltip": "Check “YES” or “NO” to indicate whether both of the child’s parents live in the home.",
+                    "ui": {
+                      "options": [
+                        "Yes",
+                        "No"
+                      ]
+                    }
+                  },
+                  {
+                    "id": "has_disability",
+                    "label": "Does the child have a disability?",
+                    "type": "radio",
+                    "required": true,
+                    "tooltip": "Check “YES” or “NO” to indicate whether the child needing child care has a disability.",
+                    "ui": {
+                      "options": [
+                        "Yes",
+                        "No"
+                      ]
+                    }
+                  },
+                  {
+                    "id": "is_immigration_status_satisfactory",
+                    "label": "Is child U.S. Citizen, U.S. National, or person with satisfactory immigration status?",
+                    "type": "radio",
+                    "required": true,
+                    "tooltip": "You will only be asked about the immigration status of the children in need of care. Other members of the family will not need to state or prove their immigration status. Your child will be eligible for care if they are a U.S. citizen, a legal permanent resident (green card holder), a refugee, or an asylee; have a T-visa; or hold another qualified immigration status. Please select “Yes” if your child holds one of these statuses.",
+                    "ui": {
+                      "options": [
+                        "Yes",
+                        "No"
+                      ]
+                    }
+                  }
+                ]
+              }
+            ]
+          }
+        ]
+      },
+      {
+        "id": "family_members",
+        "title": "Family Members",
+        "sections": [
+          {
+            "id": "household_members_info",
+            "title": "Household Members Information",
+            "type": "info",
+            "ui": {
+              "markdown": true,
+              "collapsible": false,
+              "defaultCollapsed": false
+            },
+            "content": "**List the household members who do _not_ need child care.**\\n\\nIf applicable, list:\\n\\n- Your **spouse**, your child’s **second parent**, **caretaker**, or **step-parent**\\n- Any other **adult with whom you share a child**, if they live in your home\\n\\nThen, if applicable, list:\\n\\n- Any **siblings under the age of 18** who live in your home\\n\\n> **Only list other household members** — such as **aunts, uncles, cousins, grandparents, or friends** — _if they have financial responsibility_ for the child.\\n\\nA household member with financial responsibility, other than a parent or step-parent, is one who has a **letter or order of guardianship**.\\n\\n**Otherwise, do not include them.**"
+          },
+          {
+            "id": "family_member_details",
+            "title": "Household Member Details",
+            "description": "Include household members who do not need child care assistance (e.g., spouse, partner, other children).",
+            "fields": [
+              {
+                "id": "familymember",
+                "label": "Family Members",
+                "type": "group",
+                "requiredCondition": {
+                  "repeatingGroup": "children",
+                  "operator": "ANY",
+                  "condition": { "field": "do_both_parents_reside_in_home", "operator": "equals", "value": "Yes" }
+                },  
+                "metadata": {
+                  "multiple": true,
+                  "tableColumns": [
+                    "first_name",
+                    "last_name",
+                    "relationship_to_applicant",
+                    "date_of_birth"
+                  ]
+                },
+                "fields": [
+                  {
+                    "id": "first_name",
+                    "label": "First Name",
+                    "type": "text",
+                    "required": true,
+                    "tooltip": "Provide last and first name, and middle initial if applicable."
+                  },
+                  {
+                    "id": "last_name",
+                    "label": "Last Name",
+                    "type": "text",
+                    "required": true
+                  },
+                  {
+                    "id": "mi",
+                    "label": "Middle Initial",
+                    "type": "text",
+                    "required": false
+                  },
+                  {
+                    "id": "relationship_to_applicant",
+                    "label": "Relationship to Applicant",
+                    "type": "select",
+                    "required": true,
+                    "tooltip": "Provide each person’s relationship to you (e.g. spouse, partner, child, foster parent, other).",
+                    "ui": {
+                      "options": [
+                        "",
+                        "Spouse",
+                        "Partner",
+                        "Foster Parent",
+                        "Child",
+                        "Other"
+                      ]
+                    }
+                  },
+                  {
+                    "id": "date_of_birth",
+                    "label": "Date of Birth",
+                    "type": "date",
+                    "required": true,
+                    "tooltip": "Provide the family member's date of birth."
+                  },
+                  {
+                    "id": "sex",
+                    "label": "Sex",
+                    "type": "radio",
+                    "required": true,
+                    "tooltip": "Indicate the sex for each family member listed.",
+                    "ui": {
+                      "options": [
+                        "Male",
+                        "Female"
+                      ]
+                    }
+                  },
+                  {
+                    "id": "ethnicity",
+                    "label": "Ethnicity Hispanic or Latino",
+                    "type": "select",
+                    "required": false,
+                    "tooltip": "Check “YES” or “NO” to indicate if each member in the household is Hispanic or Latino or not. Providing ethnicity information is voluntary and will not affect your eligibility for Child Care Assistance or the amount of assistance that you will be given by this agency.",
+                    "ui": {
+                      "options": [
+                        "",
+                        "Yes",
+                        "No",
+                        "Prefer not to answer"
+                      ]
+                    }
+                  },
+                  {
+                    "id": "race",
+                    "label": "Race",
+                    "type": "checkbox",
+                    "required": false,
+                    "tooltip": "You may choose multiple race categories for a single person. Providing race information is voluntary and will not affect your eligibility for Child Care Assistance or the amount of assistance that you will be given by this agency.",
+                    "ui": {
+                      "options": [
+                        {
+                          "value": "AI",
+                          "label": "American Indian or Alaska Native"
+                        },
+                        {
+                          "value": "AS",
+                          "label": "Asian"
+                        },
+                        {
+                          "value": "BL",
+                          "label": "Black or African American"
+                        },
+                        {
+                          "value": "HP",
+                          "label": "Native Hawaiian or Pacific Islander"
+                        },
+                        {
+                          "value": "WH",
+                          "label": "White"
+                        }
+                      ]
+                    },
+                    "metadata": {
+                      "multiple": true
+                    }
+                  },
+                  {
+                    "id": "ssn",
+                    "label": "Social Security Number",
+                    "type": "text",
+                    "required": false,
+                    "tooltip": "Fill in the Social Security Number (SSN) for your family members. SSN is optional. SSN may be used by federal, state, and local agencies to prevent duplication of services and fraud, and for Federal Reporting.",
+                    "constraints": {
+                      "pattern": "^\\\\d{3}-\\\\d{2}-\\\\d{4}$"
+                    },
+                    "ui": {
+                      "placeholder": "123-45-6789"
+                    }
+                  }
+                ]
+              }
+            ]
+          }
+        ]
+      },
+      {
+        "id": "child_family_needs",
+        "title": "Child / Family Needs",
+        "sections": [
+          {
+            "id": "assistance_reason",
+            "title": "Reason for Child Care Assistance",
+            "description": "Select one or two reasons you are requesting Child Care Assistance.",
+            "tooltip": "Select one reason. In a two-parent household, parents/caretakers can have the same or different reasons for needing child care. Both parents/caretakers will be required to submit documentation in support of their own reason. If you are living in temporary housing, please select Homelessness even if you have another reason that applies to you.",
+            "fields": [
+              {
+                "id": "assistance_reason",
+                "label": "Reason(s) for Assistance",
+                "type": "select",
+                "required": true,
+                "ui": {
+                  "options": [
+                    "",
+                    "Employment",
+                    "Looking for Work",
+                    "Vocational Training/Educational Activities",
+                    "Receiving Domestic Violence Services",
+                    "Homelessness"
+                  ]
+                },
+                "constraints": {
+                  "minSelections": 1,
+                  "maxSelections": 2
+                },
+                "metadata": {
+                  "multiple": true
+                }
+              }
+            ]
+          },
+          {
+            "id": "military_status",
+            "title": "Military and Parental Availability",
+            "description": "Provide information about parental military status and availability for child care.",
+            "fields": [
+              {
+                "id": "is_parent_currently_active_in_military",
+                "label": "Is a Parent Currently Active Full-Time in the U.S. Military?",
+                "tooltip": "Check “YES” or “NO” to indicate whether a parent is currently active full-time in the U.S. Military.",
+                "type": "radio",
+                "required": true,
+                "ui": {
+                  "options": [
+                    "Yes",
+                    "No"
+                  ]
+                }
+              },
+              {
+                "id": "is_parent_mem_of_guard_or_mru",
+                "label": "Is a Parent a Member of National Guard or Military Reserve Unit?",
+                "tooltip": "Check “YES” or “NO” to indicate whether a parent is currently a member of a National Guard or Military Reserve Unit.",
+                "type": "radio",
+                "required": true,
+                "ui": {
+                  "options": [
+                    "Yes",
+                    "No"
+                  ]
+                }
+              },
+              {
+                "id": "is_non_custodial_parent_available",
+                "label": "Is the Non-Custodial Parent Available to Provide Care?",
+                "tooltip": "Check “YES” or “NO” to indicate whether there is a non-custodial parent available to provide child care.",
+                "type": "radio",
+                "required": true,
+                "ui": {
+                  "options": [
+                    "Yes",
+                    "No"
+                  ]
+                }
+              }
+            ]
+          },
+          {
+            "id": "duplicate_application",
+            "title": "Other Applications",
+            "description": "Indicate if you are also applying for or receiving child care from other agencies.",
+            "tooltip": "Indicate whether you are currently receiving or have applied for child care assistance with one of the agencies or organizations listed below. Note: If you are receiving Cash Assistance and are interested in child care assistance, you must apply through the Human Resources Administration. Reach out to your Benefits Access Center or visit the Human Resources Administration webpage.",
+            "fields": [
+              {
+                "id": "duplicate_app",
+                "label": "Are You Receiving or Applying for Child Care Through Another Agency?",
+                "type": "select",
+                "required": false,
+                "ui": {
+                  "options": [
+                    "",
+                    "Not Applicable",
+                    "Department of Education (DOE)",
+                    "Human Resources Administration (HRA)",
+                    "Department of Youth and Community Development (DYCD)",
+                    "Department of Homeless Services (DHS)",
+                    "Consortium for Worker Education (CWE)",
+                    "Administration for Children's Services (ACS)"
+                  ]
+                }
+              }
+            ]
+          }
+        ]
+      },
+      {
+        "id": "employment",
+        "title": "Employment",
+        "sections": [
+          {
+            "id": "employment_precheck",
+            "title": "Tell us about your employment",
+            "description": "Tell us about your employment",
+            "fields": [
+              {
+                "id": "applicant_emp_income_indicator",
+                "label": "Does applicant earn any income/ wages from employment? ",
+                "type": "radio",
+                "required": false,
+                "ui": {
+                  "options": [
+                    "Yes",
+                    "No"
+                  ]
+                }
+              },
+              {
+                "id": "coparent_emp_income_indicator",
+                "label": "Does Coparent/2nd Guardian earn any income/ wages from employment? ",
+                "type": "radio",
+                "required": false,
+                "ui": {
+                  "options": [
+                    "Yes",
+                    "No"
+                  ]
+                }
+              }
+            ]
+          },
+          {
+            "id": "applicant_jobs",
+            "title": "Applicant Employment Information",
+            "description": "Enter details for up to two jobs held by the applicant.",
+            "visibilityCondition": {
+              "field": "applicant_emp_income_indicator",
+              "operator": "equals",
+              "value": "Yes"
+            },
+            "fields": [
+              {
+                "id": "applicant_1st_job_start_date",
+                "label": "1st Job - Start Date",
+                "type": "date",
+                "required": false,
+                "ui": {
+                  "group": "1st Job"
+                }
+              },
+              {
+                "id": "applicant_1st_job_rotating_shift",
+                "label": "1st Job - Has Rotating Shift?",
+                "type": "radio",
+                "required": false,
+                "ui": {
+                  "options": [
+                    "Yes",
+                    "No"
+                  ],
+                  "group": "1st Job"
+                }
+              },
+              {
+                "id": "applicant_1st_job_requires_overtime",
+                "label": "1st Job - Requires Overtime?",
+                "type": "radio",
+                "required": false,
+                "ui": {
+                  "options": [
+                    "Yes",
+                    "No"
+                  ],
+                  "group": "1st Job"
+                }
+              },
+              {
+                "id": "applicant_1st_job_employer_name",
+                "label": "1st Job - Employer Name",
+                "type": "text",
+                "required": false,
+                "ui": {
+                  "group": "1st Job"
+                }
+              },
+              {
+                "id": "applicant_1st_job_employer_phone",
+                "label": "1st Job - Employer Phone",
+                "type": "tel",
+                "required": false,
+                "ui": {
+                  "group": "1st Job"
+                }
+              },
+              {
+                "id": "applicant_1st_job_employer_street",
+                "label": "1st Job - Employer Street Address",
+                "type": "text",
+                "required": false,
+                "ui": {
+                  "group": "1st Job"
+                }
+              },
+              {
+                "id": "applicant_1st_job_employer_city",
+                "label": "1st Job - Employer City",
+                "type": "text",
+                "required": false,
+                "ui": {
+                  "group": "1st Job"
+                }
+              },
+              {
+                "id": "applicant_1st_job_employer_state",
+                "label": "1st Job - Employer State",
+                "type": "text",
+                "required": false,
+                "ui": {
+                  "group": "1st Job"
+                }
+              },
+              {
+                "id": "applicant_1st_job_employer_zipcode",
+                "label": "1st Job - Employer ZIP Code",
+                "type": "text",
+                "required": false,
+                "ui": {
+                  "group": "1st Job"
+                }
+              },
+              {
+                "id": "applicant_2nd_job_start_date",
+                "label": "2nd Job - Start Date",
+                "type": "date",
+                "required": false,
+                "ui": {
+                  "group": "2nd Job"
+                }
+              },
+              {
+                "id": "applicant_2nd_job_rotating_shift",
+                "label": "2nd Job - Has Rotating Shift?",
+                "type": "radio",
+                "required": false,
+                "ui": {
+                  "options": [
+                    "Yes",
+                    "No"
+                  ],
+                  "group": "2nd Job"
+                }
+              },
+              {
+                "id": "applicant_2nd_job_requires_overtime",
+                "label": "2nd Job - Requires Overtime?",
+                "type": "radio",
+                "required": false,
+                "ui": {
+                  "options": [
+                    "Yes",
+                    "No"
+                  ],
+                  "group": "2nd Job"
+                }
+              },
+              {
+                "id": "applicant_2nd_job_employer_name",
+                "label": "2nd Job - Employer Name",
+                "type": "text",
+                "required": false,
+                "ui": {
+                  "group": "2nd Job"
+                }
+              },
+              {
+                "id": "applicant_2nd_job_employer_phone",
+                "label": "2nd Job - Employer Phone",
+                "type": "tel",
+                "required": false,
+                "ui": {
+                  "group": "2nd Job"
+                }
+              },
+              {
+                "id": "applicant_2nd_job_employer_street",
+                "label": "2nd Job - Employer Street Address",
+                "type": "text",
+                "required": false,
+                "ui": {
+                  "group": "2nd Job"
+                }
+              },
+              {
+                "id": "applicant_2nd_job_employer_city",
+                "label": "2nd Job - Employer City",
+                "type": "text",
+                "required": false,
+                "ui": {
+                  "group": "2nd Job"
+                }
+              },
+              {
+                "id": "applicant_2nd_job_employer_state",
+                "label": "2nd Job - Employer State",
+                "type": "text",
+                "required": false,
+                "ui": {
+                  "group": "2nd Job"
+                }
+              },
+              {
+                "id": "applicant_2nd_job_employer_zipcode",
+                "label": "2nd Job - Employer ZIP Code",
+                "type": "text",
+                "required": false,
+                "ui": {
+                  "group": "2nd Job"
+                }
+              }
+            ]
+          },
+          {
+            "id": "second_parent_jobs",
+            "title": "Second Parent Employment Information",
+            "description": "Enter details for up to two jobs held by the second parent (if applicable).",
+            "visibilityCondition": {
+              "field": "coparent_emp_income_indicator",
+              "operator": "equals",
+              "value": "Yes"
+            },
+            "fields": [
+              {
+                "id": "second_parent_1st_job_start_date",
+                "label": "1st Job - Start Date",
+                "type": "date",
+                "required": false
+              },
+              {
+                "id": "second_parent_1st_job_rotating_shift",
+                "label": "1st Job - Has Rotating Shift?",
+                "type": "radio",
+                "required": false,
+                "ui": {
+                  "options": [
+                    "Yes",
+                    "No"
+                  ]
+                }
+              },
+              {
+                "id": "second_parent_1st_job_requires_overtime",
+                "label": "1st Job - Requires Overtime?",
+                "type": "radio",
+                "required": false,
+                "ui": {
+                  "options": [
+                    "Yes",
+                    "No"
+                  ]
+                }
+              },
+              {
+                "id": "second_parent_1st_job_employer_name",
+                "label": "1st Job - Employer Name",
+                "type": "text",
+                "required": false
+              },
+              {
+                "id": "second_parent_1st_job_employer_phone",
+                "label": "1st Job - Employer Phone",
+                "type": "tel",
+                "required": false
+              },
+              {
+                "id": "second_parent_1st_job_employer_street",
+                "label": "1st Job - Employer Street Address",
+                "type": "text",
+                "required": false
+              },
+              {
+                "id": "second_parent_1st_job_employer_city",
+                "label": "1st Job - Employer City",
+                "type": "text",
+                "required": false
+              },
+              {
+                "id": "second_parent_1st_job_employer_state",
+                "label": "1st Job - Employer State",
+                "type": "text",
+                "required": false
+              },
+              {
+                "id": "second_parent_1st_job_employer_zipcode",
+                "label": "1st Job - Employer ZIP Code",
+                "type": "text",
+                "required": false
+              },
+              {
+                "id": "second_parent_2nd_job_start_date",
+                "label": "2nd Job - Start Date",
+                "type": "date",
+                "required": false
+              },
+              {
+                "id": "second_parent_2nd_job_rotating_shift",
+                "label": "2nd Job - Has Rotating Shift?",
+                "type": "radio",
+                "required": false,
+                "ui": {
+                  "options": [
+                    "Yes",
+                    "No"
+                  ]
+                }
+              },
+              {
+                "id": "second_parent_2nd_job_requires_overtime",
+                "label": "2nd Job - Requires Overtime?",
+                "type": "radio",
+                "required": false,
+                "ui": {
+                  "options": [
+                    "Yes",
+                    "No"
+                  ]
+                }
+              },
+              {
+                "id": "second_parent_2nd_job_employer_name",
+                "label": "2nd Job - Employer Name",
+                "type": "text",
+                "required": false
+              },
+              {
+                "id": "second_parent_2nd_job_employer_phone",
+                "label": "2nd Job - Employer Phone",
+                "type": "tel",
+                "required": false
+              },
+              {
+                "id": "second_parent_2nd_job_employer_street",
+                "label": "2nd Job - Employer Street Address",
+                "type": "text",
+                "required": false
+              },
+              {
+                "id": "second_parent_2nd_job_employer_city",
+                "label": "2nd Job - Employer City",
+                "type": "text",
+                "required": false
+              },
+              {
+                "id": "second_parent_2nd_job_employer_state",
+                "label": "2nd Job - Employer State",
+                "type": "text",
+                "required": false
+              },
+              {
+                "id": "second_parent_2nd_job_employer_zipcode",
+                "label": "2nd Job - Employer ZIP Code",
+                "type": "text",
+                "required": false
+              }
+            ]
+          }
+        ]
+      },
+      {
+        "id": "schedule",
+        "title": "Work/Activity/Travel Time Schedule",
+        "sections": [
+          {
+            "id": "schedule_section_info",
+            "title": "Schedule Information",
+            "type": "info",
+            "ui": {
+              "markdown": true,
+              "collapsible": false,
+              "defaultCollapsed": false
+            },
+            "content": "Please indicate what days and hours you will need child care for based on your reason for care.\\n\\n- **Employed**: Indicate the hours you attend work\\n- **Educational or Vocational Program**: Indicate the hours you attend school or your program\\n- **Looking for Work**: Indicate the hours you spend looking for work\\n- **Homeless**: Indicate the hours you spend looking for housing\\n- **Attending Services for Domestic Violence**: Indicate the hours you attend services.\\n- **Attending Services for Substance Abuse Treatment**: Indicate the hours you attend services."
+          },
+          {
+            "id": "first_parent_activity_schedule",
+            "title": "First Parent Activity Schedule",
+            "description": "Enter the start and end times for each day of the week for the first parent's activities.",
+            "ui": {
+              "layout": "table",
+              "columns": [
+                "Start Time",
+                "End Time"
+              ],
+              "rowCopy": {
+                "enableUserPickSource": true,
+                "rowIdentifier": "ui.rowGroup",
+                "fieldsToCopy": [
+                  1,
+                  2
+                ],
+                "targetRowValues": [
+                  "Monday",
+                  "Tuesday",
+                  "Wednesday",
+                  "Thursday",
+                  "Friday"
+                ],
+                "copyControlLabel": "Apply selected schedule to other weekdays",
+                "sourceOptions": [
+                  "Monday",
+                  "Tuesday",
+                  "Wednesday",
+                  "Thursday",
+                  "Friday",
+                  "Saturday",
+                  "Sunday"
+                ]
+              }
+            },
+            "fields": [
+              {
+                "id": "fp_monday_from",
+                "label": "Monday From",
+                "type": "time",
+                "ui": {
+                  "rowGroup": "Monday",
+                  "column": 1
+                }
+              },
+              {
+                "id": "fp_monday_to",
+                "label": "Monday To",
+                "type": "time",
+                "ui": {
+                  "rowGroup": "Monday",
+                  "column": 2
+                }
+              },
+              {
+                "id": "fp_tuesday_from",
+                "label": "Tuesday From",
+                "type": "time",
+                "ui": {
+                  "rowGroup": "Tuesday",
+                  "column": 1
+                }
+              },
+              {
+                "id": "fp_tuesday_to",
+                "label": "Tuesday To",
+                "type": "time",
+                "ui": {
+                  "rowGroup": "Tuesday",
+                  "column": 2
+                }
+              },
+              {
+                "id": "fp_wednesday_from",
+                "label": "Wednesday From",
+                "type": "time",
+                "ui": {
+                  "rowGroup": "Wednesday",
+                  "column": 1
+                }
+              },
+              {
+                "id": "fp_wednesday_to",
+                "label": "Wednesday To",
+                "type": "time",
+                "ui": {
+                  "rowGroup": "Wednesday",
+                  "column": 2
+                }
+              },
+              {
+                "id": "fp_thursday_from",
+                "label": "Thursday From",
+                "type": "time",
+                "ui": {
+                  "rowGroup": "Thursday",
+                  "column": 1
+                }
+              },
+              {
+                "id": "fp_thursday_to",
+                "label": "Thursday To",
+                "type": "time",
+                "ui": {
+                  "rowGroup": "Thursday",
+                  "column": 2
+                }
+              },
+              {
+                "id": "fp_friday_from",
+                "label": "Friday From",
+                "type": "time",
+                "ui": {
+                  "rowGroup": "Friday",
+                  "column": 1
+                }
+              },
+              {
+                "id": "fp_friday_to",
+                "label": "Friday To",
+                "type": "time",
+                "ui": {
+                  "rowGroup": "Friday",
+                  "column": 2
+                }
+              },
+              {
+                "id": "fp_saturday_from",
+                "label": "Saturday From",
+                "type": "time",
+                "ui": {
+                  "rowGroup": "Saturday",
+                  "column": 1
+                }
+              },
+              {
+                "id": "fp_saturday_to",
+                "label": "Saturday To",
+                "type": "time",
+                "ui": {
+                  "rowGroup": "Saturday",
+                  "column": 2
+                }
+              },
+              {
+                "id": "fp_sunday_from",
+                "label": "Sunday From",
+                "type": "time",
+                "ui": {
+                  "rowGroup": "Sunday",
+                  "column": 1
+                }
+              },
+              {
+                "id": "fp_sunday_to",
+                "label": "Sunday To",
+                "type": "time",
+                "ui": {
+                  "rowGroup": "Sunday",
+                  "column": 2
+                }
+              }
+            ]
+          },
+          {
+            "id": "second_parent_activity_schedule",
+            "title": "Second Parent Activity Schedule",
+            "description": "Enter the start and end times for each day of the week for the second parent's activities.",
+            "ui": {
+              "layout": "table",
+              "columns": [
+                "Start Time",
+                "End Time"
+              ],
+              "rowCopy": {
+                "enableUserPickSource": true,
+                "rowIdentifier": "ui.rowGroup",
+                "fieldsToCopy": [
+                  1,
+                  2
+                ],
+                "targetRowValues": [
+                  "Monday",
+                  "Tuesday",
+                  "Wednesday",
+                  "Thursday",
+                  "Friday"
+                ],
+                "copyControlLabel": "Apply selected schedule to other weekdays",
+                "sourceOptions": [
+                  "Monday",
+                  "Tuesday",
+                  "Wednesday",
+                  "Thursday",
+                  "Friday",
+                  "Saturday",
+                  "Sunday"
+                ]
+              }
+            },
+            "fields": [
+              {
+                "id": "sp_monday_from",
+                "label": "Monday From",
+                "type": "time",
+                "ui": {
+                  "rowGroup": "Monday",
+                  "column": 1
+                }
+              },
+              {
+                "id": "sp_monday_to",
+                "label": "Monday To",
+                "type": "time",
+                "ui": {
+                  "rowGroup": "Monday",
+                  "column": 2
+                }
+              },
+              {
+                "id": "sp_tuesday_from",
+                "label": "Tuesday From",
+                "type": "time",
+                "ui": {
+                  "rowGroup": "Tuesday",
+                  "column": 1
+                }
+              },
+              {
+                "id": "sp_tuesday_to",
+                "label": "Tuesday To",
+                "type": "time",
+                "ui": {
+                  "rowGroup": "Tuesday",
+                  "column": 2
+                }
+              },
+              {
+                "id": "sp_wednesday_from",
+                "label": "Wednesday From",
+                "type": "time",
+                "ui": {
+                  "rowGroup": "Wednesday",
+                  "column": 1
+                }
+              },
+              {
+                "id": "sp_wednesday_to",
+                "label": "Wednesday To",
+                "type": "time",
+                "ui": {
+                  "rowGroup": "Wednesday",
+                  "column": 2
+                }
+              },
+              {
+                "id": "sp_thursday_from",
+                "label": "Thursday From",
+                "type": "time",
+                "ui": {
+                  "rowGroup": "Thursday",
+                  "column": 1
+                }
+              },
+              {
+                "id": "sp_thursday_to",
+                "label": "Thursday To",
+                "type": "time",
+                "ui": {
+                  "rowGroup": "Thursday",
+                  "column": 2
+                }
+              },
+              {
+                "id": "sp_friday_from",
+                "label": "Friday From",
+                "type": "time",
+                "ui": {
+                  "rowGroup": "Friday",
+                  "column": 1
+                }
+              },
+              {
+                "id": "sp_friday_to",
+                "label": "Friday To",
+                "type": "time",
+                "ui": {
+                  "rowGroup": "Friday",
+                  "column": 2
+                }
+              },
+              {
+                "id": "sp_saturday_from",
+                "label": "Saturday From",
+                "type": "time",
+                "ui": {
+                  "rowGroup": "Saturday",
+                  "column": 1
+                }
+              },
+              {
+                "id": "sp_saturday_to",
+                "label": "Saturday To",
+                "type": "time",
+                "ui": {
+                  "rowGroup": "Saturday",
+                  "column": 2
+                }
+              },
+              {
+                "id": "sp_sunday_from",
+                "label": "Sunday From",
+                "type": "time",
+                "ui": {
+                  "rowGroup": "Sunday",
+                  "column": 1
+                }
+              },
+              {
+                "id": "sp_sunday_to",
+                "label": "Sunday To",
+                "type": "time",
+                "ui": {
+                  "rowGroup": "Sunday",
+                  "column": 2
+                }
+              }
+            ]
+          },
+          {
+            "id": "first_parent_travel_time",
+            "title": "First Parent Travel Time",
+            "description": "Enter the travel times and method of transport for the first parent.",
+            "fields": [
+              {
+                "id": "fp_dropoff_travel_time",
+                "label": "Drop-off Travel Time",
+                "type": "select",
+                "tooltip": "Select your typical travel time from work/activity to your child care provider",
+                "ui": {
+                  "options": [
+                    "",
+                    "15 min",
+                    "30 min",
+                    "45 min",
+                    "1 hour",
+                    "More than 1 hour"
+                  ]
+                }
+              },
+              {
+                "id": "fp_dropoff_time_gt_1hr",
+                "label": "Drop-off Time (if > 1 hour)",
+                "type": "text",
+                "requiredCondition": {
+                  "field": "fp_dropoff_travel_time",
+                  "operator": "equals",
+                  "value": "More than 1 hour"
+                }
+              },
+              {
+                "id": "fp_pickup_travel_time",
+                "label": "Pick-up Travel Time",
+                "type": "select",
+                "tooltip": "Select your typical travel time from work/activity to your child care provider",
+                "ui": {
+                  "options": [
+                    "",
+                    "15 min",
+                    "30 min",
+                    "45 min",
+                    "1 hour",
+                    "More than 1 hour"
+                  ]
+                }
+              },
+              {
+                "id": "fp_pickup_time_gt_1hr",
+                "label": "Pick-up Time (if > 1 hour)",
+                "type": "text",
+                "requiredCondition": {
+                  "field": "fp_pickup_travel_time",
+                  "operator": "equals",
+                  "value": "More than 1 hour"
+                }
+              },
+              {
+                "id": "fp_public_transport_dropoff",
+                "label": "Public Transport for Drop-off?",
+                "type": "radio",
+                "tooltip": "Indicate if the applicant uses public transportation to travel to and from work/activity to provider.",
+                "ui": {
+                  "options": [
+                    "Yes",
+                    "No"
+                  ]
+                }
+              },
+              {
+                "id": "fp_public_transport_pickup",
+                "label": "Public Transport for Pick-up?",
+                "tooltip": "Indicate if the applicant uses public transportation to travel to and from work/activity to provider.",
+                "type": "radio",
+                "ui": {
+                  "options": [
+                    "Yes",
+                    "No"
+                  ]
+                }
+              }
+            ]
+          },
+          {
+            "id": "second_parent_travel_time",
+            "title": "Second Parent Travel Time",
+            "description": "Enter the travel times and method of transport for the second parent.",
+            "fields": [
+              {
+                "id": "sp_dropoff_travel_time",
+                "label": "Drop-off Travel Time",
+                "type": "select",
+                "ui": {
+                  "options": [
+                    "",
+                    "15 min",
+                    "30 min",
+                    "45 min",
+                    "1 hour",
+                    "More than 1 hour"
+                  ]
+                }
+              },
+              {
+                "id": "sp_pickup_travel_time",
+                "label": "Pick-up Travel Time",
+                "type": "select",
+                "ui": {
+                  "options": [
+                    "",
+                    "15 min",
+                    "30 min",
+                    "45 min",
+                    "1 hour",
+                    "More than 1 hour"
+                  ]
+                }
+              },
+              {
+                "id": "sp_dropoff_time_gt_1hr",
+                "label": "Drop-off Time (if > 1 hour)",
+                "type": "text",
+                "requiredCondition": {
+                  "field": "sp_dropoff_travel_time",
+                  "operator": "equals",
+                  "value": "More than 1 hour"
+                }
+              },
+              {
+                "id": "sp_pickup_time_gt_1hr",
+                "label": "Pick-up Time (if > 1 hour)",
+                "type": "text",
+                "requiredCondition": {
+                  "field": "sp_pickup_travel_time",
+                  "operator": "equals",
+                  "value": "More than 1 hour"
+                }
+              },
+              {
+                "id": "sp_public_transport_dropoff",
+                "label": "Public Transport for Drop-off?",
+                "type": "radio",
+                "ui": {
+                  "options": [
+                    "Yes",
+                    "No"
+                  ]
+                }
+              },
+              {
+                "id": "sp_public_transport_pickup",
+                "label": "Public Transport for Pick-up?",
+                "type": "radio",
+                "ui": {
+                  "options": [
+                    "Yes",
+                    "No"
+                  ]
+                }
+              }
+            ]
+          }
+        ]
+      },
+      {
+        "id": "income",
+        "title": "Income Information",
+        "sections": [
+          {
+            "id": "income_step_info",
+            "title": "Instructions",
+            "type": "info",
+            "ui": {
+              "markdown": true,
+              "collapsible": false,
+              "defaultCollapsed": false
+            },
+            "content": "Please include income/benefits information for yourself and, if applicable, your spouse, your child’s second caretaker, and/or any other adult with whom you share a child, if they live in your home.\\n\\nIndicate if you receive money from the following sources by selecting “Yes” or “No.” If you select “Yes,” you will be asked for additional information.\\n\\nIf the second caretaker in the household also receives the same income source, add a separate line for their income."
+          },
+          {
+            "id": "income_sources",
+            "title": "Income Sources",
+            "description": "Provide details about all income sources applicable to the applicant or household.",
+            "fields": [
+              {
+                "id": "income_sources",
+                "label": "List of Income Sources",
+                "type": "group",
+                "metadata": {
+                  "multiple": true,
+                  "tableColumns": [
+                    "name_ref",
+                    "how_often",
+                    "recipient",
+                    "monthly_amount"
+                  ]
+                },
+                "fields": [
+                  {
+                    "id": "name_ref",
+                    "label": "Income Source Type",
+                    "type": "select",
+                    "required": true,
+                    "ui": {
+                      "options": [
+                        "",
+                        "ApplicantWages",
+                        "SecondParentWages",
+                        "SelfEmployment",
+                        "ChildSupport",
+                        "Alimony",
+                        "Unemployment",
+                        "SocialSecurity",
+                        "Disability",
+                        "Rental",
+                        "Dividends",
+                        "Retirement",
+                        "CashAssistance",
+                        "Other"
+                      ]
+                    }
+                  },
+                  {
+                    "id": "other_source_text",
+                    "label": "Other Source (If applicable)",
+                    "type": "text",
+                    "visibilityCondition": {
+                      "field": "name_ref",
+                      "operator": "equals",
+                      "value": "Other"
+                    },
+                    "requiredCondition": {
+                      "condition": {
+                        "field": "name_ref",
+                        "operator": "equals",
+                        "value": "Other"
+                      }
+                    }
+                  },
+                  {
+                    "id": "is_source_applicable",
+                    "label": "Is this Source Applicable?",
+                    "type": "radio",
+                    "required": true,
+                    "ui": {
+                      "options": [
+                        "Yes",
+                        "No"
+                      ]
+                    }
+                  },
+                  {
+                    "id": "gross_amount",
+                    "label": "Gross Amount ($)",
+                    "type": "number",
+                    "required": true
+                  },
+                  {
+                    "id": "how_often",
+                    "label": "Frequency of Income",
+                    "type": "radio",
+                    "required": true,
+                    "ui": {
+                      "options": [
+                        "Weekly",
+                        "Bi-weekly",
+                        "Monthly",
+                        "Other"
+                      ]
+                    }
+                  },
+                  {
+                    "id": "recipient",
+                    "label": "Recipient of Income",
+                    "type": "text",
+                    "required": true
+                  },
+                  {
+                    "id": "monthly_amount",
+                    "label": "Monthly Amount ($)",
+                    "type": "number",
+                    "required": true
+                  }
+                ]
+              }
+            ]
+          },
+          {
+            "id": "total_income",
+            "title": "Total Household Income",
+            "description": "Sum of all monthly income across sources.",
+            "fields": [
+              {
+                "id": "total_income",
+                "label": "Total Monthly Income ($)",
+                "type": "number",
+                "required": true
+              }
+            ]
+          },
+          {
+            "id": "income_proof_section",
+            "title": "Income Proof",
+            "fields": [
+              {
+                "id": "income_proof",
+                "label": "Upload Income Proof",
+                "type": "file",
+                "requiredCondition": {
+                  "condition": {
+                    "field": "assistance_reason",
+                    "operator": "includes",
+                    "value": "Employment"
+                  }
+                },
+                "constraints": {
+                  "maxFileSizeMB": 5,
+                  "allowedTypes": [
+                    "application/pdf",
+                    "image/jpeg"
+                  ],
+                  "imageResolution": {
+                    "minWidth": 800,
+                    "minHeight": 600
+                  }
+                },
+                "metadata": {
+                  "proofCategory": "Income Verification",
+                  "examples": [
+                    "Pay Stub",
+                    "W-2"
+                  ],
+                  "multiple": true
+                }
+              }
+            ]
+          }
+        ]
+      },
+      {
+        "id": "provider",
+        "title": "Provider",
+        "sections": [
+          {
+            "id": "provider_step_info",
+            "title": "Instructions",
+            "type": "info",
+            "ui": {
+              "markdown": true,
+              "collapsible": false,
+              "defaultCollapsed": false
+            },
+            "content": "If you are found eligible for child care assistance, you can choose center-based or home-based care from a licensed, registered, or legally exempt provider. If you choose a provider that is not licensed or registered, the provider must be enrolled as a legally exempt provider.\\n\\nIf you know which child care providers you would like your child to attend, provide the names and addresses of your choice of providers. You can leave this section blank if you do not know (it will not impact your eligibility and you will have an opportunity to select a provider if determined eligible)."
+          },
+          {
+            "id": "provider_choices",
+            "title": "Provider Choices",
+            "description": "Specify details of the provider where you intend to enroll the child(ren).",
+            "fields": [
+              {
+                "id": "provider_choices",
+                "label": "List of Providers",
+                "type": "group",
+                "metadata": {
+                  "multiple": true,
+                  "tableColumns": [
+                    "provider_name",
+                    "program_number",
+                    "provider_zip_code"
+                  ]
+                },
+                "fields": [
+                  {
+                    "id": "provider_name",
+                    "label": "Provider Name",
+                    "type": "text",
+                    "required": true
+                  },
+                  {
+                    "id": "program_number",
+                    "label": "Program Number (If Applicable)",
+                    "type": "text",
+                    "required": false
+                  },
+                  {
+                    "id": "provider_street",
+                    "label": "Street Address",
+                    "type": "text",
+                    "required": true
+                  },
+                  {
+                    "id": "provider_city",
+                    "label": "City",
+                    "type": "text",
+                    "required": true
+                  },
+                  {
+                    "id": "provider_state",
+                    "label": "State",
+                    "type": "text",
+                    "required": true
+                  },
+                  {
+                    "id": "provider_zip_code",
+                    "label": "Zip Code",
+                    "type": "text",
+                    "required": true
+                  }
+                ]
+              }
+            ]
+          }
+        ]
+      },
+      {
+        "id": "document_upload_step",
+        "title": "Document Upload",
+        "description": "The Application for Child Care Assistance (CFWB-012) must include supporting documentation. Check to ensure that documentation is provided for each requirement of subsidy eligibility.",
+        "sections": [
+          {
+            "id": "nyc_residency",
+            "title": "New York City Residency",
+            "description": "These documents confirm that you live in New York City. Please upload one of the following documents.",
+            "fields": [
+              {
+                "id": "nyc_residency_type",
+                "label": "Select one of the following:",
+                "type": "radio",
+                "required": true,
+                "ui": {
+                  "options": [
+                    "IDNYC",
+                    "Utility Bill",
+                    "Section 8 Award Letter",
+                    "Driver’s License",
+                    "Rent Receipt",
+                    "NYCHA Certificate",
+                    "CFWB-067 Residency Attestation",
+                    "CFWB-027 Housing Attestation with address listed",
+                    "Shelter Residency Letter with address listed",
+                    "Other"
+                  ]
+                }
+              },
+              {
+                "id": "nyc_residency_file",
+                "label": "Upload Residency Proof Document",
+                "description": "To add a document to your application, you can upload an image or scanned file from your phone or device. Accepted formats include .pdf, .gif, .jpeg, .jpg and .png up to 25 MB. Learn how to upload your files with this Tutorial Video.",
+                "type": "file",
+                "required": true, 
+                "constraints": {
+                  "maxFileSizeMB": 25,
+                  "allowedTypes": [
+                    "application/pdf",
+                    "image/jpeg",
+                    "image/jpg",
+                    "image/png",
+                    "image/gif"
+                  ]
+                },
+                "metadata": {
+                  "proofCategory": "NYC Residency",
+                  "multiple": false
+                }
+              }
+            ]
+          },
+          {
+            "id": "citizenship_status",
+            "title": "Citizenship or Immigration Status",
+            "description": "These documents confirm the citizenship/immigration status of the children in your family for whom you’re applying for child care assistance. Please upload one of the following documents for ONLY each child needing care.",
+            "fields": [
+              {
+                "id": "citizenship_doc_type",
+                "label": "Select one of the following:",
+                "type": "radio",
+                "required": true,
+                "ui": {
+                  "options": [
+                    "US Birth Certificate",
+                    "Alien Registration Card including Permanent Resident or Green Card",
+                    "Passport",
+                    "FS-240 (Report of Birth Abroad of a U.S. Citizen)",
+                    "Naturalization Certificate",
+                    "Other"
+                  ]
+                }
+              },
+              {
+                "id": "citizenship_doc_file",
+                "label": "Upload Citizenship/Immigration Document",
+                "description": "To add a document to your application, you can upload an image or scanned file from your phone or device. Accepted formats include .pdf, .gif, .jpeg, .jpg and .png up to 25 MB. Learn how to upload your files with this Tutorial Video.",
+                "type": "file",
+                "required": true,
+                "constraints": {
+                  "maxFileSizeMB": 25,
+                  "allowedTypes": [
+                    "application/pdf",
+                    "image/jpeg",
+                    "image/jpg",
+                    "image/png",
+                    "image/gif"
+                  ]
+                },
+                "metadata": {
+                  "proofCategory": "Citizenship/Immigration Status",
+                  "multiple": false
+                }
+              }
+            ]
+          },
+          {
+            "id": "child_relationship",
+            "title": "Child’s Relationship to Parent/Applicant",
+            "description": "These documents confirm your relationship to the children in your household under age 18. Please upload one of the following documents for every child in the household under age 18, regardless of whether child care is needed for them or not. If you are a legal guardian with financial responsibility, you must upload a Court order OR a letter of guardianship.",
+            "fields": [
+              {
+                "id": "relationship_doc_type",
+                "label": "Select one of the following:",
+                "type": "radio",
+                "required": true,
+                "ui": {
+                  "options": [
+                    "Birth Certificate",
+                    "Adoption record",
+                    "Baptismal record",
+                    "Passport with parent's signature",
+                    "Court order for legal guardian with financial responsibility",
+                    "Letter of Guardianship",
+                    "Other - CFWB-058 Caretaker Attestation"
+                  ]
+                }
+              },
+              {
+                "id": "relationship_doc_file",
+                "label": "Upload Relationship Document",
+                "description": "To add a document to your application, you can upload an image or scanned file from your phone or device. Accepted formats include .pdf, .gif, .jpeg, .jpg and .png up to 25 MB. Learn how to upload your files with this Tutorial Video.",
+                "type": "file",
+                "required": true,
+                "constraints": {
+                  "maxFileSizeMB": 25,
+                  "allowedTypes": [
+                    "application/pdf",
+                    "image/jpeg",
+                    "image/jpg",
+                    "image/png",
+                    "image/gif"
+                  ]
+                },
+                "metadata": {
+                  "proofCategory": "Child Relationship",
+                  "multiple": false
+                }
+              }
+            ]
+          },
+          {
+            "id": "age_proof",
+            "title": "Age",
+            "description": "These documents confirm the age of the children in your household. Please upload one of the following documents for every child in the household under age 18, regardless of whether child care is needed for them:",
+            "fields": [
+              {
+                "id": "age_doc_type",
+                "label": "Select one of the following:",
+                "type": "radio",
+                "required": true,
+                "ui": {
+                  "options": [
+                    "Birth Certificate",
+                    "Adoption record",
+                    "Baptismal record",
+                    "Alien Registration Card",
+                    "Passport",
+                    "Official hospital documentation of the child’s birth"
+                  ]
+                }
+              },
+              {
+                "id": "age_doc_file",
+                "label": "Upload Age Proof Document",
+                "description": "To add a document to your application, you can upload an image or scanned file from your phone or device. Accepted formats include .pdf, .gif, .jpeg, .jpg and .png up to 25 MB. Learn how to upload your files with this Tutorial Video.",
+                "type": "file",
+                "required": true,
+                "constraints": {
+                  "maxFileSizeMB": 25,
+                  "allowedTypes": [
+                    "application/pdf",
+                    "image/jpeg",
+                    "image/jpg",
+                    "image/png",
+                    "image/gif"
+                  ]
+                },
+                "metadata": {
+                  "proofCategory": "Child Age",
+                  "multiple": false
+                }
+              }
+            ]
+          }
+        ]
+      },
+      {
+        "id": "review",
+        "title": "Review & Submit",
+        "type": "review",
+        "sections": []
+      }
+    ]
+  }
+}

--- a/test-form/public/data/childcare_form.ht.json
+++ b/test-form/public/data/childcare_form.ht.json
@@ -1,0 +1,2287 @@
+{
+  "form": {
+    "title": "Childcare Voucher Application",
+    "description": "Step-by-step form for applying for Childcare Assistance",
+    "layout": {
+      "stepperPosition": "left"
+    },
+    "steps": [
+      {
+        "id": "consent_step",
+        "title": "Consent",
+        "sections": [
+          {
+            "id": "mycity_consent_info",
+            "title": "ModelCity Consent",
+            "type": "info",
+            "ui": {
+              "markdown": true,
+              "collapsible": false,
+              "defaultCollapsed": false
+            },
+            "content": "In connection with this application for child care services, **ModelCity**:\\n\\n- Collects, processes, stores, and shares the information you submit to screen you when you apply for child care services;\\n- Receives, processes, and stores the information the City already knows about you to screen you when you apply for child care services;\\n- Uses your information to improve ModelCity; and\\n- Communicates with you about your ModelCity account.\\n\\n---\\n\\nIf you consent, the following information may be shared between child care services agencies:\\n\\n- Demographic and background information, including address, phone number, household composition.\\n- Housing information, including benefits awarded/received, current housing/shelter status.\\n- Benefits information, including public assistance awarded/received, child care program participation.\\n\\n---\\n\\nIf you choose not to consent, **you will not be denied** any benefits or services you are receiving or any benefits for which you are eligible.\\n\\nThe [ModelCity Privacy Policy](https://www.nyc.gov/privacy) details how ModelCity handles the information you submit through ModelCity."
+          }
+        ]
+      },
+      {
+        "id": "instructions_step",
+        "title": "Instructions",
+        "sections": [
+          {
+            "id": "application_instructions",
+            "title": "Application Instructions",
+            "type": "info",
+            "ui": {
+              "markdown": true,
+              "collapsible": false,
+              "defaultCollapsed": false
+            },
+            "content": "**Let’s get started on your application!**\\n\\nTo complete this application, you will be asked for information about:\\n\\n- Yourself\\n- Your household\\n- Your employment or reason for care\\n- Your income\\n\\nAll required fields are marked and must be filled out to move forward with the application. The pages of the application are shown on the right-hand side of the screen and will be highlighted as you move through the application.\\n\\nYour application will be saved automatically as you progress to each page.  \\nIf you need to pause at any time, click the **“Save for later”** button at the bottom of each page to save your application.  \\nYou can log back in to resume your application.\\n\\nWhen you’re ready to begin, click **“Next”** below.\\n\\n---\\n\\n⚠️ **Important:**  \\nTo keep your information current and safe, applications in draft status that you have not edited for **30 days** will be deleted.  \\nIf your draft application is deleted, you can still create and submit a new application when you're ready to apply."
+          },
+          {
+            "id": "new_york_city_residency",
+            "title": "New York City Residency",
+            "type": "info",
+            "ui": {
+              "markdown": true,
+              "collapsible": true,
+              "defaultCollapsed": true
+            },
+            "content": "You will need to upload **ONE** of the following documents to confirm your NYC residency:\\n\\n- IDNYC\\n- Driver’s License\\n- Utility Bill (dated within the last 60 days, with your address)\\n- Current lease, rent, or mortgage statement (dated within the last 60 days, with your address)\\n- Section 8 Award Letter\\n- NYCHA Certificate\\n- CFWB-027 Housing Attestation with address listed\\n- Shelter Residency Letter with address listed\\n\\nIf you do not have any of those documents, you must submit a **CFWB-067 Residency Attestation**."
+          },
+          {
+            "id": "children_documents",
+            "title": "Children Documents",
+            "type": "info",
+            "ui": {
+              "markdown": true,
+              "collapsible": true,
+              "defaultCollapsed": true
+            },
+            "content": "### Citizenship or Immigration Status\\nThese documents confirm the citizenship or immigration status of the children in your family for whom you’re applying for child care assistance. Please upload one of the following documents for each child needing care. *Do not upload these documents for children who do not need care.*\\n\\n- Birth Certificate from US state or territory\\n- Alien Registration Card including Permanent Resident or Green Card\\n- Passport\\n- FS-240 (Consular Report of Birth Abroad)\\n- Naturalization Certificate\\n- Other documentation that proves child’s immigration status\\n\\n### Child's Relationship to Applicant\\nThese documents confirm your relationship to the children in your household under age 18. Please upload one of the following documents for every child in the household under age 18, regardless of whether they need child care.\\n\\n- Birth certificate\\n- Adoption record\\n- Baptismal record\\n- Passport with parent's signature\\n- Court order for legal guardian with financial responsibility\\n- Letter of guardianship\\n- Other - CFWB-058 Caretaker Attestation\\n\\nIf you are not the child's parent or stepparent, you must submit a **CFWB-058 Caretaker Attestation Form**.\\n\\n### Age of Children\\nYou will need to upload **ONE** of the following documents for every child in the household under age 18, regardless of whether child care is needed for them:\\n\\n- Birth certificate\\n- Adoption record\\n- Baptismal record\\n- Alien Registration Card\\n- Passport\\n- Official hospital documentation of the child’s birth"
+          },
+          {
+            "id": "employment_income",
+            "title": "Employment & Income",
+            "type": "info",
+            "ui": {
+              "markdown": true,
+              "collapsible": true,
+              "defaultCollapsed": true
+            },
+            "content": "### Income\\nThese documents confirm your family’s income.\\n\\n---\\n\\n### If You Are Employed\\nIf you are employed and receive paystubs, you must submit them to confirm your income. The number of paystubs you must submit varies by how often you get paid and whether your payment amount is the same or different each time you are paid – see the table below for details. Submit the most recent paystub you have received, followed by others in consecutive order.\\n\\n**Income Information**\\n\\n| How Often Do You Get Paid? | Always the SAME Amount | DIFFERENT Amounts Each Time |\\n|----------------------------|-------------------------|------------------------------|\\n| Weekly (Every Week) | 4 most recent, consecutive pay stubs | 12 most recent, consecutive pay stubs |\\n| Bi-Weekly (Every Two Weeks) | 2 most recent, consecutive pay stubs | 6 most recent, consecutive pay stubs |\\n| Semi-Monthly (Two Times Per Month) | 2 most recent, consecutive pay stubs | 6 most recent, consecutive pay stubs |\\n| Monthly (One Time Per Month) | 3 most recent, consecutive pay stubs | 3 most recent, consecutive pay stubs |\\n\\nIf you do not have any paystubs, you must submit a **CFWB-015 Referral to Employer for Employee Income Information Form**.\\n\\n---\\n\\n### If You Are Self-Employed\\nIf you have been self-employed for **one year or more**, you must submit a current, complete and signed income tax package (e.g., 1040, 1065, Schedule C, SE for partnership, K-1, etc.).\\n\\nIf you have been self-employed for **less than one year**, you must submit a **CFWB-031 Self-Employment Income Information Attestation Form**.\\n\\n---\\n\\n### Other Income\\nIf you receive other types of income outside or instead of employment income, you must submit your most recent check, pay stub, or current award letter that indicates the amount you receive. If your other income fluctuates, **3 months of documentation is required**.\\n\\nThis includes, but is not limited to:\\n- Income from SSI, SSD\\n- Unemployment benefits\\n- Rental income\\n- Pensions\\n- Annuities\\n- Worker’s compensation\\n- Alimony\\n- Child support"
+          },
+          {
+            "id": "reason_for_care",
+            "title": "Reason for Care",
+            "type": "info",
+            "ui": {
+              "markdown": true,
+              "collapsible": true,
+              "defaultCollapsed": true
+            },
+            "content": "### Reason for Care\\nThese documents confirm your reason for care. Every applicant must have a qualified reason for care; in a two-parent household, parents or caretakers can have the same or different reasons for care. Only the documents related to your stated reasons for care need to be uploaded, and documentation must be uploaded for all parent or caretakers in the household.\\n\\n---\\n\\n### Working 10+ Hours Per Week\\nYour employment or self-employment income documents will cover this reason for care. You do not need to submit additional documentation.\\n\\n---\\n\\n### Participating in an Educational or Vocational Training Program\\nYou will need to upload **ONE** of the following documents to confirm your participation in vocational school, two-year college, or four-year college.\\n\\n- CFWB-005 Vocational, Education and Training Verification Form\\n- A letter from the educational or vocational training program on their official letterhead; this letter must contain all the information required in the CFWB-005 Vocational, Education and Training Verification Form.\\n\\n---\\n\\n### Looking for Work\\nYou will need to upload **ONE** of the following documents to confirm that you are looking for work.\\n\\n- CFWB-026 Work Search Record Form\\n- Approved work search plan from the NYS Dept. of Labor\\n- Proof of receipt of unemployment insurance\\n\\n---\\n\\n### Experiencing Homelessness\\nYou will need to upload **ONE** of the following documents to confirm that you are experiencing homelessness. This includes families who may be living in shelter or sharing the housing of others due to loss of housing, economic hardship, or similar reason.\\n\\n- Shelter Residency Letter (If living in Shelter, including Humanitarian Emergency Relief Centers)\\n- CFWB-027 Housing Attestation (If living doubled-up, in a place not meant for human habitation, in a hotel/motel, or in another living situation)\\n\\n---\\n\\n### Attending Services for Domestic Violence\\nYou will need to upload a referral for services from a domestic violence service provider to confirm that you are attending services for domestic violence.\\n\\n---\\n\\n### Attending Services for Substance Abuse Treatment\\nYou will need to upload a referral for a substance abuse treatment service provider to confirm that you are attending services for substance abuse treatment."
+          },
+          {
+            "id": "additional_details",
+            "title": "Additional Details",
+            "type": "info",
+            "ui": {
+              "markdown": true,
+              "collapsible": true,
+              "defaultCollapsed": true
+            },
+            "content": "### Application Scope\\nThis application is used to apply **only** for **Category 2 or 3 child care assistance** (for families not in receipt of cash assistance). To apply for **Cash Assistance** or other benefits, including **Category 1 Child Care Assistance** (for families in receipt of cash assistance), you must use the **New York State Application for Certain Benefits and Services (LDSS-2921)**.\\n\\n---\\n\\n### Exempt Applicants\\nThe following applicants may be eligible for child care assistance **without regard to income** and do not need to complete this application:\\n\\n- Foster parents who need child care assistance to allow them to work and are only applying for assistance for the foster children;\\n- Families in receipt of protective or preventive services.\\n\\n---\\n\\n### Application Completion\\nAll sections of this form must be filled out to be considered complete **unless the section is identified as optional**. If you do not complete all required sections of this form, you may not be considered for Child Care Assistance.\\n\\n---\\n\\n### Rights and Responsibilities\\nYou may obtain information about your rights and responsibilities [here](https://otda.ny.gov/programs/applications/). If you do not have access to the internet, you can call the **Administration for Children’s Services at 212-835-7610** to request that physical copies of the booklets which highlight your rights and responsibilities be mailed to you, including:\\n\\n- **LDSS-4148A**: What You Should Know About Your Rights and Responsibilities\\n- **LDSS-4148B**: What You Should Know About Social Services Programs\\n- **LDSS-4148C**: What You Should Know If You Have an Emergency"
+          }
+        ]
+      },
+      {
+        "id": "applicant",
+        "title": "Applicant",
+        "sections": [
+          {
+            "id": "personal_info",
+            "title": "Personal Information",
+            "fields": [
+              {
+                "id": "first_name",
+                "label": "First Name",
+                "type": "text",
+                "required": true
+              },
+              {
+                "id": "last_name",
+                "label": "Last Name",
+                "type": "text",
+                "required": true
+              },
+              {
+                "id": "mi",
+                "label": "Middle Initial",
+                "type": "text",
+                "required": false
+              },
+              {
+                "id": "date_of_birth",
+                "label": "Date of Birth",
+                "type": "date",
+                "required": true,
+                "tooltip": "To edit Date of Birth click on NYC ModelCity in the top-left corner then click on Account Settings."
+              },
+              {
+                "id": "sex",
+                "label": "Sex",
+                "type": "radio",
+                "required": true,
+                "ui": {
+                  "options": [
+                    "Male",
+                    "Female"
+                  ]
+                }
+              },
+              {
+                "id": "marital_status",
+                "label": "Marital Status",
+                "type": "select",
+                "required": true,
+                "tooltip": "Indicate your marital status (single, married, divorced, separated or widowed).",
+                "ui": {
+                  "options": [
+                    "",
+                    "Single",
+                    "Married",
+                    "Divorced",
+                    "Widowed",
+                    "Separated"
+                  ]
+                }
+              }
+            ]
+          },
+          {
+            "id": "contact_info",
+            "title": "Contact Information",
+            "fields": [
+              {
+                "id": "telephone_home",
+                "label": "Home Phone",
+                "type": "tel",
+                "required": false,
+                "constraints": {
+                  "pattern": "^\\\\(?[0-9]{3}\\\\)?[-. ]?[0-9]{3}[-. ]?[0-9]{4}$"
+                },
+                "ui": {
+                  "placeholder": "(123) 456-7890"
+                }
+              },
+              {
+                "id": "telephone_work",
+                "label": "Work Phone",
+                "type": "tel",
+                "required": false,
+                "constraints": {
+                  "pattern": "^\\\\(?[0-9]{3}\\\\)?[-. ]?[0-9]{3}[-. ]?[0-9]{4}$"
+                },
+                "ui": {
+                  "placeholder": "(123) 456-7890"
+                }
+              },
+              {
+                "id": "telephone_mobile_or_other",
+                "label": "Mobile or Other Phone",
+                "type": "tel",
+                "required": false,
+                "tooltip": "To edit Telephone (Cell or Other) click on NYC ModelCity in the top-left corner then click on Account Settings and then click on Contact.",
+                "constraints": {
+                  "pattern": "^\\\\(?[0-9]{3}\\\\)?[-. ]?[0-9]{3}[-. ]?[0-9]{4}$"
+                },
+                "ui": {
+                  "placeholder": "(123) 456-7890"
+                }
+              },
+              {
+                "id": "email",
+                "label": "Email",
+                "type": "email",
+                "required": true,
+                "tooltip": "To edit email, go to NYC ID Profile tab by clicking your name at the top right corner"
+              }
+            ]
+          },
+          {
+            "id": "address_info",
+            "title": "Address",
+            "tooltip": "To edit home address click on NYC ModelCity in the top-left corner then click on Account Settings.",
+            "ui": {
+              "autocomplete": "street",
+              "placeholder": "Start typing your street address",
+              "overrideComponent": "AddressAutocomplete"
+            },
+            "metadata": {
+              "integration": {
+                "provider": "Google",
+                "feature": "AddressAutocomplete"
+              },
+              "autofillTargets": [
+                {
+                  "fieldId": "city",
+                  "source": "locality",
+                  "fallbackSources": [
+                    "postal_town",
+                    "sublocality_level_1",
+                    "administrative_area_level_2"
+                  ]
+                },
+                {
+                  "fieldId": "borough",
+                  "source": "sublocality_level_1",
+                  "fallbackSources": [
+                    "administrative_area_level_2"
+                  ],
+                  "mapping": "boroughMap"
+                },
+                { "fieldId": "state", "source": "administrative_area_level_1" },
+                { "fieldId": "zip_code", "source": "postal_code" },
+                { "fieldId": "latitude", "source": "location.latitude" },
+                { "fieldId": "longitude", "source": "location.longitude" }
+              ]
+            },
+            "fields": [
+              {
+                "id": "street",
+                "label": "Street Address",
+                "type": "text",
+                "required": true,
+                "tooltip": "To edit home address click on NYC ModelCity in the top-left corner then click on Account Settings."
+              },
+              {
+                "id": "apt",
+                "label": "Apt #",
+                "type": "text",
+                "required": false
+              },
+              {
+                "id": "city",
+                "label": "City",
+                "type": "text",
+                "required": true
+              },
+              {
+                "id": "borough",
+                "label": "Borough",
+                "type": "select",
+                "required": true,
+                "ui": {
+                  "options": [
+                    "",
+                    "Bronx",
+                    "Brooklyn",
+                    "Manhattan",
+                    "Queens",
+                    "Staten Island"
+                  ]
+                }
+              },
+              {
+                "id": "state",
+                "label": "State",
+                "type": "text",
+                "required": true
+              },
+              {
+                "id": "zip_code",
+                "label": "Zip Code",
+                "type": "text",
+                "required": true
+              },
+              {
+                "id": "latitude",
+                "label": "Latitude",
+                "type": "number",
+                "required": false
+              },
+              {
+                "id": "longitude",
+                "label": "Longitude",
+                "type": "number",
+                "required": false
+              },
+              {
+                "id": "is_temporary_address",
+                "label": "Is Temporary Address",
+                "type": "radio",
+                "required": true,
+                "tooltip": "Check YES if you are currently living in a homeless shelter, doubled-up with another family, in a hotel/motel, in a car/ bus/ train, in a park/campsite, or other temporary accomodation.",
+                "ui": {
+                  "options": [
+                    "Yes",
+                    "No"
+                  ]
+                }
+              },
+              {
+                "id": "currently_living_in",
+                "label": "Currently Living In",
+                "type": "select",
+                "required": false,
+                "requiredCondition": {
+                  "field": "is_temporary_address",
+                  "operator": "equals",
+                  "value": "Yes"
+                },
+                "ui": {
+                  "options": [
+                    "",
+                    "Homeless Shelter",
+                    "Doubled-up with another Family",
+                    "Hotel/Motel",
+                    "Car, Bus, Train",
+                    "Park",
+                    "Campsite",
+                    "Other"
+                  ]
+                }
+              }
+            ]
+          },
+          {
+            "id": "demographics",
+            "title": "Demographics",
+            "fields": [
+              {
+                "id": "ethnicity",
+                "label": "Ethnicity",
+                "type": "select",
+                "required": false,
+                "ui": {
+                  "options": [
+                    "",
+                    "Hispanic",
+                    "Latino",
+                    "No",
+                    "Prefer not to answer"
+                  ]
+                }
+              },
+              {
+                "id": "race",
+                "label": "Race",
+                "type": "checkbox",
+                "required": false,
+                "tooltip": "You may choose multiple race categories. Providing race information is voluntary and will not affect your eligibility for Child Care Assistance or the amount of assistance that you will be given by this agency.",
+                "ui": {
+                  "options": [
+                    {
+                      "value": "AI",
+                      "label": "American Indian or Alaska Native"
+                    },
+                    {
+                      "value": "AS",
+                      "label": "Asian"
+                    },
+                    {
+                      "value": "BL",
+                      "label": "Black or African American"
+                    },
+                    {
+                      "value": "HP",
+                      "label": "Native Hawaiian or Pacific Islander"
+                    },
+                    {
+                      "value": "WH",
+                      "label": "White"
+                    }
+                  ]
+                },
+                "metadata": {
+                  "multiple": true
+                }
+              },
+              {
+                "id": "ssn",
+                "label": "Social Security Number",
+                "type": "text",
+                "tooltip": "To edit social security number click on NYC ModelCity in the top-left corner then click on Account Settings.",
+                "required": false,
+                "constraints": {
+                  "pattern": "^\\\\d{3}-\\\\d{2}-\\\\d{4}$"
+                },
+                "ui": {
+                  "placeholder": "123-45-6789"
+                }
+              }
+            ]
+          },
+          {
+            "id": "language_info",
+            "title": "Language Preferences",
+            "fields": [
+              {
+                "id": "primary_language",
+                "label": "Primary Language",
+                "type": "radio",
+                "required": true,
+                "tooltip": "Select the language that is spoken most often in your household. If “other”, provide the name of the language.",
+                "ui": {
+                  "options": [
+                    "English",
+                    "Spanish",
+                    "Other"
+                  ]
+                }
+              },
+              {
+                "id": "preferred_language",
+                "label": "Preferred Language",
+                "type": "radio",
+                "required": true,
+                "tooltip": "Select the language you prefer to communicate in. If “other”, provide the name of the language.",
+                "ui": {
+                  "options": [
+                    "English",
+                    "Spanish",
+                    "Other"
+                  ]
+                }
+              },
+              {
+                "id": "other_primary_language",
+                "label": "Other Primary Language",
+                "type": "text",
+                "required": false,
+                "requiredCondition": {
+                  "field": "primary_language",
+                  "operator": "equals",
+                  "value": "Other"
+                }
+              },
+              {
+                "id": "other_preferred_language",
+                "label": "Other Preferred Language",
+                "type": "text",
+                "required": false,
+                "requiredCondition": {
+                  "field": "preferred_language",
+                  "operator": "equals",
+                  "value": "Other"
+                }
+              }
+            ]
+          },
+          {
+            "id": "cash_assistance",
+            "title": "Cash Assistance",
+            "fields": [
+              {
+                "id": "has_cash_assistance",
+                "label": "Do you receive Cash Assistance?",
+                "type": "radio",
+                "required": false,
+                "ui": {
+                  "options": [
+                    "Yes",
+                    "No"
+                  ]
+                }
+              },
+              {
+                "id": "ca_number",
+                "label": "Cash Assistance Number",
+                "type": "text",
+                "required": false,
+                "requiredCondition": {
+                  "condition": {
+                    "field": "has_cash_assistance",
+                    "operator": "equals",
+                    "value": "Yes"
+                  }
+                }
+              }
+            ]
+          }
+        ]
+      },
+      {
+        "id": "children_needing_care",
+        "title": "Children Needing Care",
+        "sections": [
+          {
+            "id": "child_details",
+            "title": "Child Details",
+            "required": true,
+            "fields": [
+              {
+                "id": "children",
+                "label": "Children Needing Care",
+                "type": "group",
+                "metadata": {
+                  "multiple": true,
+                  "tableColumns": [
+                  "first_name",
+                  "last_name",
+                  "date_of_birth",
+                  "relationship_to_applicant"
+                  ]
+                },
+                "fields": [
+                  {
+                    "id": "first_name",
+                    "label": "First Name",
+                    "type": "text",
+                    "required": true,
+                    "tooltip": "Provide the first name, last name, and middle initial of each child you are applying for child care assistance for."
+                  },
+                  {
+                    "id": "last_name",
+                    "label": "Last Name",
+                    "type": "text",
+                    "required": true
+                  },
+                  {
+                    "id": "mi",
+                    "label": "Middle Initial",
+                    "type": "text",
+                    "required": false
+                  },
+                  {
+                    "id": "relationship_to_applicant",
+                    "label": "Relationship to Applicant",
+                    "type": "select",
+                    "required": true,
+                    "ui": {
+                      "options": [
+                        "",
+                        "Child",
+                        "Grandchild",
+                        "Foster Child",
+                        "Other"
+                      ]
+                    }
+                  },
+                  {
+                    "id": "date_of_birth",
+                    "label": "Date of Birth",
+                    "type": "date",
+                    "required": true,
+                    "tooltip": "Provide the date of birth."
+                  },
+                  {
+                    "id": "sex",
+                    "label": "Sex",
+                    "type": "radio",
+                    "required": true,
+                    "tooltip": "Select to indicate the sex.",
+                    "ui": {
+                      "options": [
+                        "Male",
+                        "Female"
+                      ]
+                    }
+                  },
+                  {
+                    "id": "ethnicity",
+                    "label": "Ethnicity Hispanic or Latino",
+                    "type": "select",
+                    "required": false,
+                    "tooltip": "Check “YES” or “NO” to indicate if each child in need of child care is Hispanic or Latino or not. Providing ethnicity information is voluntary and will not affect your eligibility for child care assistance or the amount of assistance that you will be given by this agency.",
+                    "ui": {
+                      "options": [
+                        "",
+                        "Yes",
+                        "No",
+                        "Prefer not to answer"
+                      ]
+                    }
+                  },
+                  {
+                    "id": "race",
+                    "label": "Race",
+                    "type": "checkbox",
+                    "required": false,
+                    "tooltip": "You may choose multiple race categories for a single child. Providing race information is voluntary and will not affect your eligibility for Child Care Assistance or the amount of assistance that you will be given by this agency.",
+                    "ui": {
+                      "options": [
+                        {
+                          "value": "AI",
+                          "label": "American Indian or Alaska Native"
+                        },
+                        {
+                          "value": "AS",
+                          "label": "Asian"
+                        },
+                        {
+                          "value": "BL",
+                          "label": "Black or African American"
+                        },
+                        {
+                          "value": "HP",
+                          "label": "Native Hawaiian or Pacific Islander"
+                        },
+                        {
+                          "value": "WH",
+                          "label": "White"
+                        }
+                      ]
+                    },
+                    "metadata": {
+                      "multiple": true
+                    }
+                  },
+                  {
+                    "id": "ssn",
+                    "label": "Social Security Number",
+                    "type": "text",
+                    "required": false,
+                    "tooltip": "Provide each child’s Social Security Number (SSN). You are not required to provide SSNs. They may be used by federal, state, and local agencies to prevent duplication of services and fraud, and for Federal Reporting.",
+                    "constraints": {
+                      "pattern": "^\\\\d{3}-\\\\d{2}-\\\\d{4}$"
+                    },
+                    "ui": {
+                      "placeholder": "123-45-6789"
+                    }
+                  },
+                  {
+                    "id": "do_both_parents_reside_in_home",
+                    "label": "Do both parents reside in the home?",
+                    "type": "radio",
+                    "required": true,
+                    "tooltip": "Check “YES” or “NO” to indicate whether both of the child’s parents live in the home.",
+                    "ui": {
+                      "options": [
+                        "Yes",
+                        "No"
+                      ]
+                    }
+                  },
+                  {
+                    "id": "has_disability",
+                    "label": "Does the child have a disability?",
+                    "type": "radio",
+                    "required": true,
+                    "tooltip": "Check “YES” or “NO” to indicate whether the child needing child care has a disability.",
+                    "ui": {
+                      "options": [
+                        "Yes",
+                        "No"
+                      ]
+                    }
+                  },
+                  {
+                    "id": "is_immigration_status_satisfactory",
+                    "label": "Is child U.S. Citizen, U.S. National, or person with satisfactory immigration status?",
+                    "type": "radio",
+                    "required": true,
+                    "tooltip": "You will only be asked about the immigration status of the children in need of care. Other members of the family will not need to state or prove their immigration status. Your child will be eligible for care if they are a U.S. citizen, a legal permanent resident (green card holder), a refugee, or an asylee; have a T-visa; or hold another qualified immigration status. Please select “Yes” if your child holds one of these statuses.",
+                    "ui": {
+                      "options": [
+                        "Yes",
+                        "No"
+                      ]
+                    }
+                  }
+                ]
+              }
+            ]
+          }
+        ]
+      },
+      {
+        "id": "family_members",
+        "title": "Family Members",
+        "sections": [
+          {
+            "id": "household_members_info",
+            "title": "Household Members Information",
+            "type": "info",
+            "ui": {
+              "markdown": true,
+              "collapsible": false,
+              "defaultCollapsed": false
+            },
+            "content": "**List the household members who do _not_ need child care.**\\n\\nIf applicable, list:\\n\\n- Your **spouse**, your child’s **second parent**, **caretaker**, or **step-parent**\\n- Any other **adult with whom you share a child**, if they live in your home\\n\\nThen, if applicable, list:\\n\\n- Any **siblings under the age of 18** who live in your home\\n\\n> **Only list other household members** — such as **aunts, uncles, cousins, grandparents, or friends** — _if they have financial responsibility_ for the child.\\n\\nA household member with financial responsibility, other than a parent or step-parent, is one who has a **letter or order of guardianship**.\\n\\n**Otherwise, do not include them.**"
+          },
+          {
+            "id": "family_member_details",
+            "title": "Household Member Details",
+            "description": "Include household members who do not need child care assistance (e.g., spouse, partner, other children).",
+            "fields": [
+              {
+                "id": "familymember",
+                "label": "Family Members",
+                "type": "group",
+                "requiredCondition": {
+                  "repeatingGroup": "children",
+                  "operator": "ANY",
+                  "condition": { "field": "do_both_parents_reside_in_home", "operator": "equals", "value": "Yes" }
+                },  
+                "metadata": {
+                  "multiple": true,
+                  "tableColumns": [
+                    "first_name",
+                    "last_name",
+                    "relationship_to_applicant",
+                    "date_of_birth"
+                  ]
+                },
+                "fields": [
+                  {
+                    "id": "first_name",
+                    "label": "First Name",
+                    "type": "text",
+                    "required": true,
+                    "tooltip": "Provide last and first name, and middle initial if applicable."
+                  },
+                  {
+                    "id": "last_name",
+                    "label": "Last Name",
+                    "type": "text",
+                    "required": true
+                  },
+                  {
+                    "id": "mi",
+                    "label": "Middle Initial",
+                    "type": "text",
+                    "required": false
+                  },
+                  {
+                    "id": "relationship_to_applicant",
+                    "label": "Relationship to Applicant",
+                    "type": "select",
+                    "required": true,
+                    "tooltip": "Provide each person’s relationship to you (e.g. spouse, partner, child, foster parent, other).",
+                    "ui": {
+                      "options": [
+                        "",
+                        "Spouse",
+                        "Partner",
+                        "Foster Parent",
+                        "Child",
+                        "Other"
+                      ]
+                    }
+                  },
+                  {
+                    "id": "date_of_birth",
+                    "label": "Date of Birth",
+                    "type": "date",
+                    "required": true,
+                    "tooltip": "Provide the family member's date of birth."
+                  },
+                  {
+                    "id": "sex",
+                    "label": "Sex",
+                    "type": "radio",
+                    "required": true,
+                    "tooltip": "Indicate the sex for each family member listed.",
+                    "ui": {
+                      "options": [
+                        "Male",
+                        "Female"
+                      ]
+                    }
+                  },
+                  {
+                    "id": "ethnicity",
+                    "label": "Ethnicity Hispanic or Latino",
+                    "type": "select",
+                    "required": false,
+                    "tooltip": "Check “YES” or “NO” to indicate if each member in the household is Hispanic or Latino or not. Providing ethnicity information is voluntary and will not affect your eligibility for Child Care Assistance or the amount of assistance that you will be given by this agency.",
+                    "ui": {
+                      "options": [
+                        "",
+                        "Yes",
+                        "No",
+                        "Prefer not to answer"
+                      ]
+                    }
+                  },
+                  {
+                    "id": "race",
+                    "label": "Race",
+                    "type": "checkbox",
+                    "required": false,
+                    "tooltip": "You may choose multiple race categories for a single person. Providing race information is voluntary and will not affect your eligibility for Child Care Assistance or the amount of assistance that you will be given by this agency.",
+                    "ui": {
+                      "options": [
+                        {
+                          "value": "AI",
+                          "label": "American Indian or Alaska Native"
+                        },
+                        {
+                          "value": "AS",
+                          "label": "Asian"
+                        },
+                        {
+                          "value": "BL",
+                          "label": "Black or African American"
+                        },
+                        {
+                          "value": "HP",
+                          "label": "Native Hawaiian or Pacific Islander"
+                        },
+                        {
+                          "value": "WH",
+                          "label": "White"
+                        }
+                      ]
+                    },
+                    "metadata": {
+                      "multiple": true
+                    }
+                  },
+                  {
+                    "id": "ssn",
+                    "label": "Social Security Number",
+                    "type": "text",
+                    "required": false,
+                    "tooltip": "Fill in the Social Security Number (SSN) for your family members. SSN is optional. SSN may be used by federal, state, and local agencies to prevent duplication of services and fraud, and for Federal Reporting.",
+                    "constraints": {
+                      "pattern": "^\\\\d{3}-\\\\d{2}-\\\\d{4}$"
+                    },
+                    "ui": {
+                      "placeholder": "123-45-6789"
+                    }
+                  }
+                ]
+              }
+            ]
+          }
+        ]
+      },
+      {
+        "id": "child_family_needs",
+        "title": "Child / Family Needs",
+        "sections": [
+          {
+            "id": "assistance_reason",
+            "title": "Reason for Child Care Assistance",
+            "description": "Select one or two reasons you are requesting Child Care Assistance.",
+            "tooltip": "Select one reason. In a two-parent household, parents/caretakers can have the same or different reasons for needing child care. Both parents/caretakers will be required to submit documentation in support of their own reason. If you are living in temporary housing, please select Homelessness even if you have another reason that applies to you.",
+            "fields": [
+              {
+                "id": "assistance_reason",
+                "label": "Reason(s) for Assistance",
+                "type": "select",
+                "required": true,
+                "ui": {
+                  "options": [
+                    "",
+                    "Employment",
+                    "Looking for Work",
+                    "Vocational Training/Educational Activities",
+                    "Receiving Domestic Violence Services",
+                    "Homelessness"
+                  ]
+                },
+                "constraints": {
+                  "minSelections": 1,
+                  "maxSelections": 2
+                },
+                "metadata": {
+                  "multiple": true
+                }
+              }
+            ]
+          },
+          {
+            "id": "military_status",
+            "title": "Military and Parental Availability",
+            "description": "Provide information about parental military status and availability for child care.",
+            "fields": [
+              {
+                "id": "is_parent_currently_active_in_military",
+                "label": "Is a Parent Currently Active Full-Time in the U.S. Military?",
+                "tooltip": "Check “YES” or “NO” to indicate whether a parent is currently active full-time in the U.S. Military.",
+                "type": "radio",
+                "required": true,
+                "ui": {
+                  "options": [
+                    "Yes",
+                    "No"
+                  ]
+                }
+              },
+              {
+                "id": "is_parent_mem_of_guard_or_mru",
+                "label": "Is a Parent a Member of National Guard or Military Reserve Unit?",
+                "tooltip": "Check “YES” or “NO” to indicate whether a parent is currently a member of a National Guard or Military Reserve Unit.",
+                "type": "radio",
+                "required": true,
+                "ui": {
+                  "options": [
+                    "Yes",
+                    "No"
+                  ]
+                }
+              },
+              {
+                "id": "is_non_custodial_parent_available",
+                "label": "Is the Non-Custodial Parent Available to Provide Care?",
+                "tooltip": "Check “YES” or “NO” to indicate whether there is a non-custodial parent available to provide child care.",
+                "type": "radio",
+                "required": true,
+                "ui": {
+                  "options": [
+                    "Yes",
+                    "No"
+                  ]
+                }
+              }
+            ]
+          },
+          {
+            "id": "duplicate_application",
+            "title": "Other Applications",
+            "description": "Indicate if you are also applying for or receiving child care from other agencies.",
+            "tooltip": "Indicate whether you are currently receiving or have applied for child care assistance with one of the agencies or organizations listed below. Note: If you are receiving Cash Assistance and are interested in child care assistance, you must apply through the Human Resources Administration. Reach out to your Benefits Access Center or visit the Human Resources Administration webpage.",
+            "fields": [
+              {
+                "id": "duplicate_app",
+                "label": "Are You Receiving or Applying for Child Care Through Another Agency?",
+                "type": "select",
+                "required": false,
+                "ui": {
+                  "options": [
+                    "",
+                    "Not Applicable",
+                    "Department of Education (DOE)",
+                    "Human Resources Administration (HRA)",
+                    "Department of Youth and Community Development (DYCD)",
+                    "Department of Homeless Services (DHS)",
+                    "Consortium for Worker Education (CWE)",
+                    "Administration for Children's Services (ACS)"
+                  ]
+                }
+              }
+            ]
+          }
+        ]
+      },
+      {
+        "id": "employment",
+        "title": "Employment",
+        "sections": [
+          {
+            "id": "employment_precheck",
+            "title": "Tell us about your employment",
+            "description": "Tell us about your employment",
+            "fields": [
+              {
+                "id": "applicant_emp_income_indicator",
+                "label": "Does applicant earn any income/ wages from employment? ",
+                "type": "radio",
+                "required": false,
+                "ui": {
+                  "options": [
+                    "Yes",
+                    "No"
+                  ]
+                }
+              },
+              {
+                "id": "coparent_emp_income_indicator",
+                "label": "Does Coparent/2nd Guardian earn any income/ wages from employment? ",
+                "type": "radio",
+                "required": false,
+                "ui": {
+                  "options": [
+                    "Yes",
+                    "No"
+                  ]
+                }
+              }
+            ]
+          },
+          {
+            "id": "applicant_jobs",
+            "title": "Applicant Employment Information",
+            "description": "Enter details for up to two jobs held by the applicant.",
+            "visibilityCondition": {
+              "field": "applicant_emp_income_indicator",
+              "operator": "equals",
+              "value": "Yes"
+            },
+            "fields": [
+              {
+                "id": "applicant_1st_job_start_date",
+                "label": "1st Job - Start Date",
+                "type": "date",
+                "required": false,
+                "ui": {
+                  "group": "1st Job"
+                }
+              },
+              {
+                "id": "applicant_1st_job_rotating_shift",
+                "label": "1st Job - Has Rotating Shift?",
+                "type": "radio",
+                "required": false,
+                "ui": {
+                  "options": [
+                    "Yes",
+                    "No"
+                  ],
+                  "group": "1st Job"
+                }
+              },
+              {
+                "id": "applicant_1st_job_requires_overtime",
+                "label": "1st Job - Requires Overtime?",
+                "type": "radio",
+                "required": false,
+                "ui": {
+                  "options": [
+                    "Yes",
+                    "No"
+                  ],
+                  "group": "1st Job"
+                }
+              },
+              {
+                "id": "applicant_1st_job_employer_name",
+                "label": "1st Job - Employer Name",
+                "type": "text",
+                "required": false,
+                "ui": {
+                  "group": "1st Job"
+                }
+              },
+              {
+                "id": "applicant_1st_job_employer_phone",
+                "label": "1st Job - Employer Phone",
+                "type": "tel",
+                "required": false,
+                "ui": {
+                  "group": "1st Job"
+                }
+              },
+              {
+                "id": "applicant_1st_job_employer_street",
+                "label": "1st Job - Employer Street Address",
+                "type": "text",
+                "required": false,
+                "ui": {
+                  "group": "1st Job"
+                }
+              },
+              {
+                "id": "applicant_1st_job_employer_city",
+                "label": "1st Job - Employer City",
+                "type": "text",
+                "required": false,
+                "ui": {
+                  "group": "1st Job"
+                }
+              },
+              {
+                "id": "applicant_1st_job_employer_state",
+                "label": "1st Job - Employer State",
+                "type": "text",
+                "required": false,
+                "ui": {
+                  "group": "1st Job"
+                }
+              },
+              {
+                "id": "applicant_1st_job_employer_zipcode",
+                "label": "1st Job - Employer ZIP Code",
+                "type": "text",
+                "required": false,
+                "ui": {
+                  "group": "1st Job"
+                }
+              },
+              {
+                "id": "applicant_2nd_job_start_date",
+                "label": "2nd Job - Start Date",
+                "type": "date",
+                "required": false,
+                "ui": {
+                  "group": "2nd Job"
+                }
+              },
+              {
+                "id": "applicant_2nd_job_rotating_shift",
+                "label": "2nd Job - Has Rotating Shift?",
+                "type": "radio",
+                "required": false,
+                "ui": {
+                  "options": [
+                    "Yes",
+                    "No"
+                  ],
+                  "group": "2nd Job"
+                }
+              },
+              {
+                "id": "applicant_2nd_job_requires_overtime",
+                "label": "2nd Job - Requires Overtime?",
+                "type": "radio",
+                "required": false,
+                "ui": {
+                  "options": [
+                    "Yes",
+                    "No"
+                  ],
+                  "group": "2nd Job"
+                }
+              },
+              {
+                "id": "applicant_2nd_job_employer_name",
+                "label": "2nd Job - Employer Name",
+                "type": "text",
+                "required": false,
+                "ui": {
+                  "group": "2nd Job"
+                }
+              },
+              {
+                "id": "applicant_2nd_job_employer_phone",
+                "label": "2nd Job - Employer Phone",
+                "type": "tel",
+                "required": false,
+                "ui": {
+                  "group": "2nd Job"
+                }
+              },
+              {
+                "id": "applicant_2nd_job_employer_street",
+                "label": "2nd Job - Employer Street Address",
+                "type": "text",
+                "required": false,
+                "ui": {
+                  "group": "2nd Job"
+                }
+              },
+              {
+                "id": "applicant_2nd_job_employer_city",
+                "label": "2nd Job - Employer City",
+                "type": "text",
+                "required": false,
+                "ui": {
+                  "group": "2nd Job"
+                }
+              },
+              {
+                "id": "applicant_2nd_job_employer_state",
+                "label": "2nd Job - Employer State",
+                "type": "text",
+                "required": false,
+                "ui": {
+                  "group": "2nd Job"
+                }
+              },
+              {
+                "id": "applicant_2nd_job_employer_zipcode",
+                "label": "2nd Job - Employer ZIP Code",
+                "type": "text",
+                "required": false,
+                "ui": {
+                  "group": "2nd Job"
+                }
+              }
+            ]
+          },
+          {
+            "id": "second_parent_jobs",
+            "title": "Second Parent Employment Information",
+            "description": "Enter details for up to two jobs held by the second parent (if applicable).",
+            "visibilityCondition": {
+              "field": "coparent_emp_income_indicator",
+              "operator": "equals",
+              "value": "Yes"
+            },
+            "fields": [
+              {
+                "id": "second_parent_1st_job_start_date",
+                "label": "1st Job - Start Date",
+                "type": "date",
+                "required": false
+              },
+              {
+                "id": "second_parent_1st_job_rotating_shift",
+                "label": "1st Job - Has Rotating Shift?",
+                "type": "radio",
+                "required": false,
+                "ui": {
+                  "options": [
+                    "Yes",
+                    "No"
+                  ]
+                }
+              },
+              {
+                "id": "second_parent_1st_job_requires_overtime",
+                "label": "1st Job - Requires Overtime?",
+                "type": "radio",
+                "required": false,
+                "ui": {
+                  "options": [
+                    "Yes",
+                    "No"
+                  ]
+                }
+              },
+              {
+                "id": "second_parent_1st_job_employer_name",
+                "label": "1st Job - Employer Name",
+                "type": "text",
+                "required": false
+              },
+              {
+                "id": "second_parent_1st_job_employer_phone",
+                "label": "1st Job - Employer Phone",
+                "type": "tel",
+                "required": false
+              },
+              {
+                "id": "second_parent_1st_job_employer_street",
+                "label": "1st Job - Employer Street Address",
+                "type": "text",
+                "required": false
+              },
+              {
+                "id": "second_parent_1st_job_employer_city",
+                "label": "1st Job - Employer City",
+                "type": "text",
+                "required": false
+              },
+              {
+                "id": "second_parent_1st_job_employer_state",
+                "label": "1st Job - Employer State",
+                "type": "text",
+                "required": false
+              },
+              {
+                "id": "second_parent_1st_job_employer_zipcode",
+                "label": "1st Job - Employer ZIP Code",
+                "type": "text",
+                "required": false
+              },
+              {
+                "id": "second_parent_2nd_job_start_date",
+                "label": "2nd Job - Start Date",
+                "type": "date",
+                "required": false
+              },
+              {
+                "id": "second_parent_2nd_job_rotating_shift",
+                "label": "2nd Job - Has Rotating Shift?",
+                "type": "radio",
+                "required": false,
+                "ui": {
+                  "options": [
+                    "Yes",
+                    "No"
+                  ]
+                }
+              },
+              {
+                "id": "second_parent_2nd_job_requires_overtime",
+                "label": "2nd Job - Requires Overtime?",
+                "type": "radio",
+                "required": false,
+                "ui": {
+                  "options": [
+                    "Yes",
+                    "No"
+                  ]
+                }
+              },
+              {
+                "id": "second_parent_2nd_job_employer_name",
+                "label": "2nd Job - Employer Name",
+                "type": "text",
+                "required": false
+              },
+              {
+                "id": "second_parent_2nd_job_employer_phone",
+                "label": "2nd Job - Employer Phone",
+                "type": "tel",
+                "required": false
+              },
+              {
+                "id": "second_parent_2nd_job_employer_street",
+                "label": "2nd Job - Employer Street Address",
+                "type": "text",
+                "required": false
+              },
+              {
+                "id": "second_parent_2nd_job_employer_city",
+                "label": "2nd Job - Employer City",
+                "type": "text",
+                "required": false
+              },
+              {
+                "id": "second_parent_2nd_job_employer_state",
+                "label": "2nd Job - Employer State",
+                "type": "text",
+                "required": false
+              },
+              {
+                "id": "second_parent_2nd_job_employer_zipcode",
+                "label": "2nd Job - Employer ZIP Code",
+                "type": "text",
+                "required": false
+              }
+            ]
+          }
+        ]
+      },
+      {
+        "id": "schedule",
+        "title": "Work/Activity/Travel Time Schedule",
+        "sections": [
+          {
+            "id": "schedule_section_info",
+            "title": "Schedule Information",
+            "type": "info",
+            "ui": {
+              "markdown": true,
+              "collapsible": false,
+              "defaultCollapsed": false
+            },
+            "content": "Please indicate what days and hours you will need child care for based on your reason for care.\\n\\n- **Employed**: Indicate the hours you attend work\\n- **Educational or Vocational Program**: Indicate the hours you attend school or your program\\n- **Looking for Work**: Indicate the hours you spend looking for work\\n- **Homeless**: Indicate the hours you spend looking for housing\\n- **Attending Services for Domestic Violence**: Indicate the hours you attend services.\\n- **Attending Services for Substance Abuse Treatment**: Indicate the hours you attend services."
+          },
+          {
+            "id": "first_parent_activity_schedule",
+            "title": "First Parent Activity Schedule",
+            "description": "Enter the start and end times for each day of the week for the first parent's activities.",
+            "ui": {
+              "layout": "table",
+              "columns": [
+                "Start Time",
+                "End Time"
+              ],
+              "rowCopy": {
+                "enableUserPickSource": true,
+                "rowIdentifier": "ui.rowGroup",
+                "fieldsToCopy": [
+                  1,
+                  2
+                ],
+                "targetRowValues": [
+                  "Monday",
+                  "Tuesday",
+                  "Wednesday",
+                  "Thursday",
+                  "Friday"
+                ],
+                "copyControlLabel": "Apply selected schedule to other weekdays",
+                "sourceOptions": [
+                  "Monday",
+                  "Tuesday",
+                  "Wednesday",
+                  "Thursday",
+                  "Friday",
+                  "Saturday",
+                  "Sunday"
+                ]
+              }
+            },
+            "fields": [
+              {
+                "id": "fp_monday_from",
+                "label": "Monday From",
+                "type": "time",
+                "ui": {
+                  "rowGroup": "Monday",
+                  "column": 1
+                }
+              },
+              {
+                "id": "fp_monday_to",
+                "label": "Monday To",
+                "type": "time",
+                "ui": {
+                  "rowGroup": "Monday",
+                  "column": 2
+                }
+              },
+              {
+                "id": "fp_tuesday_from",
+                "label": "Tuesday From",
+                "type": "time",
+                "ui": {
+                  "rowGroup": "Tuesday",
+                  "column": 1
+                }
+              },
+              {
+                "id": "fp_tuesday_to",
+                "label": "Tuesday To",
+                "type": "time",
+                "ui": {
+                  "rowGroup": "Tuesday",
+                  "column": 2
+                }
+              },
+              {
+                "id": "fp_wednesday_from",
+                "label": "Wednesday From",
+                "type": "time",
+                "ui": {
+                  "rowGroup": "Wednesday",
+                  "column": 1
+                }
+              },
+              {
+                "id": "fp_wednesday_to",
+                "label": "Wednesday To",
+                "type": "time",
+                "ui": {
+                  "rowGroup": "Wednesday",
+                  "column": 2
+                }
+              },
+              {
+                "id": "fp_thursday_from",
+                "label": "Thursday From",
+                "type": "time",
+                "ui": {
+                  "rowGroup": "Thursday",
+                  "column": 1
+                }
+              },
+              {
+                "id": "fp_thursday_to",
+                "label": "Thursday To",
+                "type": "time",
+                "ui": {
+                  "rowGroup": "Thursday",
+                  "column": 2
+                }
+              },
+              {
+                "id": "fp_friday_from",
+                "label": "Friday From",
+                "type": "time",
+                "ui": {
+                  "rowGroup": "Friday",
+                  "column": 1
+                }
+              },
+              {
+                "id": "fp_friday_to",
+                "label": "Friday To",
+                "type": "time",
+                "ui": {
+                  "rowGroup": "Friday",
+                  "column": 2
+                }
+              },
+              {
+                "id": "fp_saturday_from",
+                "label": "Saturday From",
+                "type": "time",
+                "ui": {
+                  "rowGroup": "Saturday",
+                  "column": 1
+                }
+              },
+              {
+                "id": "fp_saturday_to",
+                "label": "Saturday To",
+                "type": "time",
+                "ui": {
+                  "rowGroup": "Saturday",
+                  "column": 2
+                }
+              },
+              {
+                "id": "fp_sunday_from",
+                "label": "Sunday From",
+                "type": "time",
+                "ui": {
+                  "rowGroup": "Sunday",
+                  "column": 1
+                }
+              },
+              {
+                "id": "fp_sunday_to",
+                "label": "Sunday To",
+                "type": "time",
+                "ui": {
+                  "rowGroup": "Sunday",
+                  "column": 2
+                }
+              }
+            ]
+          },
+          {
+            "id": "second_parent_activity_schedule",
+            "title": "Second Parent Activity Schedule",
+            "description": "Enter the start and end times for each day of the week for the second parent's activities.",
+            "ui": {
+              "layout": "table",
+              "columns": [
+                "Start Time",
+                "End Time"
+              ],
+              "rowCopy": {
+                "enableUserPickSource": true,
+                "rowIdentifier": "ui.rowGroup",
+                "fieldsToCopy": [
+                  1,
+                  2
+                ],
+                "targetRowValues": [
+                  "Monday",
+                  "Tuesday",
+                  "Wednesday",
+                  "Thursday",
+                  "Friday"
+                ],
+                "copyControlLabel": "Apply selected schedule to other weekdays",
+                "sourceOptions": [
+                  "Monday",
+                  "Tuesday",
+                  "Wednesday",
+                  "Thursday",
+                  "Friday",
+                  "Saturday",
+                  "Sunday"
+                ]
+              }
+            },
+            "fields": [
+              {
+                "id": "sp_monday_from",
+                "label": "Monday From",
+                "type": "time",
+                "ui": {
+                  "rowGroup": "Monday",
+                  "column": 1
+                }
+              },
+              {
+                "id": "sp_monday_to",
+                "label": "Monday To",
+                "type": "time",
+                "ui": {
+                  "rowGroup": "Monday",
+                  "column": 2
+                }
+              },
+              {
+                "id": "sp_tuesday_from",
+                "label": "Tuesday From",
+                "type": "time",
+                "ui": {
+                  "rowGroup": "Tuesday",
+                  "column": 1
+                }
+              },
+              {
+                "id": "sp_tuesday_to",
+                "label": "Tuesday To",
+                "type": "time",
+                "ui": {
+                  "rowGroup": "Tuesday",
+                  "column": 2
+                }
+              },
+              {
+                "id": "sp_wednesday_from",
+                "label": "Wednesday From",
+                "type": "time",
+                "ui": {
+                  "rowGroup": "Wednesday",
+                  "column": 1
+                }
+              },
+              {
+                "id": "sp_wednesday_to",
+                "label": "Wednesday To",
+                "type": "time",
+                "ui": {
+                  "rowGroup": "Wednesday",
+                  "column": 2
+                }
+              },
+              {
+                "id": "sp_thursday_from",
+                "label": "Thursday From",
+                "type": "time",
+                "ui": {
+                  "rowGroup": "Thursday",
+                  "column": 1
+                }
+              },
+              {
+                "id": "sp_thursday_to",
+                "label": "Thursday To",
+                "type": "time",
+                "ui": {
+                  "rowGroup": "Thursday",
+                  "column": 2
+                }
+              },
+              {
+                "id": "sp_friday_from",
+                "label": "Friday From",
+                "type": "time",
+                "ui": {
+                  "rowGroup": "Friday",
+                  "column": 1
+                }
+              },
+              {
+                "id": "sp_friday_to",
+                "label": "Friday To",
+                "type": "time",
+                "ui": {
+                  "rowGroup": "Friday",
+                  "column": 2
+                }
+              },
+              {
+                "id": "sp_saturday_from",
+                "label": "Saturday From",
+                "type": "time",
+                "ui": {
+                  "rowGroup": "Saturday",
+                  "column": 1
+                }
+              },
+              {
+                "id": "sp_saturday_to",
+                "label": "Saturday To",
+                "type": "time",
+                "ui": {
+                  "rowGroup": "Saturday",
+                  "column": 2
+                }
+              },
+              {
+                "id": "sp_sunday_from",
+                "label": "Sunday From",
+                "type": "time",
+                "ui": {
+                  "rowGroup": "Sunday",
+                  "column": 1
+                }
+              },
+              {
+                "id": "sp_sunday_to",
+                "label": "Sunday To",
+                "type": "time",
+                "ui": {
+                  "rowGroup": "Sunday",
+                  "column": 2
+                }
+              }
+            ]
+          },
+          {
+            "id": "first_parent_travel_time",
+            "title": "First Parent Travel Time",
+            "description": "Enter the travel times and method of transport for the first parent.",
+            "fields": [
+              {
+                "id": "fp_dropoff_travel_time",
+                "label": "Drop-off Travel Time",
+                "type": "select",
+                "tooltip": "Select your typical travel time from work/activity to your child care provider",
+                "ui": {
+                  "options": [
+                    "",
+                    "15 min",
+                    "30 min",
+                    "45 min",
+                    "1 hour",
+                    "More than 1 hour"
+                  ]
+                }
+              },
+              {
+                "id": "fp_dropoff_time_gt_1hr",
+                "label": "Drop-off Time (if > 1 hour)",
+                "type": "text",
+                "requiredCondition": {
+                  "field": "fp_dropoff_travel_time",
+                  "operator": "equals",
+                  "value": "More than 1 hour"
+                }
+              },
+              {
+                "id": "fp_pickup_travel_time",
+                "label": "Pick-up Travel Time",
+                "type": "select",
+                "tooltip": "Select your typical travel time from work/activity to your child care provider",
+                "ui": {
+                  "options": [
+                    "",
+                    "15 min",
+                    "30 min",
+                    "45 min",
+                    "1 hour",
+                    "More than 1 hour"
+                  ]
+                }
+              },
+              {
+                "id": "fp_pickup_time_gt_1hr",
+                "label": "Pick-up Time (if > 1 hour)",
+                "type": "text",
+                "requiredCondition": {
+                  "field": "fp_pickup_travel_time",
+                  "operator": "equals",
+                  "value": "More than 1 hour"
+                }
+              },
+              {
+                "id": "fp_public_transport_dropoff",
+                "label": "Public Transport for Drop-off?",
+                "type": "radio",
+                "tooltip": "Indicate if the applicant uses public transportation to travel to and from work/activity to provider.",
+                "ui": {
+                  "options": [
+                    "Yes",
+                    "No"
+                  ]
+                }
+              },
+              {
+                "id": "fp_public_transport_pickup",
+                "label": "Public Transport for Pick-up?",
+                "tooltip": "Indicate if the applicant uses public transportation to travel to and from work/activity to provider.",
+                "type": "radio",
+                "ui": {
+                  "options": [
+                    "Yes",
+                    "No"
+                  ]
+                }
+              }
+            ]
+          },
+          {
+            "id": "second_parent_travel_time",
+            "title": "Second Parent Travel Time",
+            "description": "Enter the travel times and method of transport for the second parent.",
+            "fields": [
+              {
+                "id": "sp_dropoff_travel_time",
+                "label": "Drop-off Travel Time",
+                "type": "select",
+                "ui": {
+                  "options": [
+                    "",
+                    "15 min",
+                    "30 min",
+                    "45 min",
+                    "1 hour",
+                    "More than 1 hour"
+                  ]
+                }
+              },
+              {
+                "id": "sp_pickup_travel_time",
+                "label": "Pick-up Travel Time",
+                "type": "select",
+                "ui": {
+                  "options": [
+                    "",
+                    "15 min",
+                    "30 min",
+                    "45 min",
+                    "1 hour",
+                    "More than 1 hour"
+                  ]
+                }
+              },
+              {
+                "id": "sp_dropoff_time_gt_1hr",
+                "label": "Drop-off Time (if > 1 hour)",
+                "type": "text",
+                "requiredCondition": {
+                  "field": "sp_dropoff_travel_time",
+                  "operator": "equals",
+                  "value": "More than 1 hour"
+                }
+              },
+              {
+                "id": "sp_pickup_time_gt_1hr",
+                "label": "Pick-up Time (if > 1 hour)",
+                "type": "text",
+                "requiredCondition": {
+                  "field": "sp_pickup_travel_time",
+                  "operator": "equals",
+                  "value": "More than 1 hour"
+                }
+              },
+              {
+                "id": "sp_public_transport_dropoff",
+                "label": "Public Transport for Drop-off?",
+                "type": "radio",
+                "ui": {
+                  "options": [
+                    "Yes",
+                    "No"
+                  ]
+                }
+              },
+              {
+                "id": "sp_public_transport_pickup",
+                "label": "Public Transport for Pick-up?",
+                "type": "radio",
+                "ui": {
+                  "options": [
+                    "Yes",
+                    "No"
+                  ]
+                }
+              }
+            ]
+          }
+        ]
+      },
+      {
+        "id": "income",
+        "title": "Income Information",
+        "sections": [
+          {
+            "id": "income_step_info",
+            "title": "Instructions",
+            "type": "info",
+            "ui": {
+              "markdown": true,
+              "collapsible": false,
+              "defaultCollapsed": false
+            },
+            "content": "Please include income/benefits information for yourself and, if applicable, your spouse, your child’s second caretaker, and/or any other adult with whom you share a child, if they live in your home.\\n\\nIndicate if you receive money from the following sources by selecting “Yes” or “No.” If you select “Yes,” you will be asked for additional information.\\n\\nIf the second caretaker in the household also receives the same income source, add a separate line for their income."
+          },
+          {
+            "id": "income_sources",
+            "title": "Income Sources",
+            "description": "Provide details about all income sources applicable to the applicant or household.",
+            "fields": [
+              {
+                "id": "income_sources",
+                "label": "List of Income Sources",
+                "type": "group",
+                "metadata": {
+                  "multiple": true,
+                  "tableColumns": [
+                    "name_ref",
+                    "how_often",
+                    "recipient",
+                    "monthly_amount"
+                  ]
+                },
+                "fields": [
+                  {
+                    "id": "name_ref",
+                    "label": "Income Source Type",
+                    "type": "select",
+                    "required": true,
+                    "ui": {
+                      "options": [
+                        "",
+                        "ApplicantWages",
+                        "SecondParentWages",
+                        "SelfEmployment",
+                        "ChildSupport",
+                        "Alimony",
+                        "Unemployment",
+                        "SocialSecurity",
+                        "Disability",
+                        "Rental",
+                        "Dividends",
+                        "Retirement",
+                        "CashAssistance",
+                        "Other"
+                      ]
+                    }
+                  },
+                  {
+                    "id": "other_source_text",
+                    "label": "Other Source (If applicable)",
+                    "type": "text",
+                    "visibilityCondition": {
+                      "field": "name_ref",
+                      "operator": "equals",
+                      "value": "Other"
+                    },
+                    "requiredCondition": {
+                      "condition": {
+                        "field": "name_ref",
+                        "operator": "equals",
+                        "value": "Other"
+                      }
+                    }
+                  },
+                  {
+                    "id": "is_source_applicable",
+                    "label": "Is this Source Applicable?",
+                    "type": "radio",
+                    "required": true,
+                    "ui": {
+                      "options": [
+                        "Yes",
+                        "No"
+                      ]
+                    }
+                  },
+                  {
+                    "id": "gross_amount",
+                    "label": "Gross Amount ($)",
+                    "type": "number",
+                    "required": true
+                  },
+                  {
+                    "id": "how_often",
+                    "label": "Frequency of Income",
+                    "type": "radio",
+                    "required": true,
+                    "ui": {
+                      "options": [
+                        "Weekly",
+                        "Bi-weekly",
+                        "Monthly",
+                        "Other"
+                      ]
+                    }
+                  },
+                  {
+                    "id": "recipient",
+                    "label": "Recipient of Income",
+                    "type": "text",
+                    "required": true
+                  },
+                  {
+                    "id": "monthly_amount",
+                    "label": "Monthly Amount ($)",
+                    "type": "number",
+                    "required": true
+                  }
+                ]
+              }
+            ]
+          },
+          {
+            "id": "total_income",
+            "title": "Total Household Income",
+            "description": "Sum of all monthly income across sources.",
+            "fields": [
+              {
+                "id": "total_income",
+                "label": "Total Monthly Income ($)",
+                "type": "number",
+                "required": true
+              }
+            ]
+          },
+          {
+            "id": "income_proof_section",
+            "title": "Income Proof",
+            "fields": [
+              {
+                "id": "income_proof",
+                "label": "Upload Income Proof",
+                "type": "file",
+                "requiredCondition": {
+                  "condition": {
+                    "field": "assistance_reason",
+                    "operator": "includes",
+                    "value": "Employment"
+                  }
+                },
+                "constraints": {
+                  "maxFileSizeMB": 5,
+                  "allowedTypes": [
+                    "application/pdf",
+                    "image/jpeg"
+                  ],
+                  "imageResolution": {
+                    "minWidth": 800,
+                    "minHeight": 600
+                  }
+                },
+                "metadata": {
+                  "proofCategory": "Income Verification",
+                  "examples": [
+                    "Pay Stub",
+                    "W-2"
+                  ],
+                  "multiple": true
+                }
+              }
+            ]
+          }
+        ]
+      },
+      {
+        "id": "provider",
+        "title": "Provider",
+        "sections": [
+          {
+            "id": "provider_step_info",
+            "title": "Instructions",
+            "type": "info",
+            "ui": {
+              "markdown": true,
+              "collapsible": false,
+              "defaultCollapsed": false
+            },
+            "content": "If you are found eligible for child care assistance, you can choose center-based or home-based care from a licensed, registered, or legally exempt provider. If you choose a provider that is not licensed or registered, the provider must be enrolled as a legally exempt provider.\\n\\nIf you know which child care providers you would like your child to attend, provide the names and addresses of your choice of providers. You can leave this section blank if you do not know (it will not impact your eligibility and you will have an opportunity to select a provider if determined eligible)."
+          },
+          {
+            "id": "provider_choices",
+            "title": "Provider Choices",
+            "description": "Specify details of the provider where you intend to enroll the child(ren).",
+            "fields": [
+              {
+                "id": "provider_choices",
+                "label": "List of Providers",
+                "type": "group",
+                "metadata": {
+                  "multiple": true,
+                  "tableColumns": [
+                    "provider_name",
+                    "program_number",
+                    "provider_zip_code"
+                  ]
+                },
+                "fields": [
+                  {
+                    "id": "provider_name",
+                    "label": "Provider Name",
+                    "type": "text",
+                    "required": true
+                  },
+                  {
+                    "id": "program_number",
+                    "label": "Program Number (If Applicable)",
+                    "type": "text",
+                    "required": false
+                  },
+                  {
+                    "id": "provider_street",
+                    "label": "Street Address",
+                    "type": "text",
+                    "required": true
+                  },
+                  {
+                    "id": "provider_city",
+                    "label": "City",
+                    "type": "text",
+                    "required": true
+                  },
+                  {
+                    "id": "provider_state",
+                    "label": "State",
+                    "type": "text",
+                    "required": true
+                  },
+                  {
+                    "id": "provider_zip_code",
+                    "label": "Zip Code",
+                    "type": "text",
+                    "required": true
+                  }
+                ]
+              }
+            ]
+          }
+        ]
+      },
+      {
+        "id": "document_upload_step",
+        "title": "Document Upload",
+        "description": "The Application for Child Care Assistance (CFWB-012) must include supporting documentation. Check to ensure that documentation is provided for each requirement of subsidy eligibility.",
+        "sections": [
+          {
+            "id": "nyc_residency",
+            "title": "New York City Residency",
+            "description": "These documents confirm that you live in New York City. Please upload one of the following documents.",
+            "fields": [
+              {
+                "id": "nyc_residency_type",
+                "label": "Select one of the following:",
+                "type": "radio",
+                "required": true,
+                "ui": {
+                  "options": [
+                    "IDNYC",
+                    "Utility Bill",
+                    "Section 8 Award Letter",
+                    "Driver’s License",
+                    "Rent Receipt",
+                    "NYCHA Certificate",
+                    "CFWB-067 Residency Attestation",
+                    "CFWB-027 Housing Attestation with address listed",
+                    "Shelter Residency Letter with address listed",
+                    "Other"
+                  ]
+                }
+              },
+              {
+                "id": "nyc_residency_file",
+                "label": "Upload Residency Proof Document",
+                "description": "To add a document to your application, you can upload an image or scanned file from your phone or device. Accepted formats include .pdf, .gif, .jpeg, .jpg and .png up to 25 MB. Learn how to upload your files with this Tutorial Video.",
+                "type": "file",
+                "required": true, 
+                "constraints": {
+                  "maxFileSizeMB": 25,
+                  "allowedTypes": [
+                    "application/pdf",
+                    "image/jpeg",
+                    "image/jpg",
+                    "image/png",
+                    "image/gif"
+                  ]
+                },
+                "metadata": {
+                  "proofCategory": "NYC Residency",
+                  "multiple": false
+                }
+              }
+            ]
+          },
+          {
+            "id": "citizenship_status",
+            "title": "Citizenship or Immigration Status",
+            "description": "These documents confirm the citizenship/immigration status of the children in your family for whom you’re applying for child care assistance. Please upload one of the following documents for ONLY each child needing care.",
+            "fields": [
+              {
+                "id": "citizenship_doc_type",
+                "label": "Select one of the following:",
+                "type": "radio",
+                "required": true,
+                "ui": {
+                  "options": [
+                    "US Birth Certificate",
+                    "Alien Registration Card including Permanent Resident or Green Card",
+                    "Passport",
+                    "FS-240 (Report of Birth Abroad of a U.S. Citizen)",
+                    "Naturalization Certificate",
+                    "Other"
+                  ]
+                }
+              },
+              {
+                "id": "citizenship_doc_file",
+                "label": "Upload Citizenship/Immigration Document",
+                "description": "To add a document to your application, you can upload an image or scanned file from your phone or device. Accepted formats include .pdf, .gif, .jpeg, .jpg and .png up to 25 MB. Learn how to upload your files with this Tutorial Video.",
+                "type": "file",
+                "required": true,
+                "constraints": {
+                  "maxFileSizeMB": 25,
+                  "allowedTypes": [
+                    "application/pdf",
+                    "image/jpeg",
+                    "image/jpg",
+                    "image/png",
+                    "image/gif"
+                  ]
+                },
+                "metadata": {
+                  "proofCategory": "Citizenship/Immigration Status",
+                  "multiple": false
+                }
+              }
+            ]
+          },
+          {
+            "id": "child_relationship",
+            "title": "Child’s Relationship to Parent/Applicant",
+            "description": "These documents confirm your relationship to the children in your household under age 18. Please upload one of the following documents for every child in the household under age 18, regardless of whether child care is needed for them or not. If you are a legal guardian with financial responsibility, you must upload a Court order OR a letter of guardianship.",
+            "fields": [
+              {
+                "id": "relationship_doc_type",
+                "label": "Select one of the following:",
+                "type": "radio",
+                "required": true,
+                "ui": {
+                  "options": [
+                    "Birth Certificate",
+                    "Adoption record",
+                    "Baptismal record",
+                    "Passport with parent's signature",
+                    "Court order for legal guardian with financial responsibility",
+                    "Letter of Guardianship",
+                    "Other - CFWB-058 Caretaker Attestation"
+                  ]
+                }
+              },
+              {
+                "id": "relationship_doc_file",
+                "label": "Upload Relationship Document",
+                "description": "To add a document to your application, you can upload an image or scanned file from your phone or device. Accepted formats include .pdf, .gif, .jpeg, .jpg and .png up to 25 MB. Learn how to upload your files with this Tutorial Video.",
+                "type": "file",
+                "required": true,
+                "constraints": {
+                  "maxFileSizeMB": 25,
+                  "allowedTypes": [
+                    "application/pdf",
+                    "image/jpeg",
+                    "image/jpg",
+                    "image/png",
+                    "image/gif"
+                  ]
+                },
+                "metadata": {
+                  "proofCategory": "Child Relationship",
+                  "multiple": false
+                }
+              }
+            ]
+          },
+          {
+            "id": "age_proof",
+            "title": "Age",
+            "description": "These documents confirm the age of the children in your household. Please upload one of the following documents for every child in the household under age 18, regardless of whether child care is needed for them:",
+            "fields": [
+              {
+                "id": "age_doc_type",
+                "label": "Select one of the following:",
+                "type": "radio",
+                "required": true,
+                "ui": {
+                  "options": [
+                    "Birth Certificate",
+                    "Adoption record",
+                    "Baptismal record",
+                    "Alien Registration Card",
+                    "Passport",
+                    "Official hospital documentation of the child’s birth"
+                  ]
+                }
+              },
+              {
+                "id": "age_doc_file",
+                "label": "Upload Age Proof Document",
+                "description": "To add a document to your application, you can upload an image or scanned file from your phone or device. Accepted formats include .pdf, .gif, .jpeg, .jpg and .png up to 25 MB. Learn how to upload your files with this Tutorial Video.",
+                "type": "file",
+                "required": true,
+                "constraints": {
+                  "maxFileSizeMB": 25,
+                  "allowedTypes": [
+                    "application/pdf",
+                    "image/jpeg",
+                    "image/jpg",
+                    "image/png",
+                    "image/gif"
+                  ]
+                },
+                "metadata": {
+                  "proofCategory": "Child Age",
+                  "multiple": false
+                }
+              }
+            ]
+          }
+        ]
+      },
+      {
+        "id": "review",
+        "title": "Review & Submit",
+        "type": "review",
+        "sections": []
+      }
+    ]
+  }
+}

--- a/test-form/public/data/childcare_form.ko.json
+++ b/test-form/public/data/childcare_form.ko.json
@@ -1,0 +1,2287 @@
+{
+  "form": {
+    "title": "Childcare Voucher Application",
+    "description": "Step-by-step form for applying for Childcare Assistance",
+    "layout": {
+      "stepperPosition": "left"
+    },
+    "steps": [
+      {
+        "id": "consent_step",
+        "title": "Consent",
+        "sections": [
+          {
+            "id": "mycity_consent_info",
+            "title": "ModelCity Consent",
+            "type": "info",
+            "ui": {
+              "markdown": true,
+              "collapsible": false,
+              "defaultCollapsed": false
+            },
+            "content": "In connection with this application for child care services, **ModelCity**:\\n\\n- Collects, processes, stores, and shares the information you submit to screen you when you apply for child care services;\\n- Receives, processes, and stores the information the City already knows about you to screen you when you apply for child care services;\\n- Uses your information to improve ModelCity; and\\n- Communicates with you about your ModelCity account.\\n\\n---\\n\\nIf you consent, the following information may be shared between child care services agencies:\\n\\n- Demographic and background information, including address, phone number, household composition.\\n- Housing information, including benefits awarded/received, current housing/shelter status.\\n- Benefits information, including public assistance awarded/received, child care program participation.\\n\\n---\\n\\nIf you choose not to consent, **you will not be denied** any benefits or services you are receiving or any benefits for which you are eligible.\\n\\nThe [ModelCity Privacy Policy](https://www.nyc.gov/privacy) details how ModelCity handles the information you submit through ModelCity."
+          }
+        ]
+      },
+      {
+        "id": "instructions_step",
+        "title": "Instructions",
+        "sections": [
+          {
+            "id": "application_instructions",
+            "title": "Application Instructions",
+            "type": "info",
+            "ui": {
+              "markdown": true,
+              "collapsible": false,
+              "defaultCollapsed": false
+            },
+            "content": "**Let’s get started on your application!**\\n\\nTo complete this application, you will be asked for information about:\\n\\n- Yourself\\n- Your household\\n- Your employment or reason for care\\n- Your income\\n\\nAll required fields are marked and must be filled out to move forward with the application. The pages of the application are shown on the right-hand side of the screen and will be highlighted as you move through the application.\\n\\nYour application will be saved automatically as you progress to each page.  \\nIf you need to pause at any time, click the **“Save for later”** button at the bottom of each page to save your application.  \\nYou can log back in to resume your application.\\n\\nWhen you’re ready to begin, click **“Next”** below.\\n\\n---\\n\\n⚠️ **Important:**  \\nTo keep your information current and safe, applications in draft status that you have not edited for **30 days** will be deleted.  \\nIf your draft application is deleted, you can still create and submit a new application when you're ready to apply."
+          },
+          {
+            "id": "new_york_city_residency",
+            "title": "New York City Residency",
+            "type": "info",
+            "ui": {
+              "markdown": true,
+              "collapsible": true,
+              "defaultCollapsed": true
+            },
+            "content": "You will need to upload **ONE** of the following documents to confirm your NYC residency:\\n\\n- IDNYC\\n- Driver’s License\\n- Utility Bill (dated within the last 60 days, with your address)\\n- Current lease, rent, or mortgage statement (dated within the last 60 days, with your address)\\n- Section 8 Award Letter\\n- NYCHA Certificate\\n- CFWB-027 Housing Attestation with address listed\\n- Shelter Residency Letter with address listed\\n\\nIf you do not have any of those documents, you must submit a **CFWB-067 Residency Attestation**."
+          },
+          {
+            "id": "children_documents",
+            "title": "Children Documents",
+            "type": "info",
+            "ui": {
+              "markdown": true,
+              "collapsible": true,
+              "defaultCollapsed": true
+            },
+            "content": "### Citizenship or Immigration Status\\nThese documents confirm the citizenship or immigration status of the children in your family for whom you’re applying for child care assistance. Please upload one of the following documents for each child needing care. *Do not upload these documents for children who do not need care.*\\n\\n- Birth Certificate from US state or territory\\n- Alien Registration Card including Permanent Resident or Green Card\\n- Passport\\n- FS-240 (Consular Report of Birth Abroad)\\n- Naturalization Certificate\\n- Other documentation that proves child’s immigration status\\n\\n### Child's Relationship to Applicant\\nThese documents confirm your relationship to the children in your household under age 18. Please upload one of the following documents for every child in the household under age 18, regardless of whether they need child care.\\n\\n- Birth certificate\\n- Adoption record\\n- Baptismal record\\n- Passport with parent's signature\\n- Court order for legal guardian with financial responsibility\\n- Letter of guardianship\\n- Other - CFWB-058 Caretaker Attestation\\n\\nIf you are not the child's parent or stepparent, you must submit a **CFWB-058 Caretaker Attestation Form**.\\n\\n### Age of Children\\nYou will need to upload **ONE** of the following documents for every child in the household under age 18, regardless of whether child care is needed for them:\\n\\n- Birth certificate\\n- Adoption record\\n- Baptismal record\\n- Alien Registration Card\\n- Passport\\n- Official hospital documentation of the child’s birth"
+          },
+          {
+            "id": "employment_income",
+            "title": "Employment & Income",
+            "type": "info",
+            "ui": {
+              "markdown": true,
+              "collapsible": true,
+              "defaultCollapsed": true
+            },
+            "content": "### Income\\nThese documents confirm your family’s income.\\n\\n---\\n\\n### If You Are Employed\\nIf you are employed and receive paystubs, you must submit them to confirm your income. The number of paystubs you must submit varies by how often you get paid and whether your payment amount is the same or different each time you are paid – see the table below for details. Submit the most recent paystub you have received, followed by others in consecutive order.\\n\\n**Income Information**\\n\\n| How Often Do You Get Paid? | Always the SAME Amount | DIFFERENT Amounts Each Time |\\n|----------------------------|-------------------------|------------------------------|\\n| Weekly (Every Week) | 4 most recent, consecutive pay stubs | 12 most recent, consecutive pay stubs |\\n| Bi-Weekly (Every Two Weeks) | 2 most recent, consecutive pay stubs | 6 most recent, consecutive pay stubs |\\n| Semi-Monthly (Two Times Per Month) | 2 most recent, consecutive pay stubs | 6 most recent, consecutive pay stubs |\\n| Monthly (One Time Per Month) | 3 most recent, consecutive pay stubs | 3 most recent, consecutive pay stubs |\\n\\nIf you do not have any paystubs, you must submit a **CFWB-015 Referral to Employer for Employee Income Information Form**.\\n\\n---\\n\\n### If You Are Self-Employed\\nIf you have been self-employed for **one year or more**, you must submit a current, complete and signed income tax package (e.g., 1040, 1065, Schedule C, SE for partnership, K-1, etc.).\\n\\nIf you have been self-employed for **less than one year**, you must submit a **CFWB-031 Self-Employment Income Information Attestation Form**.\\n\\n---\\n\\n### Other Income\\nIf you receive other types of income outside or instead of employment income, you must submit your most recent check, pay stub, or current award letter that indicates the amount you receive. If your other income fluctuates, **3 months of documentation is required**.\\n\\nThis includes, but is not limited to:\\n- Income from SSI, SSD\\n- Unemployment benefits\\n- Rental income\\n- Pensions\\n- Annuities\\n- Worker’s compensation\\n- Alimony\\n- Child support"
+          },
+          {
+            "id": "reason_for_care",
+            "title": "Reason for Care",
+            "type": "info",
+            "ui": {
+              "markdown": true,
+              "collapsible": true,
+              "defaultCollapsed": true
+            },
+            "content": "### Reason for Care\\nThese documents confirm your reason for care. Every applicant must have a qualified reason for care; in a two-parent household, parents or caretakers can have the same or different reasons for care. Only the documents related to your stated reasons for care need to be uploaded, and documentation must be uploaded for all parent or caretakers in the household.\\n\\n---\\n\\n### Working 10+ Hours Per Week\\nYour employment or self-employment income documents will cover this reason for care. You do not need to submit additional documentation.\\n\\n---\\n\\n### Participating in an Educational or Vocational Training Program\\nYou will need to upload **ONE** of the following documents to confirm your participation in vocational school, two-year college, or four-year college.\\n\\n- CFWB-005 Vocational, Education and Training Verification Form\\n- A letter from the educational or vocational training program on their official letterhead; this letter must contain all the information required in the CFWB-005 Vocational, Education and Training Verification Form.\\n\\n---\\n\\n### Looking for Work\\nYou will need to upload **ONE** of the following documents to confirm that you are looking for work.\\n\\n- CFWB-026 Work Search Record Form\\n- Approved work search plan from the NYS Dept. of Labor\\n- Proof of receipt of unemployment insurance\\n\\n---\\n\\n### Experiencing Homelessness\\nYou will need to upload **ONE** of the following documents to confirm that you are experiencing homelessness. This includes families who may be living in shelter or sharing the housing of others due to loss of housing, economic hardship, or similar reason.\\n\\n- Shelter Residency Letter (If living in Shelter, including Humanitarian Emergency Relief Centers)\\n- CFWB-027 Housing Attestation (If living doubled-up, in a place not meant for human habitation, in a hotel/motel, or in another living situation)\\n\\n---\\n\\n### Attending Services for Domestic Violence\\nYou will need to upload a referral for services from a domestic violence service provider to confirm that you are attending services for domestic violence.\\n\\n---\\n\\n### Attending Services for Substance Abuse Treatment\\nYou will need to upload a referral for a substance abuse treatment service provider to confirm that you are attending services for substance abuse treatment."
+          },
+          {
+            "id": "additional_details",
+            "title": "Additional Details",
+            "type": "info",
+            "ui": {
+              "markdown": true,
+              "collapsible": true,
+              "defaultCollapsed": true
+            },
+            "content": "### Application Scope\\nThis application is used to apply **only** for **Category 2 or 3 child care assistance** (for families not in receipt of cash assistance). To apply for **Cash Assistance** or other benefits, including **Category 1 Child Care Assistance** (for families in receipt of cash assistance), you must use the **New York State Application for Certain Benefits and Services (LDSS-2921)**.\\n\\n---\\n\\n### Exempt Applicants\\nThe following applicants may be eligible for child care assistance **without regard to income** and do not need to complete this application:\\n\\n- Foster parents who need child care assistance to allow them to work and are only applying for assistance for the foster children;\\n- Families in receipt of protective or preventive services.\\n\\n---\\n\\n### Application Completion\\nAll sections of this form must be filled out to be considered complete **unless the section is identified as optional**. If you do not complete all required sections of this form, you may not be considered for Child Care Assistance.\\n\\n---\\n\\n### Rights and Responsibilities\\nYou may obtain information about your rights and responsibilities [here](https://otda.ny.gov/programs/applications/). If you do not have access to the internet, you can call the **Administration for Children’s Services at 212-835-7610** to request that physical copies of the booklets which highlight your rights and responsibilities be mailed to you, including:\\n\\n- **LDSS-4148A**: What You Should Know About Your Rights and Responsibilities\\n- **LDSS-4148B**: What You Should Know About Social Services Programs\\n- **LDSS-4148C**: What You Should Know If You Have an Emergency"
+          }
+        ]
+      },
+      {
+        "id": "applicant",
+        "title": "Applicant",
+        "sections": [
+          {
+            "id": "personal_info",
+            "title": "Personal Information",
+            "fields": [
+              {
+                "id": "first_name",
+                "label": "First Name",
+                "type": "text",
+                "required": true
+              },
+              {
+                "id": "last_name",
+                "label": "Last Name",
+                "type": "text",
+                "required": true
+              },
+              {
+                "id": "mi",
+                "label": "Middle Initial",
+                "type": "text",
+                "required": false
+              },
+              {
+                "id": "date_of_birth",
+                "label": "Date of Birth",
+                "type": "date",
+                "required": true,
+                "tooltip": "To edit Date of Birth click on NYC ModelCity in the top-left corner then click on Account Settings."
+              },
+              {
+                "id": "sex",
+                "label": "Sex",
+                "type": "radio",
+                "required": true,
+                "ui": {
+                  "options": [
+                    "Male",
+                    "Female"
+                  ]
+                }
+              },
+              {
+                "id": "marital_status",
+                "label": "Marital Status",
+                "type": "select",
+                "required": true,
+                "tooltip": "Indicate your marital status (single, married, divorced, separated or widowed).",
+                "ui": {
+                  "options": [
+                    "",
+                    "Single",
+                    "Married",
+                    "Divorced",
+                    "Widowed",
+                    "Separated"
+                  ]
+                }
+              }
+            ]
+          },
+          {
+            "id": "contact_info",
+            "title": "Contact Information",
+            "fields": [
+              {
+                "id": "telephone_home",
+                "label": "Home Phone",
+                "type": "tel",
+                "required": false,
+                "constraints": {
+                  "pattern": "^\\\\(?[0-9]{3}\\\\)?[-. ]?[0-9]{3}[-. ]?[0-9]{4}$"
+                },
+                "ui": {
+                  "placeholder": "(123) 456-7890"
+                }
+              },
+              {
+                "id": "telephone_work",
+                "label": "Work Phone",
+                "type": "tel",
+                "required": false,
+                "constraints": {
+                  "pattern": "^\\\\(?[0-9]{3}\\\\)?[-. ]?[0-9]{3}[-. ]?[0-9]{4}$"
+                },
+                "ui": {
+                  "placeholder": "(123) 456-7890"
+                }
+              },
+              {
+                "id": "telephone_mobile_or_other",
+                "label": "Mobile or Other Phone",
+                "type": "tel",
+                "required": false,
+                "tooltip": "To edit Telephone (Cell or Other) click on NYC ModelCity in the top-left corner then click on Account Settings and then click on Contact.",
+                "constraints": {
+                  "pattern": "^\\\\(?[0-9]{3}\\\\)?[-. ]?[0-9]{3}[-. ]?[0-9]{4}$"
+                },
+                "ui": {
+                  "placeholder": "(123) 456-7890"
+                }
+              },
+              {
+                "id": "email",
+                "label": "Email",
+                "type": "email",
+                "required": true,
+                "tooltip": "To edit email, go to NYC ID Profile tab by clicking your name at the top right corner"
+              }
+            ]
+          },
+          {
+            "id": "address_info",
+            "title": "Address",
+            "tooltip": "To edit home address click on NYC ModelCity in the top-left corner then click on Account Settings.",
+            "ui": {
+              "autocomplete": "street",
+              "placeholder": "Start typing your street address",
+              "overrideComponent": "AddressAutocomplete"
+            },
+            "metadata": {
+              "integration": {
+                "provider": "Google",
+                "feature": "AddressAutocomplete"
+              },
+              "autofillTargets": [
+                {
+                  "fieldId": "city",
+                  "source": "locality",
+                  "fallbackSources": [
+                    "postal_town",
+                    "sublocality_level_1",
+                    "administrative_area_level_2"
+                  ]
+                },
+                {
+                  "fieldId": "borough",
+                  "source": "sublocality_level_1",
+                  "fallbackSources": [
+                    "administrative_area_level_2"
+                  ],
+                  "mapping": "boroughMap"
+                },
+                { "fieldId": "state", "source": "administrative_area_level_1" },
+                { "fieldId": "zip_code", "source": "postal_code" },
+                { "fieldId": "latitude", "source": "location.latitude" },
+                { "fieldId": "longitude", "source": "location.longitude" }
+              ]
+            },
+            "fields": [
+              {
+                "id": "street",
+                "label": "Street Address",
+                "type": "text",
+                "required": true,
+                "tooltip": "To edit home address click on NYC ModelCity in the top-left corner then click on Account Settings."
+              },
+              {
+                "id": "apt",
+                "label": "Apt #",
+                "type": "text",
+                "required": false
+              },
+              {
+                "id": "city",
+                "label": "City",
+                "type": "text",
+                "required": true
+              },
+              {
+                "id": "borough",
+                "label": "Borough",
+                "type": "select",
+                "required": true,
+                "ui": {
+                  "options": [
+                    "",
+                    "Bronx",
+                    "Brooklyn",
+                    "Manhattan",
+                    "Queens",
+                    "Staten Island"
+                  ]
+                }
+              },
+              {
+                "id": "state",
+                "label": "State",
+                "type": "text",
+                "required": true
+              },
+              {
+                "id": "zip_code",
+                "label": "Zip Code",
+                "type": "text",
+                "required": true
+              },
+              {
+                "id": "latitude",
+                "label": "Latitude",
+                "type": "number",
+                "required": false
+              },
+              {
+                "id": "longitude",
+                "label": "Longitude",
+                "type": "number",
+                "required": false
+              },
+              {
+                "id": "is_temporary_address",
+                "label": "Is Temporary Address",
+                "type": "radio",
+                "required": true,
+                "tooltip": "Check YES if you are currently living in a homeless shelter, doubled-up with another family, in a hotel/motel, in a car/ bus/ train, in a park/campsite, or other temporary accomodation.",
+                "ui": {
+                  "options": [
+                    "Yes",
+                    "No"
+                  ]
+                }
+              },
+              {
+                "id": "currently_living_in",
+                "label": "Currently Living In",
+                "type": "select",
+                "required": false,
+                "requiredCondition": {
+                  "field": "is_temporary_address",
+                  "operator": "equals",
+                  "value": "Yes"
+                },
+                "ui": {
+                  "options": [
+                    "",
+                    "Homeless Shelter",
+                    "Doubled-up with another Family",
+                    "Hotel/Motel",
+                    "Car, Bus, Train",
+                    "Park",
+                    "Campsite",
+                    "Other"
+                  ]
+                }
+              }
+            ]
+          },
+          {
+            "id": "demographics",
+            "title": "Demographics",
+            "fields": [
+              {
+                "id": "ethnicity",
+                "label": "Ethnicity",
+                "type": "select",
+                "required": false,
+                "ui": {
+                  "options": [
+                    "",
+                    "Hispanic",
+                    "Latino",
+                    "No",
+                    "Prefer not to answer"
+                  ]
+                }
+              },
+              {
+                "id": "race",
+                "label": "Race",
+                "type": "checkbox",
+                "required": false,
+                "tooltip": "You may choose multiple race categories. Providing race information is voluntary and will not affect your eligibility for Child Care Assistance or the amount of assistance that you will be given by this agency.",
+                "ui": {
+                  "options": [
+                    {
+                      "value": "AI",
+                      "label": "American Indian or Alaska Native"
+                    },
+                    {
+                      "value": "AS",
+                      "label": "Asian"
+                    },
+                    {
+                      "value": "BL",
+                      "label": "Black or African American"
+                    },
+                    {
+                      "value": "HP",
+                      "label": "Native Hawaiian or Pacific Islander"
+                    },
+                    {
+                      "value": "WH",
+                      "label": "White"
+                    }
+                  ]
+                },
+                "metadata": {
+                  "multiple": true
+                }
+              },
+              {
+                "id": "ssn",
+                "label": "Social Security Number",
+                "type": "text",
+                "tooltip": "To edit social security number click on NYC ModelCity in the top-left corner then click on Account Settings.",
+                "required": false,
+                "constraints": {
+                  "pattern": "^\\\\d{3}-\\\\d{2}-\\\\d{4}$"
+                },
+                "ui": {
+                  "placeholder": "123-45-6789"
+                }
+              }
+            ]
+          },
+          {
+            "id": "language_info",
+            "title": "Language Preferences",
+            "fields": [
+              {
+                "id": "primary_language",
+                "label": "Primary Language",
+                "type": "radio",
+                "required": true,
+                "tooltip": "Select the language that is spoken most often in your household. If “other”, provide the name of the language.",
+                "ui": {
+                  "options": [
+                    "English",
+                    "Spanish",
+                    "Other"
+                  ]
+                }
+              },
+              {
+                "id": "preferred_language",
+                "label": "Preferred Language",
+                "type": "radio",
+                "required": true,
+                "tooltip": "Select the language you prefer to communicate in. If “other”, provide the name of the language.",
+                "ui": {
+                  "options": [
+                    "English",
+                    "Spanish",
+                    "Other"
+                  ]
+                }
+              },
+              {
+                "id": "other_primary_language",
+                "label": "Other Primary Language",
+                "type": "text",
+                "required": false,
+                "requiredCondition": {
+                  "field": "primary_language",
+                  "operator": "equals",
+                  "value": "Other"
+                }
+              },
+              {
+                "id": "other_preferred_language",
+                "label": "Other Preferred Language",
+                "type": "text",
+                "required": false,
+                "requiredCondition": {
+                  "field": "preferred_language",
+                  "operator": "equals",
+                  "value": "Other"
+                }
+              }
+            ]
+          },
+          {
+            "id": "cash_assistance",
+            "title": "Cash Assistance",
+            "fields": [
+              {
+                "id": "has_cash_assistance",
+                "label": "Do you receive Cash Assistance?",
+                "type": "radio",
+                "required": false,
+                "ui": {
+                  "options": [
+                    "Yes",
+                    "No"
+                  ]
+                }
+              },
+              {
+                "id": "ca_number",
+                "label": "Cash Assistance Number",
+                "type": "text",
+                "required": false,
+                "requiredCondition": {
+                  "condition": {
+                    "field": "has_cash_assistance",
+                    "operator": "equals",
+                    "value": "Yes"
+                  }
+                }
+              }
+            ]
+          }
+        ]
+      },
+      {
+        "id": "children_needing_care",
+        "title": "Children Needing Care",
+        "sections": [
+          {
+            "id": "child_details",
+            "title": "Child Details",
+            "required": true,
+            "fields": [
+              {
+                "id": "children",
+                "label": "Children Needing Care",
+                "type": "group",
+                "metadata": {
+                  "multiple": true,
+                  "tableColumns": [
+                  "first_name",
+                  "last_name",
+                  "date_of_birth",
+                  "relationship_to_applicant"
+                  ]
+                },
+                "fields": [
+                  {
+                    "id": "first_name",
+                    "label": "First Name",
+                    "type": "text",
+                    "required": true,
+                    "tooltip": "Provide the first name, last name, and middle initial of each child you are applying for child care assistance for."
+                  },
+                  {
+                    "id": "last_name",
+                    "label": "Last Name",
+                    "type": "text",
+                    "required": true
+                  },
+                  {
+                    "id": "mi",
+                    "label": "Middle Initial",
+                    "type": "text",
+                    "required": false
+                  },
+                  {
+                    "id": "relationship_to_applicant",
+                    "label": "Relationship to Applicant",
+                    "type": "select",
+                    "required": true,
+                    "ui": {
+                      "options": [
+                        "",
+                        "Child",
+                        "Grandchild",
+                        "Foster Child",
+                        "Other"
+                      ]
+                    }
+                  },
+                  {
+                    "id": "date_of_birth",
+                    "label": "Date of Birth",
+                    "type": "date",
+                    "required": true,
+                    "tooltip": "Provide the date of birth."
+                  },
+                  {
+                    "id": "sex",
+                    "label": "Sex",
+                    "type": "radio",
+                    "required": true,
+                    "tooltip": "Select to indicate the sex.",
+                    "ui": {
+                      "options": [
+                        "Male",
+                        "Female"
+                      ]
+                    }
+                  },
+                  {
+                    "id": "ethnicity",
+                    "label": "Ethnicity Hispanic or Latino",
+                    "type": "select",
+                    "required": false,
+                    "tooltip": "Check “YES” or “NO” to indicate if each child in need of child care is Hispanic or Latino or not. Providing ethnicity information is voluntary and will not affect your eligibility for child care assistance or the amount of assistance that you will be given by this agency.",
+                    "ui": {
+                      "options": [
+                        "",
+                        "Yes",
+                        "No",
+                        "Prefer not to answer"
+                      ]
+                    }
+                  },
+                  {
+                    "id": "race",
+                    "label": "Race",
+                    "type": "checkbox",
+                    "required": false,
+                    "tooltip": "You may choose multiple race categories for a single child. Providing race information is voluntary and will not affect your eligibility for Child Care Assistance or the amount of assistance that you will be given by this agency.",
+                    "ui": {
+                      "options": [
+                        {
+                          "value": "AI",
+                          "label": "American Indian or Alaska Native"
+                        },
+                        {
+                          "value": "AS",
+                          "label": "Asian"
+                        },
+                        {
+                          "value": "BL",
+                          "label": "Black or African American"
+                        },
+                        {
+                          "value": "HP",
+                          "label": "Native Hawaiian or Pacific Islander"
+                        },
+                        {
+                          "value": "WH",
+                          "label": "White"
+                        }
+                      ]
+                    },
+                    "metadata": {
+                      "multiple": true
+                    }
+                  },
+                  {
+                    "id": "ssn",
+                    "label": "Social Security Number",
+                    "type": "text",
+                    "required": false,
+                    "tooltip": "Provide each child’s Social Security Number (SSN). You are not required to provide SSNs. They may be used by federal, state, and local agencies to prevent duplication of services and fraud, and for Federal Reporting.",
+                    "constraints": {
+                      "pattern": "^\\\\d{3}-\\\\d{2}-\\\\d{4}$"
+                    },
+                    "ui": {
+                      "placeholder": "123-45-6789"
+                    }
+                  },
+                  {
+                    "id": "do_both_parents_reside_in_home",
+                    "label": "Do both parents reside in the home?",
+                    "type": "radio",
+                    "required": true,
+                    "tooltip": "Check “YES” or “NO” to indicate whether both of the child’s parents live in the home.",
+                    "ui": {
+                      "options": [
+                        "Yes",
+                        "No"
+                      ]
+                    }
+                  },
+                  {
+                    "id": "has_disability",
+                    "label": "Does the child have a disability?",
+                    "type": "radio",
+                    "required": true,
+                    "tooltip": "Check “YES” or “NO” to indicate whether the child needing child care has a disability.",
+                    "ui": {
+                      "options": [
+                        "Yes",
+                        "No"
+                      ]
+                    }
+                  },
+                  {
+                    "id": "is_immigration_status_satisfactory",
+                    "label": "Is child U.S. Citizen, U.S. National, or person with satisfactory immigration status?",
+                    "type": "radio",
+                    "required": true,
+                    "tooltip": "You will only be asked about the immigration status of the children in need of care. Other members of the family will not need to state or prove their immigration status. Your child will be eligible for care if they are a U.S. citizen, a legal permanent resident (green card holder), a refugee, or an asylee; have a T-visa; or hold another qualified immigration status. Please select “Yes” if your child holds one of these statuses.",
+                    "ui": {
+                      "options": [
+                        "Yes",
+                        "No"
+                      ]
+                    }
+                  }
+                ]
+              }
+            ]
+          }
+        ]
+      },
+      {
+        "id": "family_members",
+        "title": "Family Members",
+        "sections": [
+          {
+            "id": "household_members_info",
+            "title": "Household Members Information",
+            "type": "info",
+            "ui": {
+              "markdown": true,
+              "collapsible": false,
+              "defaultCollapsed": false
+            },
+            "content": "**List the household members who do _not_ need child care.**\\n\\nIf applicable, list:\\n\\n- Your **spouse**, your child’s **second parent**, **caretaker**, or **step-parent**\\n- Any other **adult with whom you share a child**, if they live in your home\\n\\nThen, if applicable, list:\\n\\n- Any **siblings under the age of 18** who live in your home\\n\\n> **Only list other household members** — such as **aunts, uncles, cousins, grandparents, or friends** — _if they have financial responsibility_ for the child.\\n\\nA household member with financial responsibility, other than a parent or step-parent, is one who has a **letter or order of guardianship**.\\n\\n**Otherwise, do not include them.**"
+          },
+          {
+            "id": "family_member_details",
+            "title": "Household Member Details",
+            "description": "Include household members who do not need child care assistance (e.g., spouse, partner, other children).",
+            "fields": [
+              {
+                "id": "familymember",
+                "label": "Family Members",
+                "type": "group",
+                "requiredCondition": {
+                  "repeatingGroup": "children",
+                  "operator": "ANY",
+                  "condition": { "field": "do_both_parents_reside_in_home", "operator": "equals", "value": "Yes" }
+                },  
+                "metadata": {
+                  "multiple": true,
+                  "tableColumns": [
+                    "first_name",
+                    "last_name",
+                    "relationship_to_applicant",
+                    "date_of_birth"
+                  ]
+                },
+                "fields": [
+                  {
+                    "id": "first_name",
+                    "label": "First Name",
+                    "type": "text",
+                    "required": true,
+                    "tooltip": "Provide last and first name, and middle initial if applicable."
+                  },
+                  {
+                    "id": "last_name",
+                    "label": "Last Name",
+                    "type": "text",
+                    "required": true
+                  },
+                  {
+                    "id": "mi",
+                    "label": "Middle Initial",
+                    "type": "text",
+                    "required": false
+                  },
+                  {
+                    "id": "relationship_to_applicant",
+                    "label": "Relationship to Applicant",
+                    "type": "select",
+                    "required": true,
+                    "tooltip": "Provide each person’s relationship to you (e.g. spouse, partner, child, foster parent, other).",
+                    "ui": {
+                      "options": [
+                        "",
+                        "Spouse",
+                        "Partner",
+                        "Foster Parent",
+                        "Child",
+                        "Other"
+                      ]
+                    }
+                  },
+                  {
+                    "id": "date_of_birth",
+                    "label": "Date of Birth",
+                    "type": "date",
+                    "required": true,
+                    "tooltip": "Provide the family member's date of birth."
+                  },
+                  {
+                    "id": "sex",
+                    "label": "Sex",
+                    "type": "radio",
+                    "required": true,
+                    "tooltip": "Indicate the sex for each family member listed.",
+                    "ui": {
+                      "options": [
+                        "Male",
+                        "Female"
+                      ]
+                    }
+                  },
+                  {
+                    "id": "ethnicity",
+                    "label": "Ethnicity Hispanic or Latino",
+                    "type": "select",
+                    "required": false,
+                    "tooltip": "Check “YES” or “NO” to indicate if each member in the household is Hispanic or Latino or not. Providing ethnicity information is voluntary and will not affect your eligibility for Child Care Assistance or the amount of assistance that you will be given by this agency.",
+                    "ui": {
+                      "options": [
+                        "",
+                        "Yes",
+                        "No",
+                        "Prefer not to answer"
+                      ]
+                    }
+                  },
+                  {
+                    "id": "race",
+                    "label": "Race",
+                    "type": "checkbox",
+                    "required": false,
+                    "tooltip": "You may choose multiple race categories for a single person. Providing race information is voluntary and will not affect your eligibility for Child Care Assistance or the amount of assistance that you will be given by this agency.",
+                    "ui": {
+                      "options": [
+                        {
+                          "value": "AI",
+                          "label": "American Indian or Alaska Native"
+                        },
+                        {
+                          "value": "AS",
+                          "label": "Asian"
+                        },
+                        {
+                          "value": "BL",
+                          "label": "Black or African American"
+                        },
+                        {
+                          "value": "HP",
+                          "label": "Native Hawaiian or Pacific Islander"
+                        },
+                        {
+                          "value": "WH",
+                          "label": "White"
+                        }
+                      ]
+                    },
+                    "metadata": {
+                      "multiple": true
+                    }
+                  },
+                  {
+                    "id": "ssn",
+                    "label": "Social Security Number",
+                    "type": "text",
+                    "required": false,
+                    "tooltip": "Fill in the Social Security Number (SSN) for your family members. SSN is optional. SSN may be used by federal, state, and local agencies to prevent duplication of services and fraud, and for Federal Reporting.",
+                    "constraints": {
+                      "pattern": "^\\\\d{3}-\\\\d{2}-\\\\d{4}$"
+                    },
+                    "ui": {
+                      "placeholder": "123-45-6789"
+                    }
+                  }
+                ]
+              }
+            ]
+          }
+        ]
+      },
+      {
+        "id": "child_family_needs",
+        "title": "Child / Family Needs",
+        "sections": [
+          {
+            "id": "assistance_reason",
+            "title": "Reason for Child Care Assistance",
+            "description": "Select one or two reasons you are requesting Child Care Assistance.",
+            "tooltip": "Select one reason. In a two-parent household, parents/caretakers can have the same or different reasons for needing child care. Both parents/caretakers will be required to submit documentation in support of their own reason. If you are living in temporary housing, please select Homelessness even if you have another reason that applies to you.",
+            "fields": [
+              {
+                "id": "assistance_reason",
+                "label": "Reason(s) for Assistance",
+                "type": "select",
+                "required": true,
+                "ui": {
+                  "options": [
+                    "",
+                    "Employment",
+                    "Looking for Work",
+                    "Vocational Training/Educational Activities",
+                    "Receiving Domestic Violence Services",
+                    "Homelessness"
+                  ]
+                },
+                "constraints": {
+                  "minSelections": 1,
+                  "maxSelections": 2
+                },
+                "metadata": {
+                  "multiple": true
+                }
+              }
+            ]
+          },
+          {
+            "id": "military_status",
+            "title": "Military and Parental Availability",
+            "description": "Provide information about parental military status and availability for child care.",
+            "fields": [
+              {
+                "id": "is_parent_currently_active_in_military",
+                "label": "Is a Parent Currently Active Full-Time in the U.S. Military?",
+                "tooltip": "Check “YES” or “NO” to indicate whether a parent is currently active full-time in the U.S. Military.",
+                "type": "radio",
+                "required": true,
+                "ui": {
+                  "options": [
+                    "Yes",
+                    "No"
+                  ]
+                }
+              },
+              {
+                "id": "is_parent_mem_of_guard_or_mru",
+                "label": "Is a Parent a Member of National Guard or Military Reserve Unit?",
+                "tooltip": "Check “YES” or “NO” to indicate whether a parent is currently a member of a National Guard or Military Reserve Unit.",
+                "type": "radio",
+                "required": true,
+                "ui": {
+                  "options": [
+                    "Yes",
+                    "No"
+                  ]
+                }
+              },
+              {
+                "id": "is_non_custodial_parent_available",
+                "label": "Is the Non-Custodial Parent Available to Provide Care?",
+                "tooltip": "Check “YES” or “NO” to indicate whether there is a non-custodial parent available to provide child care.",
+                "type": "radio",
+                "required": true,
+                "ui": {
+                  "options": [
+                    "Yes",
+                    "No"
+                  ]
+                }
+              }
+            ]
+          },
+          {
+            "id": "duplicate_application",
+            "title": "Other Applications",
+            "description": "Indicate if you are also applying for or receiving child care from other agencies.",
+            "tooltip": "Indicate whether you are currently receiving or have applied for child care assistance with one of the agencies or organizations listed below. Note: If you are receiving Cash Assistance and are interested in child care assistance, you must apply through the Human Resources Administration. Reach out to your Benefits Access Center or visit the Human Resources Administration webpage.",
+            "fields": [
+              {
+                "id": "duplicate_app",
+                "label": "Are You Receiving or Applying for Child Care Through Another Agency?",
+                "type": "select",
+                "required": false,
+                "ui": {
+                  "options": [
+                    "",
+                    "Not Applicable",
+                    "Department of Education (DOE)",
+                    "Human Resources Administration (HRA)",
+                    "Department of Youth and Community Development (DYCD)",
+                    "Department of Homeless Services (DHS)",
+                    "Consortium for Worker Education (CWE)",
+                    "Administration for Children's Services (ACS)"
+                  ]
+                }
+              }
+            ]
+          }
+        ]
+      },
+      {
+        "id": "employment",
+        "title": "Employment",
+        "sections": [
+          {
+            "id": "employment_precheck",
+            "title": "Tell us about your employment",
+            "description": "Tell us about your employment",
+            "fields": [
+              {
+                "id": "applicant_emp_income_indicator",
+                "label": "Does applicant earn any income/ wages from employment? ",
+                "type": "radio",
+                "required": false,
+                "ui": {
+                  "options": [
+                    "Yes",
+                    "No"
+                  ]
+                }
+              },
+              {
+                "id": "coparent_emp_income_indicator",
+                "label": "Does Coparent/2nd Guardian earn any income/ wages from employment? ",
+                "type": "radio",
+                "required": false,
+                "ui": {
+                  "options": [
+                    "Yes",
+                    "No"
+                  ]
+                }
+              }
+            ]
+          },
+          {
+            "id": "applicant_jobs",
+            "title": "Applicant Employment Information",
+            "description": "Enter details for up to two jobs held by the applicant.",
+            "visibilityCondition": {
+              "field": "applicant_emp_income_indicator",
+              "operator": "equals",
+              "value": "Yes"
+            },
+            "fields": [
+              {
+                "id": "applicant_1st_job_start_date",
+                "label": "1st Job - Start Date",
+                "type": "date",
+                "required": false,
+                "ui": {
+                  "group": "1st Job"
+                }
+              },
+              {
+                "id": "applicant_1st_job_rotating_shift",
+                "label": "1st Job - Has Rotating Shift?",
+                "type": "radio",
+                "required": false,
+                "ui": {
+                  "options": [
+                    "Yes",
+                    "No"
+                  ],
+                  "group": "1st Job"
+                }
+              },
+              {
+                "id": "applicant_1st_job_requires_overtime",
+                "label": "1st Job - Requires Overtime?",
+                "type": "radio",
+                "required": false,
+                "ui": {
+                  "options": [
+                    "Yes",
+                    "No"
+                  ],
+                  "group": "1st Job"
+                }
+              },
+              {
+                "id": "applicant_1st_job_employer_name",
+                "label": "1st Job - Employer Name",
+                "type": "text",
+                "required": false,
+                "ui": {
+                  "group": "1st Job"
+                }
+              },
+              {
+                "id": "applicant_1st_job_employer_phone",
+                "label": "1st Job - Employer Phone",
+                "type": "tel",
+                "required": false,
+                "ui": {
+                  "group": "1st Job"
+                }
+              },
+              {
+                "id": "applicant_1st_job_employer_street",
+                "label": "1st Job - Employer Street Address",
+                "type": "text",
+                "required": false,
+                "ui": {
+                  "group": "1st Job"
+                }
+              },
+              {
+                "id": "applicant_1st_job_employer_city",
+                "label": "1st Job - Employer City",
+                "type": "text",
+                "required": false,
+                "ui": {
+                  "group": "1st Job"
+                }
+              },
+              {
+                "id": "applicant_1st_job_employer_state",
+                "label": "1st Job - Employer State",
+                "type": "text",
+                "required": false,
+                "ui": {
+                  "group": "1st Job"
+                }
+              },
+              {
+                "id": "applicant_1st_job_employer_zipcode",
+                "label": "1st Job - Employer ZIP Code",
+                "type": "text",
+                "required": false,
+                "ui": {
+                  "group": "1st Job"
+                }
+              },
+              {
+                "id": "applicant_2nd_job_start_date",
+                "label": "2nd Job - Start Date",
+                "type": "date",
+                "required": false,
+                "ui": {
+                  "group": "2nd Job"
+                }
+              },
+              {
+                "id": "applicant_2nd_job_rotating_shift",
+                "label": "2nd Job - Has Rotating Shift?",
+                "type": "radio",
+                "required": false,
+                "ui": {
+                  "options": [
+                    "Yes",
+                    "No"
+                  ],
+                  "group": "2nd Job"
+                }
+              },
+              {
+                "id": "applicant_2nd_job_requires_overtime",
+                "label": "2nd Job - Requires Overtime?",
+                "type": "radio",
+                "required": false,
+                "ui": {
+                  "options": [
+                    "Yes",
+                    "No"
+                  ],
+                  "group": "2nd Job"
+                }
+              },
+              {
+                "id": "applicant_2nd_job_employer_name",
+                "label": "2nd Job - Employer Name",
+                "type": "text",
+                "required": false,
+                "ui": {
+                  "group": "2nd Job"
+                }
+              },
+              {
+                "id": "applicant_2nd_job_employer_phone",
+                "label": "2nd Job - Employer Phone",
+                "type": "tel",
+                "required": false,
+                "ui": {
+                  "group": "2nd Job"
+                }
+              },
+              {
+                "id": "applicant_2nd_job_employer_street",
+                "label": "2nd Job - Employer Street Address",
+                "type": "text",
+                "required": false,
+                "ui": {
+                  "group": "2nd Job"
+                }
+              },
+              {
+                "id": "applicant_2nd_job_employer_city",
+                "label": "2nd Job - Employer City",
+                "type": "text",
+                "required": false,
+                "ui": {
+                  "group": "2nd Job"
+                }
+              },
+              {
+                "id": "applicant_2nd_job_employer_state",
+                "label": "2nd Job - Employer State",
+                "type": "text",
+                "required": false,
+                "ui": {
+                  "group": "2nd Job"
+                }
+              },
+              {
+                "id": "applicant_2nd_job_employer_zipcode",
+                "label": "2nd Job - Employer ZIP Code",
+                "type": "text",
+                "required": false,
+                "ui": {
+                  "group": "2nd Job"
+                }
+              }
+            ]
+          },
+          {
+            "id": "second_parent_jobs",
+            "title": "Second Parent Employment Information",
+            "description": "Enter details for up to two jobs held by the second parent (if applicable).",
+            "visibilityCondition": {
+              "field": "coparent_emp_income_indicator",
+              "operator": "equals",
+              "value": "Yes"
+            },
+            "fields": [
+              {
+                "id": "second_parent_1st_job_start_date",
+                "label": "1st Job - Start Date",
+                "type": "date",
+                "required": false
+              },
+              {
+                "id": "second_parent_1st_job_rotating_shift",
+                "label": "1st Job - Has Rotating Shift?",
+                "type": "radio",
+                "required": false,
+                "ui": {
+                  "options": [
+                    "Yes",
+                    "No"
+                  ]
+                }
+              },
+              {
+                "id": "second_parent_1st_job_requires_overtime",
+                "label": "1st Job - Requires Overtime?",
+                "type": "radio",
+                "required": false,
+                "ui": {
+                  "options": [
+                    "Yes",
+                    "No"
+                  ]
+                }
+              },
+              {
+                "id": "second_parent_1st_job_employer_name",
+                "label": "1st Job - Employer Name",
+                "type": "text",
+                "required": false
+              },
+              {
+                "id": "second_parent_1st_job_employer_phone",
+                "label": "1st Job - Employer Phone",
+                "type": "tel",
+                "required": false
+              },
+              {
+                "id": "second_parent_1st_job_employer_street",
+                "label": "1st Job - Employer Street Address",
+                "type": "text",
+                "required": false
+              },
+              {
+                "id": "second_parent_1st_job_employer_city",
+                "label": "1st Job - Employer City",
+                "type": "text",
+                "required": false
+              },
+              {
+                "id": "second_parent_1st_job_employer_state",
+                "label": "1st Job - Employer State",
+                "type": "text",
+                "required": false
+              },
+              {
+                "id": "second_parent_1st_job_employer_zipcode",
+                "label": "1st Job - Employer ZIP Code",
+                "type": "text",
+                "required": false
+              },
+              {
+                "id": "second_parent_2nd_job_start_date",
+                "label": "2nd Job - Start Date",
+                "type": "date",
+                "required": false
+              },
+              {
+                "id": "second_parent_2nd_job_rotating_shift",
+                "label": "2nd Job - Has Rotating Shift?",
+                "type": "radio",
+                "required": false,
+                "ui": {
+                  "options": [
+                    "Yes",
+                    "No"
+                  ]
+                }
+              },
+              {
+                "id": "second_parent_2nd_job_requires_overtime",
+                "label": "2nd Job - Requires Overtime?",
+                "type": "radio",
+                "required": false,
+                "ui": {
+                  "options": [
+                    "Yes",
+                    "No"
+                  ]
+                }
+              },
+              {
+                "id": "second_parent_2nd_job_employer_name",
+                "label": "2nd Job - Employer Name",
+                "type": "text",
+                "required": false
+              },
+              {
+                "id": "second_parent_2nd_job_employer_phone",
+                "label": "2nd Job - Employer Phone",
+                "type": "tel",
+                "required": false
+              },
+              {
+                "id": "second_parent_2nd_job_employer_street",
+                "label": "2nd Job - Employer Street Address",
+                "type": "text",
+                "required": false
+              },
+              {
+                "id": "second_parent_2nd_job_employer_city",
+                "label": "2nd Job - Employer City",
+                "type": "text",
+                "required": false
+              },
+              {
+                "id": "second_parent_2nd_job_employer_state",
+                "label": "2nd Job - Employer State",
+                "type": "text",
+                "required": false
+              },
+              {
+                "id": "second_parent_2nd_job_employer_zipcode",
+                "label": "2nd Job - Employer ZIP Code",
+                "type": "text",
+                "required": false
+              }
+            ]
+          }
+        ]
+      },
+      {
+        "id": "schedule",
+        "title": "Work/Activity/Travel Time Schedule",
+        "sections": [
+          {
+            "id": "schedule_section_info",
+            "title": "Schedule Information",
+            "type": "info",
+            "ui": {
+              "markdown": true,
+              "collapsible": false,
+              "defaultCollapsed": false
+            },
+            "content": "Please indicate what days and hours you will need child care for based on your reason for care.\\n\\n- **Employed**: Indicate the hours you attend work\\n- **Educational or Vocational Program**: Indicate the hours you attend school or your program\\n- **Looking for Work**: Indicate the hours you spend looking for work\\n- **Homeless**: Indicate the hours you spend looking for housing\\n- **Attending Services for Domestic Violence**: Indicate the hours you attend services.\\n- **Attending Services for Substance Abuse Treatment**: Indicate the hours you attend services."
+          },
+          {
+            "id": "first_parent_activity_schedule",
+            "title": "First Parent Activity Schedule",
+            "description": "Enter the start and end times for each day of the week for the first parent's activities.",
+            "ui": {
+              "layout": "table",
+              "columns": [
+                "Start Time",
+                "End Time"
+              ],
+              "rowCopy": {
+                "enableUserPickSource": true,
+                "rowIdentifier": "ui.rowGroup",
+                "fieldsToCopy": [
+                  1,
+                  2
+                ],
+                "targetRowValues": [
+                  "Monday",
+                  "Tuesday",
+                  "Wednesday",
+                  "Thursday",
+                  "Friday"
+                ],
+                "copyControlLabel": "Apply selected schedule to other weekdays",
+                "sourceOptions": [
+                  "Monday",
+                  "Tuesday",
+                  "Wednesday",
+                  "Thursday",
+                  "Friday",
+                  "Saturday",
+                  "Sunday"
+                ]
+              }
+            },
+            "fields": [
+              {
+                "id": "fp_monday_from",
+                "label": "Monday From",
+                "type": "time",
+                "ui": {
+                  "rowGroup": "Monday",
+                  "column": 1
+                }
+              },
+              {
+                "id": "fp_monday_to",
+                "label": "Monday To",
+                "type": "time",
+                "ui": {
+                  "rowGroup": "Monday",
+                  "column": 2
+                }
+              },
+              {
+                "id": "fp_tuesday_from",
+                "label": "Tuesday From",
+                "type": "time",
+                "ui": {
+                  "rowGroup": "Tuesday",
+                  "column": 1
+                }
+              },
+              {
+                "id": "fp_tuesday_to",
+                "label": "Tuesday To",
+                "type": "time",
+                "ui": {
+                  "rowGroup": "Tuesday",
+                  "column": 2
+                }
+              },
+              {
+                "id": "fp_wednesday_from",
+                "label": "Wednesday From",
+                "type": "time",
+                "ui": {
+                  "rowGroup": "Wednesday",
+                  "column": 1
+                }
+              },
+              {
+                "id": "fp_wednesday_to",
+                "label": "Wednesday To",
+                "type": "time",
+                "ui": {
+                  "rowGroup": "Wednesday",
+                  "column": 2
+                }
+              },
+              {
+                "id": "fp_thursday_from",
+                "label": "Thursday From",
+                "type": "time",
+                "ui": {
+                  "rowGroup": "Thursday",
+                  "column": 1
+                }
+              },
+              {
+                "id": "fp_thursday_to",
+                "label": "Thursday To",
+                "type": "time",
+                "ui": {
+                  "rowGroup": "Thursday",
+                  "column": 2
+                }
+              },
+              {
+                "id": "fp_friday_from",
+                "label": "Friday From",
+                "type": "time",
+                "ui": {
+                  "rowGroup": "Friday",
+                  "column": 1
+                }
+              },
+              {
+                "id": "fp_friday_to",
+                "label": "Friday To",
+                "type": "time",
+                "ui": {
+                  "rowGroup": "Friday",
+                  "column": 2
+                }
+              },
+              {
+                "id": "fp_saturday_from",
+                "label": "Saturday From",
+                "type": "time",
+                "ui": {
+                  "rowGroup": "Saturday",
+                  "column": 1
+                }
+              },
+              {
+                "id": "fp_saturday_to",
+                "label": "Saturday To",
+                "type": "time",
+                "ui": {
+                  "rowGroup": "Saturday",
+                  "column": 2
+                }
+              },
+              {
+                "id": "fp_sunday_from",
+                "label": "Sunday From",
+                "type": "time",
+                "ui": {
+                  "rowGroup": "Sunday",
+                  "column": 1
+                }
+              },
+              {
+                "id": "fp_sunday_to",
+                "label": "Sunday To",
+                "type": "time",
+                "ui": {
+                  "rowGroup": "Sunday",
+                  "column": 2
+                }
+              }
+            ]
+          },
+          {
+            "id": "second_parent_activity_schedule",
+            "title": "Second Parent Activity Schedule",
+            "description": "Enter the start and end times for each day of the week for the second parent's activities.",
+            "ui": {
+              "layout": "table",
+              "columns": [
+                "Start Time",
+                "End Time"
+              ],
+              "rowCopy": {
+                "enableUserPickSource": true,
+                "rowIdentifier": "ui.rowGroup",
+                "fieldsToCopy": [
+                  1,
+                  2
+                ],
+                "targetRowValues": [
+                  "Monday",
+                  "Tuesday",
+                  "Wednesday",
+                  "Thursday",
+                  "Friday"
+                ],
+                "copyControlLabel": "Apply selected schedule to other weekdays",
+                "sourceOptions": [
+                  "Monday",
+                  "Tuesday",
+                  "Wednesday",
+                  "Thursday",
+                  "Friday",
+                  "Saturday",
+                  "Sunday"
+                ]
+              }
+            },
+            "fields": [
+              {
+                "id": "sp_monday_from",
+                "label": "Monday From",
+                "type": "time",
+                "ui": {
+                  "rowGroup": "Monday",
+                  "column": 1
+                }
+              },
+              {
+                "id": "sp_monday_to",
+                "label": "Monday To",
+                "type": "time",
+                "ui": {
+                  "rowGroup": "Monday",
+                  "column": 2
+                }
+              },
+              {
+                "id": "sp_tuesday_from",
+                "label": "Tuesday From",
+                "type": "time",
+                "ui": {
+                  "rowGroup": "Tuesday",
+                  "column": 1
+                }
+              },
+              {
+                "id": "sp_tuesday_to",
+                "label": "Tuesday To",
+                "type": "time",
+                "ui": {
+                  "rowGroup": "Tuesday",
+                  "column": 2
+                }
+              },
+              {
+                "id": "sp_wednesday_from",
+                "label": "Wednesday From",
+                "type": "time",
+                "ui": {
+                  "rowGroup": "Wednesday",
+                  "column": 1
+                }
+              },
+              {
+                "id": "sp_wednesday_to",
+                "label": "Wednesday To",
+                "type": "time",
+                "ui": {
+                  "rowGroup": "Wednesday",
+                  "column": 2
+                }
+              },
+              {
+                "id": "sp_thursday_from",
+                "label": "Thursday From",
+                "type": "time",
+                "ui": {
+                  "rowGroup": "Thursday",
+                  "column": 1
+                }
+              },
+              {
+                "id": "sp_thursday_to",
+                "label": "Thursday To",
+                "type": "time",
+                "ui": {
+                  "rowGroup": "Thursday",
+                  "column": 2
+                }
+              },
+              {
+                "id": "sp_friday_from",
+                "label": "Friday From",
+                "type": "time",
+                "ui": {
+                  "rowGroup": "Friday",
+                  "column": 1
+                }
+              },
+              {
+                "id": "sp_friday_to",
+                "label": "Friday To",
+                "type": "time",
+                "ui": {
+                  "rowGroup": "Friday",
+                  "column": 2
+                }
+              },
+              {
+                "id": "sp_saturday_from",
+                "label": "Saturday From",
+                "type": "time",
+                "ui": {
+                  "rowGroup": "Saturday",
+                  "column": 1
+                }
+              },
+              {
+                "id": "sp_saturday_to",
+                "label": "Saturday To",
+                "type": "time",
+                "ui": {
+                  "rowGroup": "Saturday",
+                  "column": 2
+                }
+              },
+              {
+                "id": "sp_sunday_from",
+                "label": "Sunday From",
+                "type": "time",
+                "ui": {
+                  "rowGroup": "Sunday",
+                  "column": 1
+                }
+              },
+              {
+                "id": "sp_sunday_to",
+                "label": "Sunday To",
+                "type": "time",
+                "ui": {
+                  "rowGroup": "Sunday",
+                  "column": 2
+                }
+              }
+            ]
+          },
+          {
+            "id": "first_parent_travel_time",
+            "title": "First Parent Travel Time",
+            "description": "Enter the travel times and method of transport for the first parent.",
+            "fields": [
+              {
+                "id": "fp_dropoff_travel_time",
+                "label": "Drop-off Travel Time",
+                "type": "select",
+                "tooltip": "Select your typical travel time from work/activity to your child care provider",
+                "ui": {
+                  "options": [
+                    "",
+                    "15 min",
+                    "30 min",
+                    "45 min",
+                    "1 hour",
+                    "More than 1 hour"
+                  ]
+                }
+              },
+              {
+                "id": "fp_dropoff_time_gt_1hr",
+                "label": "Drop-off Time (if > 1 hour)",
+                "type": "text",
+                "requiredCondition": {
+                  "field": "fp_dropoff_travel_time",
+                  "operator": "equals",
+                  "value": "More than 1 hour"
+                }
+              },
+              {
+                "id": "fp_pickup_travel_time",
+                "label": "Pick-up Travel Time",
+                "type": "select",
+                "tooltip": "Select your typical travel time from work/activity to your child care provider",
+                "ui": {
+                  "options": [
+                    "",
+                    "15 min",
+                    "30 min",
+                    "45 min",
+                    "1 hour",
+                    "More than 1 hour"
+                  ]
+                }
+              },
+              {
+                "id": "fp_pickup_time_gt_1hr",
+                "label": "Pick-up Time (if > 1 hour)",
+                "type": "text",
+                "requiredCondition": {
+                  "field": "fp_pickup_travel_time",
+                  "operator": "equals",
+                  "value": "More than 1 hour"
+                }
+              },
+              {
+                "id": "fp_public_transport_dropoff",
+                "label": "Public Transport for Drop-off?",
+                "type": "radio",
+                "tooltip": "Indicate if the applicant uses public transportation to travel to and from work/activity to provider.",
+                "ui": {
+                  "options": [
+                    "Yes",
+                    "No"
+                  ]
+                }
+              },
+              {
+                "id": "fp_public_transport_pickup",
+                "label": "Public Transport for Pick-up?",
+                "tooltip": "Indicate if the applicant uses public transportation to travel to and from work/activity to provider.",
+                "type": "radio",
+                "ui": {
+                  "options": [
+                    "Yes",
+                    "No"
+                  ]
+                }
+              }
+            ]
+          },
+          {
+            "id": "second_parent_travel_time",
+            "title": "Second Parent Travel Time",
+            "description": "Enter the travel times and method of transport for the second parent.",
+            "fields": [
+              {
+                "id": "sp_dropoff_travel_time",
+                "label": "Drop-off Travel Time",
+                "type": "select",
+                "ui": {
+                  "options": [
+                    "",
+                    "15 min",
+                    "30 min",
+                    "45 min",
+                    "1 hour",
+                    "More than 1 hour"
+                  ]
+                }
+              },
+              {
+                "id": "sp_pickup_travel_time",
+                "label": "Pick-up Travel Time",
+                "type": "select",
+                "ui": {
+                  "options": [
+                    "",
+                    "15 min",
+                    "30 min",
+                    "45 min",
+                    "1 hour",
+                    "More than 1 hour"
+                  ]
+                }
+              },
+              {
+                "id": "sp_dropoff_time_gt_1hr",
+                "label": "Drop-off Time (if > 1 hour)",
+                "type": "text",
+                "requiredCondition": {
+                  "field": "sp_dropoff_travel_time",
+                  "operator": "equals",
+                  "value": "More than 1 hour"
+                }
+              },
+              {
+                "id": "sp_pickup_time_gt_1hr",
+                "label": "Pick-up Time (if > 1 hour)",
+                "type": "text",
+                "requiredCondition": {
+                  "field": "sp_pickup_travel_time",
+                  "operator": "equals",
+                  "value": "More than 1 hour"
+                }
+              },
+              {
+                "id": "sp_public_transport_dropoff",
+                "label": "Public Transport for Drop-off?",
+                "type": "radio",
+                "ui": {
+                  "options": [
+                    "Yes",
+                    "No"
+                  ]
+                }
+              },
+              {
+                "id": "sp_public_transport_pickup",
+                "label": "Public Transport for Pick-up?",
+                "type": "radio",
+                "ui": {
+                  "options": [
+                    "Yes",
+                    "No"
+                  ]
+                }
+              }
+            ]
+          }
+        ]
+      },
+      {
+        "id": "income",
+        "title": "Income Information",
+        "sections": [
+          {
+            "id": "income_step_info",
+            "title": "Instructions",
+            "type": "info",
+            "ui": {
+              "markdown": true,
+              "collapsible": false,
+              "defaultCollapsed": false
+            },
+            "content": "Please include income/benefits information for yourself and, if applicable, your spouse, your child’s second caretaker, and/or any other adult with whom you share a child, if they live in your home.\\n\\nIndicate if you receive money from the following sources by selecting “Yes” or “No.” If you select “Yes,” you will be asked for additional information.\\n\\nIf the second caretaker in the household also receives the same income source, add a separate line for their income."
+          },
+          {
+            "id": "income_sources",
+            "title": "Income Sources",
+            "description": "Provide details about all income sources applicable to the applicant or household.",
+            "fields": [
+              {
+                "id": "income_sources",
+                "label": "List of Income Sources",
+                "type": "group",
+                "metadata": {
+                  "multiple": true,
+                  "tableColumns": [
+                    "name_ref",
+                    "how_often",
+                    "recipient",
+                    "monthly_amount"
+                  ]
+                },
+                "fields": [
+                  {
+                    "id": "name_ref",
+                    "label": "Income Source Type",
+                    "type": "select",
+                    "required": true,
+                    "ui": {
+                      "options": [
+                        "",
+                        "ApplicantWages",
+                        "SecondParentWages",
+                        "SelfEmployment",
+                        "ChildSupport",
+                        "Alimony",
+                        "Unemployment",
+                        "SocialSecurity",
+                        "Disability",
+                        "Rental",
+                        "Dividends",
+                        "Retirement",
+                        "CashAssistance",
+                        "Other"
+                      ]
+                    }
+                  },
+                  {
+                    "id": "other_source_text",
+                    "label": "Other Source (If applicable)",
+                    "type": "text",
+                    "visibilityCondition": {
+                      "field": "name_ref",
+                      "operator": "equals",
+                      "value": "Other"
+                    },
+                    "requiredCondition": {
+                      "condition": {
+                        "field": "name_ref",
+                        "operator": "equals",
+                        "value": "Other"
+                      }
+                    }
+                  },
+                  {
+                    "id": "is_source_applicable",
+                    "label": "Is this Source Applicable?",
+                    "type": "radio",
+                    "required": true,
+                    "ui": {
+                      "options": [
+                        "Yes",
+                        "No"
+                      ]
+                    }
+                  },
+                  {
+                    "id": "gross_amount",
+                    "label": "Gross Amount ($)",
+                    "type": "number",
+                    "required": true
+                  },
+                  {
+                    "id": "how_often",
+                    "label": "Frequency of Income",
+                    "type": "radio",
+                    "required": true,
+                    "ui": {
+                      "options": [
+                        "Weekly",
+                        "Bi-weekly",
+                        "Monthly",
+                        "Other"
+                      ]
+                    }
+                  },
+                  {
+                    "id": "recipient",
+                    "label": "Recipient of Income",
+                    "type": "text",
+                    "required": true
+                  },
+                  {
+                    "id": "monthly_amount",
+                    "label": "Monthly Amount ($)",
+                    "type": "number",
+                    "required": true
+                  }
+                ]
+              }
+            ]
+          },
+          {
+            "id": "total_income",
+            "title": "Total Household Income",
+            "description": "Sum of all monthly income across sources.",
+            "fields": [
+              {
+                "id": "total_income",
+                "label": "Total Monthly Income ($)",
+                "type": "number",
+                "required": true
+              }
+            ]
+          },
+          {
+            "id": "income_proof_section",
+            "title": "Income Proof",
+            "fields": [
+              {
+                "id": "income_proof",
+                "label": "Upload Income Proof",
+                "type": "file",
+                "requiredCondition": {
+                  "condition": {
+                    "field": "assistance_reason",
+                    "operator": "includes",
+                    "value": "Employment"
+                  }
+                },
+                "constraints": {
+                  "maxFileSizeMB": 5,
+                  "allowedTypes": [
+                    "application/pdf",
+                    "image/jpeg"
+                  ],
+                  "imageResolution": {
+                    "minWidth": 800,
+                    "minHeight": 600
+                  }
+                },
+                "metadata": {
+                  "proofCategory": "Income Verification",
+                  "examples": [
+                    "Pay Stub",
+                    "W-2"
+                  ],
+                  "multiple": true
+                }
+              }
+            ]
+          }
+        ]
+      },
+      {
+        "id": "provider",
+        "title": "Provider",
+        "sections": [
+          {
+            "id": "provider_step_info",
+            "title": "Instructions",
+            "type": "info",
+            "ui": {
+              "markdown": true,
+              "collapsible": false,
+              "defaultCollapsed": false
+            },
+            "content": "If you are found eligible for child care assistance, you can choose center-based or home-based care from a licensed, registered, or legally exempt provider. If you choose a provider that is not licensed or registered, the provider must be enrolled as a legally exempt provider.\\n\\nIf you know which child care providers you would like your child to attend, provide the names and addresses of your choice of providers. You can leave this section blank if you do not know (it will not impact your eligibility and you will have an opportunity to select a provider if determined eligible)."
+          },
+          {
+            "id": "provider_choices",
+            "title": "Provider Choices",
+            "description": "Specify details of the provider where you intend to enroll the child(ren).",
+            "fields": [
+              {
+                "id": "provider_choices",
+                "label": "List of Providers",
+                "type": "group",
+                "metadata": {
+                  "multiple": true,
+                  "tableColumns": [
+                    "provider_name",
+                    "program_number",
+                    "provider_zip_code"
+                  ]
+                },
+                "fields": [
+                  {
+                    "id": "provider_name",
+                    "label": "Provider Name",
+                    "type": "text",
+                    "required": true
+                  },
+                  {
+                    "id": "program_number",
+                    "label": "Program Number (If Applicable)",
+                    "type": "text",
+                    "required": false
+                  },
+                  {
+                    "id": "provider_street",
+                    "label": "Street Address",
+                    "type": "text",
+                    "required": true
+                  },
+                  {
+                    "id": "provider_city",
+                    "label": "City",
+                    "type": "text",
+                    "required": true
+                  },
+                  {
+                    "id": "provider_state",
+                    "label": "State",
+                    "type": "text",
+                    "required": true
+                  },
+                  {
+                    "id": "provider_zip_code",
+                    "label": "Zip Code",
+                    "type": "text",
+                    "required": true
+                  }
+                ]
+              }
+            ]
+          }
+        ]
+      },
+      {
+        "id": "document_upload_step",
+        "title": "Document Upload",
+        "description": "The Application for Child Care Assistance (CFWB-012) must include supporting documentation. Check to ensure that documentation is provided for each requirement of subsidy eligibility.",
+        "sections": [
+          {
+            "id": "nyc_residency",
+            "title": "New York City Residency",
+            "description": "These documents confirm that you live in New York City. Please upload one of the following documents.",
+            "fields": [
+              {
+                "id": "nyc_residency_type",
+                "label": "Select one of the following:",
+                "type": "radio",
+                "required": true,
+                "ui": {
+                  "options": [
+                    "IDNYC",
+                    "Utility Bill",
+                    "Section 8 Award Letter",
+                    "Driver’s License",
+                    "Rent Receipt",
+                    "NYCHA Certificate",
+                    "CFWB-067 Residency Attestation",
+                    "CFWB-027 Housing Attestation with address listed",
+                    "Shelter Residency Letter with address listed",
+                    "Other"
+                  ]
+                }
+              },
+              {
+                "id": "nyc_residency_file",
+                "label": "Upload Residency Proof Document",
+                "description": "To add a document to your application, you can upload an image or scanned file from your phone or device. Accepted formats include .pdf, .gif, .jpeg, .jpg and .png up to 25 MB. Learn how to upload your files with this Tutorial Video.",
+                "type": "file",
+                "required": true, 
+                "constraints": {
+                  "maxFileSizeMB": 25,
+                  "allowedTypes": [
+                    "application/pdf",
+                    "image/jpeg",
+                    "image/jpg",
+                    "image/png",
+                    "image/gif"
+                  ]
+                },
+                "metadata": {
+                  "proofCategory": "NYC Residency",
+                  "multiple": false
+                }
+              }
+            ]
+          },
+          {
+            "id": "citizenship_status",
+            "title": "Citizenship or Immigration Status",
+            "description": "These documents confirm the citizenship/immigration status of the children in your family for whom you’re applying for child care assistance. Please upload one of the following documents for ONLY each child needing care.",
+            "fields": [
+              {
+                "id": "citizenship_doc_type",
+                "label": "Select one of the following:",
+                "type": "radio",
+                "required": true,
+                "ui": {
+                  "options": [
+                    "US Birth Certificate",
+                    "Alien Registration Card including Permanent Resident or Green Card",
+                    "Passport",
+                    "FS-240 (Report of Birth Abroad of a U.S. Citizen)",
+                    "Naturalization Certificate",
+                    "Other"
+                  ]
+                }
+              },
+              {
+                "id": "citizenship_doc_file",
+                "label": "Upload Citizenship/Immigration Document",
+                "description": "To add a document to your application, you can upload an image or scanned file from your phone or device. Accepted formats include .pdf, .gif, .jpeg, .jpg and .png up to 25 MB. Learn how to upload your files with this Tutorial Video.",
+                "type": "file",
+                "required": true,
+                "constraints": {
+                  "maxFileSizeMB": 25,
+                  "allowedTypes": [
+                    "application/pdf",
+                    "image/jpeg",
+                    "image/jpg",
+                    "image/png",
+                    "image/gif"
+                  ]
+                },
+                "metadata": {
+                  "proofCategory": "Citizenship/Immigration Status",
+                  "multiple": false
+                }
+              }
+            ]
+          },
+          {
+            "id": "child_relationship",
+            "title": "Child’s Relationship to Parent/Applicant",
+            "description": "These documents confirm your relationship to the children in your household under age 18. Please upload one of the following documents for every child in the household under age 18, regardless of whether child care is needed for them or not. If you are a legal guardian with financial responsibility, you must upload a Court order OR a letter of guardianship.",
+            "fields": [
+              {
+                "id": "relationship_doc_type",
+                "label": "Select one of the following:",
+                "type": "radio",
+                "required": true,
+                "ui": {
+                  "options": [
+                    "Birth Certificate",
+                    "Adoption record",
+                    "Baptismal record",
+                    "Passport with parent's signature",
+                    "Court order for legal guardian with financial responsibility",
+                    "Letter of Guardianship",
+                    "Other - CFWB-058 Caretaker Attestation"
+                  ]
+                }
+              },
+              {
+                "id": "relationship_doc_file",
+                "label": "Upload Relationship Document",
+                "description": "To add a document to your application, you can upload an image or scanned file from your phone or device. Accepted formats include .pdf, .gif, .jpeg, .jpg and .png up to 25 MB. Learn how to upload your files with this Tutorial Video.",
+                "type": "file",
+                "required": true,
+                "constraints": {
+                  "maxFileSizeMB": 25,
+                  "allowedTypes": [
+                    "application/pdf",
+                    "image/jpeg",
+                    "image/jpg",
+                    "image/png",
+                    "image/gif"
+                  ]
+                },
+                "metadata": {
+                  "proofCategory": "Child Relationship",
+                  "multiple": false
+                }
+              }
+            ]
+          },
+          {
+            "id": "age_proof",
+            "title": "Age",
+            "description": "These documents confirm the age of the children in your household. Please upload one of the following documents for every child in the household under age 18, regardless of whether child care is needed for them:",
+            "fields": [
+              {
+                "id": "age_doc_type",
+                "label": "Select one of the following:",
+                "type": "radio",
+                "required": true,
+                "ui": {
+                  "options": [
+                    "Birth Certificate",
+                    "Adoption record",
+                    "Baptismal record",
+                    "Alien Registration Card",
+                    "Passport",
+                    "Official hospital documentation of the child’s birth"
+                  ]
+                }
+              },
+              {
+                "id": "age_doc_file",
+                "label": "Upload Age Proof Document",
+                "description": "To add a document to your application, you can upload an image or scanned file from your phone or device. Accepted formats include .pdf, .gif, .jpeg, .jpg and .png up to 25 MB. Learn how to upload your files with this Tutorial Video.",
+                "type": "file",
+                "required": true,
+                "constraints": {
+                  "maxFileSizeMB": 25,
+                  "allowedTypes": [
+                    "application/pdf",
+                    "image/jpeg",
+                    "image/jpg",
+                    "image/png",
+                    "image/gif"
+                  ]
+                },
+                "metadata": {
+                  "proofCategory": "Child Age",
+                  "multiple": false
+                }
+              }
+            ]
+          }
+        ]
+      },
+      {
+        "id": "review",
+        "title": "Review & Submit",
+        "type": "review",
+        "sections": []
+      }
+    ]
+  }
+}

--- a/test-form/public/data/childcare_form.pl.json
+++ b/test-form/public/data/childcare_form.pl.json
@@ -1,0 +1,2287 @@
+{
+  "form": {
+    "title": "Childcare Voucher Application",
+    "description": "Step-by-step form for applying for Childcare Assistance",
+    "layout": {
+      "stepperPosition": "left"
+    },
+    "steps": [
+      {
+        "id": "consent_step",
+        "title": "Consent",
+        "sections": [
+          {
+            "id": "mycity_consent_info",
+            "title": "ModelCity Consent",
+            "type": "info",
+            "ui": {
+              "markdown": true,
+              "collapsible": false,
+              "defaultCollapsed": false
+            },
+            "content": "In connection with this application for child care services, **ModelCity**:\\n\\n- Collects, processes, stores, and shares the information you submit to screen you when you apply for child care services;\\n- Receives, processes, and stores the information the City already knows about you to screen you when you apply for child care services;\\n- Uses your information to improve ModelCity; and\\n- Communicates with you about your ModelCity account.\\n\\n---\\n\\nIf you consent, the following information may be shared between child care services agencies:\\n\\n- Demographic and background information, including address, phone number, household composition.\\n- Housing information, including benefits awarded/received, current housing/shelter status.\\n- Benefits information, including public assistance awarded/received, child care program participation.\\n\\n---\\n\\nIf you choose not to consent, **you will not be denied** any benefits or services you are receiving or any benefits for which you are eligible.\\n\\nThe [ModelCity Privacy Policy](https://www.nyc.gov/privacy) details how ModelCity handles the information you submit through ModelCity."
+          }
+        ]
+      },
+      {
+        "id": "instructions_step",
+        "title": "Instructions",
+        "sections": [
+          {
+            "id": "application_instructions",
+            "title": "Application Instructions",
+            "type": "info",
+            "ui": {
+              "markdown": true,
+              "collapsible": false,
+              "defaultCollapsed": false
+            },
+            "content": "**Let’s get started on your application!**\\n\\nTo complete this application, you will be asked for information about:\\n\\n- Yourself\\n- Your household\\n- Your employment or reason for care\\n- Your income\\n\\nAll required fields are marked and must be filled out to move forward with the application. The pages of the application are shown on the right-hand side of the screen and will be highlighted as you move through the application.\\n\\nYour application will be saved automatically as you progress to each page.  \\nIf you need to pause at any time, click the **“Save for later”** button at the bottom of each page to save your application.  \\nYou can log back in to resume your application.\\n\\nWhen you’re ready to begin, click **“Next”** below.\\n\\n---\\n\\n⚠️ **Important:**  \\nTo keep your information current and safe, applications in draft status that you have not edited for **30 days** will be deleted.  \\nIf your draft application is deleted, you can still create and submit a new application when you're ready to apply."
+          },
+          {
+            "id": "new_york_city_residency",
+            "title": "New York City Residency",
+            "type": "info",
+            "ui": {
+              "markdown": true,
+              "collapsible": true,
+              "defaultCollapsed": true
+            },
+            "content": "You will need to upload **ONE** of the following documents to confirm your NYC residency:\\n\\n- IDNYC\\n- Driver’s License\\n- Utility Bill (dated within the last 60 days, with your address)\\n- Current lease, rent, or mortgage statement (dated within the last 60 days, with your address)\\n- Section 8 Award Letter\\n- NYCHA Certificate\\n- CFWB-027 Housing Attestation with address listed\\n- Shelter Residency Letter with address listed\\n\\nIf you do not have any of those documents, you must submit a **CFWB-067 Residency Attestation**."
+          },
+          {
+            "id": "children_documents",
+            "title": "Children Documents",
+            "type": "info",
+            "ui": {
+              "markdown": true,
+              "collapsible": true,
+              "defaultCollapsed": true
+            },
+            "content": "### Citizenship or Immigration Status\\nThese documents confirm the citizenship or immigration status of the children in your family for whom you’re applying for child care assistance. Please upload one of the following documents for each child needing care. *Do not upload these documents for children who do not need care.*\\n\\n- Birth Certificate from US state or territory\\n- Alien Registration Card including Permanent Resident or Green Card\\n- Passport\\n- FS-240 (Consular Report of Birth Abroad)\\n- Naturalization Certificate\\n- Other documentation that proves child’s immigration status\\n\\n### Child's Relationship to Applicant\\nThese documents confirm your relationship to the children in your household under age 18. Please upload one of the following documents for every child in the household under age 18, regardless of whether they need child care.\\n\\n- Birth certificate\\n- Adoption record\\n- Baptismal record\\n- Passport with parent's signature\\n- Court order for legal guardian with financial responsibility\\n- Letter of guardianship\\n- Other - CFWB-058 Caretaker Attestation\\n\\nIf you are not the child's parent or stepparent, you must submit a **CFWB-058 Caretaker Attestation Form**.\\n\\n### Age of Children\\nYou will need to upload **ONE** of the following documents for every child in the household under age 18, regardless of whether child care is needed for them:\\n\\n- Birth certificate\\n- Adoption record\\n- Baptismal record\\n- Alien Registration Card\\n- Passport\\n- Official hospital documentation of the child’s birth"
+          },
+          {
+            "id": "employment_income",
+            "title": "Employment & Income",
+            "type": "info",
+            "ui": {
+              "markdown": true,
+              "collapsible": true,
+              "defaultCollapsed": true
+            },
+            "content": "### Income\\nThese documents confirm your family’s income.\\n\\n---\\n\\n### If You Are Employed\\nIf you are employed and receive paystubs, you must submit them to confirm your income. The number of paystubs you must submit varies by how often you get paid and whether your payment amount is the same or different each time you are paid – see the table below for details. Submit the most recent paystub you have received, followed by others in consecutive order.\\n\\n**Income Information**\\n\\n| How Often Do You Get Paid? | Always the SAME Amount | DIFFERENT Amounts Each Time |\\n|----------------------------|-------------------------|------------------------------|\\n| Weekly (Every Week) | 4 most recent, consecutive pay stubs | 12 most recent, consecutive pay stubs |\\n| Bi-Weekly (Every Two Weeks) | 2 most recent, consecutive pay stubs | 6 most recent, consecutive pay stubs |\\n| Semi-Monthly (Two Times Per Month) | 2 most recent, consecutive pay stubs | 6 most recent, consecutive pay stubs |\\n| Monthly (One Time Per Month) | 3 most recent, consecutive pay stubs | 3 most recent, consecutive pay stubs |\\n\\nIf you do not have any paystubs, you must submit a **CFWB-015 Referral to Employer for Employee Income Information Form**.\\n\\n---\\n\\n### If You Are Self-Employed\\nIf you have been self-employed for **one year or more**, you must submit a current, complete and signed income tax package (e.g., 1040, 1065, Schedule C, SE for partnership, K-1, etc.).\\n\\nIf you have been self-employed for **less than one year**, you must submit a **CFWB-031 Self-Employment Income Information Attestation Form**.\\n\\n---\\n\\n### Other Income\\nIf you receive other types of income outside or instead of employment income, you must submit your most recent check, pay stub, or current award letter that indicates the amount you receive. If your other income fluctuates, **3 months of documentation is required**.\\n\\nThis includes, but is not limited to:\\n- Income from SSI, SSD\\n- Unemployment benefits\\n- Rental income\\n- Pensions\\n- Annuities\\n- Worker’s compensation\\n- Alimony\\n- Child support"
+          },
+          {
+            "id": "reason_for_care",
+            "title": "Reason for Care",
+            "type": "info",
+            "ui": {
+              "markdown": true,
+              "collapsible": true,
+              "defaultCollapsed": true
+            },
+            "content": "### Reason for Care\\nThese documents confirm your reason for care. Every applicant must have a qualified reason for care; in a two-parent household, parents or caretakers can have the same or different reasons for care. Only the documents related to your stated reasons for care need to be uploaded, and documentation must be uploaded for all parent or caretakers in the household.\\n\\n---\\n\\n### Working 10+ Hours Per Week\\nYour employment or self-employment income documents will cover this reason for care. You do not need to submit additional documentation.\\n\\n---\\n\\n### Participating in an Educational or Vocational Training Program\\nYou will need to upload **ONE** of the following documents to confirm your participation in vocational school, two-year college, or four-year college.\\n\\n- CFWB-005 Vocational, Education and Training Verification Form\\n- A letter from the educational or vocational training program on their official letterhead; this letter must contain all the information required in the CFWB-005 Vocational, Education and Training Verification Form.\\n\\n---\\n\\n### Looking for Work\\nYou will need to upload **ONE** of the following documents to confirm that you are looking for work.\\n\\n- CFWB-026 Work Search Record Form\\n- Approved work search plan from the NYS Dept. of Labor\\n- Proof of receipt of unemployment insurance\\n\\n---\\n\\n### Experiencing Homelessness\\nYou will need to upload **ONE** of the following documents to confirm that you are experiencing homelessness. This includes families who may be living in shelter or sharing the housing of others due to loss of housing, economic hardship, or similar reason.\\n\\n- Shelter Residency Letter (If living in Shelter, including Humanitarian Emergency Relief Centers)\\n- CFWB-027 Housing Attestation (If living doubled-up, in a place not meant for human habitation, in a hotel/motel, or in another living situation)\\n\\n---\\n\\n### Attending Services for Domestic Violence\\nYou will need to upload a referral for services from a domestic violence service provider to confirm that you are attending services for domestic violence.\\n\\n---\\n\\n### Attending Services for Substance Abuse Treatment\\nYou will need to upload a referral for a substance abuse treatment service provider to confirm that you are attending services for substance abuse treatment."
+          },
+          {
+            "id": "additional_details",
+            "title": "Additional Details",
+            "type": "info",
+            "ui": {
+              "markdown": true,
+              "collapsible": true,
+              "defaultCollapsed": true
+            },
+            "content": "### Application Scope\\nThis application is used to apply **only** for **Category 2 or 3 child care assistance** (for families not in receipt of cash assistance). To apply for **Cash Assistance** or other benefits, including **Category 1 Child Care Assistance** (for families in receipt of cash assistance), you must use the **New York State Application for Certain Benefits and Services (LDSS-2921)**.\\n\\n---\\n\\n### Exempt Applicants\\nThe following applicants may be eligible for child care assistance **without regard to income** and do not need to complete this application:\\n\\n- Foster parents who need child care assistance to allow them to work and are only applying for assistance for the foster children;\\n- Families in receipt of protective or preventive services.\\n\\n---\\n\\n### Application Completion\\nAll sections of this form must be filled out to be considered complete **unless the section is identified as optional**. If you do not complete all required sections of this form, you may not be considered for Child Care Assistance.\\n\\n---\\n\\n### Rights and Responsibilities\\nYou may obtain information about your rights and responsibilities [here](https://otda.ny.gov/programs/applications/). If you do not have access to the internet, you can call the **Administration for Children’s Services at 212-835-7610** to request that physical copies of the booklets which highlight your rights and responsibilities be mailed to you, including:\\n\\n- **LDSS-4148A**: What You Should Know About Your Rights and Responsibilities\\n- **LDSS-4148B**: What You Should Know About Social Services Programs\\n- **LDSS-4148C**: What You Should Know If You Have an Emergency"
+          }
+        ]
+      },
+      {
+        "id": "applicant",
+        "title": "Applicant",
+        "sections": [
+          {
+            "id": "personal_info",
+            "title": "Personal Information",
+            "fields": [
+              {
+                "id": "first_name",
+                "label": "First Name",
+                "type": "text",
+                "required": true
+              },
+              {
+                "id": "last_name",
+                "label": "Last Name",
+                "type": "text",
+                "required": true
+              },
+              {
+                "id": "mi",
+                "label": "Middle Initial",
+                "type": "text",
+                "required": false
+              },
+              {
+                "id": "date_of_birth",
+                "label": "Date of Birth",
+                "type": "date",
+                "required": true,
+                "tooltip": "To edit Date of Birth click on NYC ModelCity in the top-left corner then click on Account Settings."
+              },
+              {
+                "id": "sex",
+                "label": "Sex",
+                "type": "radio",
+                "required": true,
+                "ui": {
+                  "options": [
+                    "Male",
+                    "Female"
+                  ]
+                }
+              },
+              {
+                "id": "marital_status",
+                "label": "Marital Status",
+                "type": "select",
+                "required": true,
+                "tooltip": "Indicate your marital status (single, married, divorced, separated or widowed).",
+                "ui": {
+                  "options": [
+                    "",
+                    "Single",
+                    "Married",
+                    "Divorced",
+                    "Widowed",
+                    "Separated"
+                  ]
+                }
+              }
+            ]
+          },
+          {
+            "id": "contact_info",
+            "title": "Contact Information",
+            "fields": [
+              {
+                "id": "telephone_home",
+                "label": "Home Phone",
+                "type": "tel",
+                "required": false,
+                "constraints": {
+                  "pattern": "^\\\\(?[0-9]{3}\\\\)?[-. ]?[0-9]{3}[-. ]?[0-9]{4}$"
+                },
+                "ui": {
+                  "placeholder": "(123) 456-7890"
+                }
+              },
+              {
+                "id": "telephone_work",
+                "label": "Work Phone",
+                "type": "tel",
+                "required": false,
+                "constraints": {
+                  "pattern": "^\\\\(?[0-9]{3}\\\\)?[-. ]?[0-9]{3}[-. ]?[0-9]{4}$"
+                },
+                "ui": {
+                  "placeholder": "(123) 456-7890"
+                }
+              },
+              {
+                "id": "telephone_mobile_or_other",
+                "label": "Mobile or Other Phone",
+                "type": "tel",
+                "required": false,
+                "tooltip": "To edit Telephone (Cell or Other) click on NYC ModelCity in the top-left corner then click on Account Settings and then click on Contact.",
+                "constraints": {
+                  "pattern": "^\\\\(?[0-9]{3}\\\\)?[-. ]?[0-9]{3}[-. ]?[0-9]{4}$"
+                },
+                "ui": {
+                  "placeholder": "(123) 456-7890"
+                }
+              },
+              {
+                "id": "email",
+                "label": "Email",
+                "type": "email",
+                "required": true,
+                "tooltip": "To edit email, go to NYC ID Profile tab by clicking your name at the top right corner"
+              }
+            ]
+          },
+          {
+            "id": "address_info",
+            "title": "Address",
+            "tooltip": "To edit home address click on NYC ModelCity in the top-left corner then click on Account Settings.",
+            "ui": {
+              "autocomplete": "street",
+              "placeholder": "Start typing your street address",
+              "overrideComponent": "AddressAutocomplete"
+            },
+            "metadata": {
+              "integration": {
+                "provider": "Google",
+                "feature": "AddressAutocomplete"
+              },
+              "autofillTargets": [
+                {
+                  "fieldId": "city",
+                  "source": "locality",
+                  "fallbackSources": [
+                    "postal_town",
+                    "sublocality_level_1",
+                    "administrative_area_level_2"
+                  ]
+                },
+                {
+                  "fieldId": "borough",
+                  "source": "sublocality_level_1",
+                  "fallbackSources": [
+                    "administrative_area_level_2"
+                  ],
+                  "mapping": "boroughMap"
+                },
+                { "fieldId": "state", "source": "administrative_area_level_1" },
+                { "fieldId": "zip_code", "source": "postal_code" },
+                { "fieldId": "latitude", "source": "location.latitude" },
+                { "fieldId": "longitude", "source": "location.longitude" }
+              ]
+            },
+            "fields": [
+              {
+                "id": "street",
+                "label": "Street Address",
+                "type": "text",
+                "required": true,
+                "tooltip": "To edit home address click on NYC ModelCity in the top-left corner then click on Account Settings."
+              },
+              {
+                "id": "apt",
+                "label": "Apt #",
+                "type": "text",
+                "required": false
+              },
+              {
+                "id": "city",
+                "label": "City",
+                "type": "text",
+                "required": true
+              },
+              {
+                "id": "borough",
+                "label": "Borough",
+                "type": "select",
+                "required": true,
+                "ui": {
+                  "options": [
+                    "",
+                    "Bronx",
+                    "Brooklyn",
+                    "Manhattan",
+                    "Queens",
+                    "Staten Island"
+                  ]
+                }
+              },
+              {
+                "id": "state",
+                "label": "State",
+                "type": "text",
+                "required": true
+              },
+              {
+                "id": "zip_code",
+                "label": "Zip Code",
+                "type": "text",
+                "required": true
+              },
+              {
+                "id": "latitude",
+                "label": "Latitude",
+                "type": "number",
+                "required": false
+              },
+              {
+                "id": "longitude",
+                "label": "Longitude",
+                "type": "number",
+                "required": false
+              },
+              {
+                "id": "is_temporary_address",
+                "label": "Is Temporary Address",
+                "type": "radio",
+                "required": true,
+                "tooltip": "Check YES if you are currently living in a homeless shelter, doubled-up with another family, in a hotel/motel, in a car/ bus/ train, in a park/campsite, or other temporary accomodation.",
+                "ui": {
+                  "options": [
+                    "Yes",
+                    "No"
+                  ]
+                }
+              },
+              {
+                "id": "currently_living_in",
+                "label": "Currently Living In",
+                "type": "select",
+                "required": false,
+                "requiredCondition": {
+                  "field": "is_temporary_address",
+                  "operator": "equals",
+                  "value": "Yes"
+                },
+                "ui": {
+                  "options": [
+                    "",
+                    "Homeless Shelter",
+                    "Doubled-up with another Family",
+                    "Hotel/Motel",
+                    "Car, Bus, Train",
+                    "Park",
+                    "Campsite",
+                    "Other"
+                  ]
+                }
+              }
+            ]
+          },
+          {
+            "id": "demographics",
+            "title": "Demographics",
+            "fields": [
+              {
+                "id": "ethnicity",
+                "label": "Ethnicity",
+                "type": "select",
+                "required": false,
+                "ui": {
+                  "options": [
+                    "",
+                    "Hispanic",
+                    "Latino",
+                    "No",
+                    "Prefer not to answer"
+                  ]
+                }
+              },
+              {
+                "id": "race",
+                "label": "Race",
+                "type": "checkbox",
+                "required": false,
+                "tooltip": "You may choose multiple race categories. Providing race information is voluntary and will not affect your eligibility for Child Care Assistance or the amount of assistance that you will be given by this agency.",
+                "ui": {
+                  "options": [
+                    {
+                      "value": "AI",
+                      "label": "American Indian or Alaska Native"
+                    },
+                    {
+                      "value": "AS",
+                      "label": "Asian"
+                    },
+                    {
+                      "value": "BL",
+                      "label": "Black or African American"
+                    },
+                    {
+                      "value": "HP",
+                      "label": "Native Hawaiian or Pacific Islander"
+                    },
+                    {
+                      "value": "WH",
+                      "label": "White"
+                    }
+                  ]
+                },
+                "metadata": {
+                  "multiple": true
+                }
+              },
+              {
+                "id": "ssn",
+                "label": "Social Security Number",
+                "type": "text",
+                "tooltip": "To edit social security number click on NYC ModelCity in the top-left corner then click on Account Settings.",
+                "required": false,
+                "constraints": {
+                  "pattern": "^\\\\d{3}-\\\\d{2}-\\\\d{4}$"
+                },
+                "ui": {
+                  "placeholder": "123-45-6789"
+                }
+              }
+            ]
+          },
+          {
+            "id": "language_info",
+            "title": "Language Preferences",
+            "fields": [
+              {
+                "id": "primary_language",
+                "label": "Primary Language",
+                "type": "radio",
+                "required": true,
+                "tooltip": "Select the language that is spoken most often in your household. If “other”, provide the name of the language.",
+                "ui": {
+                  "options": [
+                    "English",
+                    "Spanish",
+                    "Other"
+                  ]
+                }
+              },
+              {
+                "id": "preferred_language",
+                "label": "Preferred Language",
+                "type": "radio",
+                "required": true,
+                "tooltip": "Select the language you prefer to communicate in. If “other”, provide the name of the language.",
+                "ui": {
+                  "options": [
+                    "English",
+                    "Spanish",
+                    "Other"
+                  ]
+                }
+              },
+              {
+                "id": "other_primary_language",
+                "label": "Other Primary Language",
+                "type": "text",
+                "required": false,
+                "requiredCondition": {
+                  "field": "primary_language",
+                  "operator": "equals",
+                  "value": "Other"
+                }
+              },
+              {
+                "id": "other_preferred_language",
+                "label": "Other Preferred Language",
+                "type": "text",
+                "required": false,
+                "requiredCondition": {
+                  "field": "preferred_language",
+                  "operator": "equals",
+                  "value": "Other"
+                }
+              }
+            ]
+          },
+          {
+            "id": "cash_assistance",
+            "title": "Cash Assistance",
+            "fields": [
+              {
+                "id": "has_cash_assistance",
+                "label": "Do you receive Cash Assistance?",
+                "type": "radio",
+                "required": false,
+                "ui": {
+                  "options": [
+                    "Yes",
+                    "No"
+                  ]
+                }
+              },
+              {
+                "id": "ca_number",
+                "label": "Cash Assistance Number",
+                "type": "text",
+                "required": false,
+                "requiredCondition": {
+                  "condition": {
+                    "field": "has_cash_assistance",
+                    "operator": "equals",
+                    "value": "Yes"
+                  }
+                }
+              }
+            ]
+          }
+        ]
+      },
+      {
+        "id": "children_needing_care",
+        "title": "Children Needing Care",
+        "sections": [
+          {
+            "id": "child_details",
+            "title": "Child Details",
+            "required": true,
+            "fields": [
+              {
+                "id": "children",
+                "label": "Children Needing Care",
+                "type": "group",
+                "metadata": {
+                  "multiple": true,
+                  "tableColumns": [
+                  "first_name",
+                  "last_name",
+                  "date_of_birth",
+                  "relationship_to_applicant"
+                  ]
+                },
+                "fields": [
+                  {
+                    "id": "first_name",
+                    "label": "First Name",
+                    "type": "text",
+                    "required": true,
+                    "tooltip": "Provide the first name, last name, and middle initial of each child you are applying for child care assistance for."
+                  },
+                  {
+                    "id": "last_name",
+                    "label": "Last Name",
+                    "type": "text",
+                    "required": true
+                  },
+                  {
+                    "id": "mi",
+                    "label": "Middle Initial",
+                    "type": "text",
+                    "required": false
+                  },
+                  {
+                    "id": "relationship_to_applicant",
+                    "label": "Relationship to Applicant",
+                    "type": "select",
+                    "required": true,
+                    "ui": {
+                      "options": [
+                        "",
+                        "Child",
+                        "Grandchild",
+                        "Foster Child",
+                        "Other"
+                      ]
+                    }
+                  },
+                  {
+                    "id": "date_of_birth",
+                    "label": "Date of Birth",
+                    "type": "date",
+                    "required": true,
+                    "tooltip": "Provide the date of birth."
+                  },
+                  {
+                    "id": "sex",
+                    "label": "Sex",
+                    "type": "radio",
+                    "required": true,
+                    "tooltip": "Select to indicate the sex.",
+                    "ui": {
+                      "options": [
+                        "Male",
+                        "Female"
+                      ]
+                    }
+                  },
+                  {
+                    "id": "ethnicity",
+                    "label": "Ethnicity Hispanic or Latino",
+                    "type": "select",
+                    "required": false,
+                    "tooltip": "Check “YES” or “NO” to indicate if each child in need of child care is Hispanic or Latino or not. Providing ethnicity information is voluntary and will not affect your eligibility for child care assistance or the amount of assistance that you will be given by this agency.",
+                    "ui": {
+                      "options": [
+                        "",
+                        "Yes",
+                        "No",
+                        "Prefer not to answer"
+                      ]
+                    }
+                  },
+                  {
+                    "id": "race",
+                    "label": "Race",
+                    "type": "checkbox",
+                    "required": false,
+                    "tooltip": "You may choose multiple race categories for a single child. Providing race information is voluntary and will not affect your eligibility for Child Care Assistance or the amount of assistance that you will be given by this agency.",
+                    "ui": {
+                      "options": [
+                        {
+                          "value": "AI",
+                          "label": "American Indian or Alaska Native"
+                        },
+                        {
+                          "value": "AS",
+                          "label": "Asian"
+                        },
+                        {
+                          "value": "BL",
+                          "label": "Black or African American"
+                        },
+                        {
+                          "value": "HP",
+                          "label": "Native Hawaiian or Pacific Islander"
+                        },
+                        {
+                          "value": "WH",
+                          "label": "White"
+                        }
+                      ]
+                    },
+                    "metadata": {
+                      "multiple": true
+                    }
+                  },
+                  {
+                    "id": "ssn",
+                    "label": "Social Security Number",
+                    "type": "text",
+                    "required": false,
+                    "tooltip": "Provide each child’s Social Security Number (SSN). You are not required to provide SSNs. They may be used by federal, state, and local agencies to prevent duplication of services and fraud, and for Federal Reporting.",
+                    "constraints": {
+                      "pattern": "^\\\\d{3}-\\\\d{2}-\\\\d{4}$"
+                    },
+                    "ui": {
+                      "placeholder": "123-45-6789"
+                    }
+                  },
+                  {
+                    "id": "do_both_parents_reside_in_home",
+                    "label": "Do both parents reside in the home?",
+                    "type": "radio",
+                    "required": true,
+                    "tooltip": "Check “YES” or “NO” to indicate whether both of the child’s parents live in the home.",
+                    "ui": {
+                      "options": [
+                        "Yes",
+                        "No"
+                      ]
+                    }
+                  },
+                  {
+                    "id": "has_disability",
+                    "label": "Does the child have a disability?",
+                    "type": "radio",
+                    "required": true,
+                    "tooltip": "Check “YES” or “NO” to indicate whether the child needing child care has a disability.",
+                    "ui": {
+                      "options": [
+                        "Yes",
+                        "No"
+                      ]
+                    }
+                  },
+                  {
+                    "id": "is_immigration_status_satisfactory",
+                    "label": "Is child U.S. Citizen, U.S. National, or person with satisfactory immigration status?",
+                    "type": "radio",
+                    "required": true,
+                    "tooltip": "You will only be asked about the immigration status of the children in need of care. Other members of the family will not need to state or prove their immigration status. Your child will be eligible for care if they are a U.S. citizen, a legal permanent resident (green card holder), a refugee, or an asylee; have a T-visa; or hold another qualified immigration status. Please select “Yes” if your child holds one of these statuses.",
+                    "ui": {
+                      "options": [
+                        "Yes",
+                        "No"
+                      ]
+                    }
+                  }
+                ]
+              }
+            ]
+          }
+        ]
+      },
+      {
+        "id": "family_members",
+        "title": "Family Members",
+        "sections": [
+          {
+            "id": "household_members_info",
+            "title": "Household Members Information",
+            "type": "info",
+            "ui": {
+              "markdown": true,
+              "collapsible": false,
+              "defaultCollapsed": false
+            },
+            "content": "**List the household members who do _not_ need child care.**\\n\\nIf applicable, list:\\n\\n- Your **spouse**, your child’s **second parent**, **caretaker**, or **step-parent**\\n- Any other **adult with whom you share a child**, if they live in your home\\n\\nThen, if applicable, list:\\n\\n- Any **siblings under the age of 18** who live in your home\\n\\n> **Only list other household members** — such as **aunts, uncles, cousins, grandparents, or friends** — _if they have financial responsibility_ for the child.\\n\\nA household member with financial responsibility, other than a parent or step-parent, is one who has a **letter or order of guardianship**.\\n\\n**Otherwise, do not include them.**"
+          },
+          {
+            "id": "family_member_details",
+            "title": "Household Member Details",
+            "description": "Include household members who do not need child care assistance (e.g., spouse, partner, other children).",
+            "fields": [
+              {
+                "id": "familymember",
+                "label": "Family Members",
+                "type": "group",
+                "requiredCondition": {
+                  "repeatingGroup": "children",
+                  "operator": "ANY",
+                  "condition": { "field": "do_both_parents_reside_in_home", "operator": "equals", "value": "Yes" }
+                },  
+                "metadata": {
+                  "multiple": true,
+                  "tableColumns": [
+                    "first_name",
+                    "last_name",
+                    "relationship_to_applicant",
+                    "date_of_birth"
+                  ]
+                },
+                "fields": [
+                  {
+                    "id": "first_name",
+                    "label": "First Name",
+                    "type": "text",
+                    "required": true,
+                    "tooltip": "Provide last and first name, and middle initial if applicable."
+                  },
+                  {
+                    "id": "last_name",
+                    "label": "Last Name",
+                    "type": "text",
+                    "required": true
+                  },
+                  {
+                    "id": "mi",
+                    "label": "Middle Initial",
+                    "type": "text",
+                    "required": false
+                  },
+                  {
+                    "id": "relationship_to_applicant",
+                    "label": "Relationship to Applicant",
+                    "type": "select",
+                    "required": true,
+                    "tooltip": "Provide each person’s relationship to you (e.g. spouse, partner, child, foster parent, other).",
+                    "ui": {
+                      "options": [
+                        "",
+                        "Spouse",
+                        "Partner",
+                        "Foster Parent",
+                        "Child",
+                        "Other"
+                      ]
+                    }
+                  },
+                  {
+                    "id": "date_of_birth",
+                    "label": "Date of Birth",
+                    "type": "date",
+                    "required": true,
+                    "tooltip": "Provide the family member's date of birth."
+                  },
+                  {
+                    "id": "sex",
+                    "label": "Sex",
+                    "type": "radio",
+                    "required": true,
+                    "tooltip": "Indicate the sex for each family member listed.",
+                    "ui": {
+                      "options": [
+                        "Male",
+                        "Female"
+                      ]
+                    }
+                  },
+                  {
+                    "id": "ethnicity",
+                    "label": "Ethnicity Hispanic or Latino",
+                    "type": "select",
+                    "required": false,
+                    "tooltip": "Check “YES” or “NO” to indicate if each member in the household is Hispanic or Latino or not. Providing ethnicity information is voluntary and will not affect your eligibility for Child Care Assistance or the amount of assistance that you will be given by this agency.",
+                    "ui": {
+                      "options": [
+                        "",
+                        "Yes",
+                        "No",
+                        "Prefer not to answer"
+                      ]
+                    }
+                  },
+                  {
+                    "id": "race",
+                    "label": "Race",
+                    "type": "checkbox",
+                    "required": false,
+                    "tooltip": "You may choose multiple race categories for a single person. Providing race information is voluntary and will not affect your eligibility for Child Care Assistance or the amount of assistance that you will be given by this agency.",
+                    "ui": {
+                      "options": [
+                        {
+                          "value": "AI",
+                          "label": "American Indian or Alaska Native"
+                        },
+                        {
+                          "value": "AS",
+                          "label": "Asian"
+                        },
+                        {
+                          "value": "BL",
+                          "label": "Black or African American"
+                        },
+                        {
+                          "value": "HP",
+                          "label": "Native Hawaiian or Pacific Islander"
+                        },
+                        {
+                          "value": "WH",
+                          "label": "White"
+                        }
+                      ]
+                    },
+                    "metadata": {
+                      "multiple": true
+                    }
+                  },
+                  {
+                    "id": "ssn",
+                    "label": "Social Security Number",
+                    "type": "text",
+                    "required": false,
+                    "tooltip": "Fill in the Social Security Number (SSN) for your family members. SSN is optional. SSN may be used by federal, state, and local agencies to prevent duplication of services and fraud, and for Federal Reporting.",
+                    "constraints": {
+                      "pattern": "^\\\\d{3}-\\\\d{2}-\\\\d{4}$"
+                    },
+                    "ui": {
+                      "placeholder": "123-45-6789"
+                    }
+                  }
+                ]
+              }
+            ]
+          }
+        ]
+      },
+      {
+        "id": "child_family_needs",
+        "title": "Child / Family Needs",
+        "sections": [
+          {
+            "id": "assistance_reason",
+            "title": "Reason for Child Care Assistance",
+            "description": "Select one or two reasons you are requesting Child Care Assistance.",
+            "tooltip": "Select one reason. In a two-parent household, parents/caretakers can have the same or different reasons for needing child care. Both parents/caretakers will be required to submit documentation in support of their own reason. If you are living in temporary housing, please select Homelessness even if you have another reason that applies to you.",
+            "fields": [
+              {
+                "id": "assistance_reason",
+                "label": "Reason(s) for Assistance",
+                "type": "select",
+                "required": true,
+                "ui": {
+                  "options": [
+                    "",
+                    "Employment",
+                    "Looking for Work",
+                    "Vocational Training/Educational Activities",
+                    "Receiving Domestic Violence Services",
+                    "Homelessness"
+                  ]
+                },
+                "constraints": {
+                  "minSelections": 1,
+                  "maxSelections": 2
+                },
+                "metadata": {
+                  "multiple": true
+                }
+              }
+            ]
+          },
+          {
+            "id": "military_status",
+            "title": "Military and Parental Availability",
+            "description": "Provide information about parental military status and availability for child care.",
+            "fields": [
+              {
+                "id": "is_parent_currently_active_in_military",
+                "label": "Is a Parent Currently Active Full-Time in the U.S. Military?",
+                "tooltip": "Check “YES” or “NO” to indicate whether a parent is currently active full-time in the U.S. Military.",
+                "type": "radio",
+                "required": true,
+                "ui": {
+                  "options": [
+                    "Yes",
+                    "No"
+                  ]
+                }
+              },
+              {
+                "id": "is_parent_mem_of_guard_or_mru",
+                "label": "Is a Parent a Member of National Guard or Military Reserve Unit?",
+                "tooltip": "Check “YES” or “NO” to indicate whether a parent is currently a member of a National Guard or Military Reserve Unit.",
+                "type": "radio",
+                "required": true,
+                "ui": {
+                  "options": [
+                    "Yes",
+                    "No"
+                  ]
+                }
+              },
+              {
+                "id": "is_non_custodial_parent_available",
+                "label": "Is the Non-Custodial Parent Available to Provide Care?",
+                "tooltip": "Check “YES” or “NO” to indicate whether there is a non-custodial parent available to provide child care.",
+                "type": "radio",
+                "required": true,
+                "ui": {
+                  "options": [
+                    "Yes",
+                    "No"
+                  ]
+                }
+              }
+            ]
+          },
+          {
+            "id": "duplicate_application",
+            "title": "Other Applications",
+            "description": "Indicate if you are also applying for or receiving child care from other agencies.",
+            "tooltip": "Indicate whether you are currently receiving or have applied for child care assistance with one of the agencies or organizations listed below. Note: If you are receiving Cash Assistance and are interested in child care assistance, you must apply through the Human Resources Administration. Reach out to your Benefits Access Center or visit the Human Resources Administration webpage.",
+            "fields": [
+              {
+                "id": "duplicate_app",
+                "label": "Are You Receiving or Applying for Child Care Through Another Agency?",
+                "type": "select",
+                "required": false,
+                "ui": {
+                  "options": [
+                    "",
+                    "Not Applicable",
+                    "Department of Education (DOE)",
+                    "Human Resources Administration (HRA)",
+                    "Department of Youth and Community Development (DYCD)",
+                    "Department of Homeless Services (DHS)",
+                    "Consortium for Worker Education (CWE)",
+                    "Administration for Children's Services (ACS)"
+                  ]
+                }
+              }
+            ]
+          }
+        ]
+      },
+      {
+        "id": "employment",
+        "title": "Employment",
+        "sections": [
+          {
+            "id": "employment_precheck",
+            "title": "Tell us about your employment",
+            "description": "Tell us about your employment",
+            "fields": [
+              {
+                "id": "applicant_emp_income_indicator",
+                "label": "Does applicant earn any income/ wages from employment? ",
+                "type": "radio",
+                "required": false,
+                "ui": {
+                  "options": [
+                    "Yes",
+                    "No"
+                  ]
+                }
+              },
+              {
+                "id": "coparent_emp_income_indicator",
+                "label": "Does Coparent/2nd Guardian earn any income/ wages from employment? ",
+                "type": "radio",
+                "required": false,
+                "ui": {
+                  "options": [
+                    "Yes",
+                    "No"
+                  ]
+                }
+              }
+            ]
+          },
+          {
+            "id": "applicant_jobs",
+            "title": "Applicant Employment Information",
+            "description": "Enter details for up to two jobs held by the applicant.",
+            "visibilityCondition": {
+              "field": "applicant_emp_income_indicator",
+              "operator": "equals",
+              "value": "Yes"
+            },
+            "fields": [
+              {
+                "id": "applicant_1st_job_start_date",
+                "label": "1st Job - Start Date",
+                "type": "date",
+                "required": false,
+                "ui": {
+                  "group": "1st Job"
+                }
+              },
+              {
+                "id": "applicant_1st_job_rotating_shift",
+                "label": "1st Job - Has Rotating Shift?",
+                "type": "radio",
+                "required": false,
+                "ui": {
+                  "options": [
+                    "Yes",
+                    "No"
+                  ],
+                  "group": "1st Job"
+                }
+              },
+              {
+                "id": "applicant_1st_job_requires_overtime",
+                "label": "1st Job - Requires Overtime?",
+                "type": "radio",
+                "required": false,
+                "ui": {
+                  "options": [
+                    "Yes",
+                    "No"
+                  ],
+                  "group": "1st Job"
+                }
+              },
+              {
+                "id": "applicant_1st_job_employer_name",
+                "label": "1st Job - Employer Name",
+                "type": "text",
+                "required": false,
+                "ui": {
+                  "group": "1st Job"
+                }
+              },
+              {
+                "id": "applicant_1st_job_employer_phone",
+                "label": "1st Job - Employer Phone",
+                "type": "tel",
+                "required": false,
+                "ui": {
+                  "group": "1st Job"
+                }
+              },
+              {
+                "id": "applicant_1st_job_employer_street",
+                "label": "1st Job - Employer Street Address",
+                "type": "text",
+                "required": false,
+                "ui": {
+                  "group": "1st Job"
+                }
+              },
+              {
+                "id": "applicant_1st_job_employer_city",
+                "label": "1st Job - Employer City",
+                "type": "text",
+                "required": false,
+                "ui": {
+                  "group": "1st Job"
+                }
+              },
+              {
+                "id": "applicant_1st_job_employer_state",
+                "label": "1st Job - Employer State",
+                "type": "text",
+                "required": false,
+                "ui": {
+                  "group": "1st Job"
+                }
+              },
+              {
+                "id": "applicant_1st_job_employer_zipcode",
+                "label": "1st Job - Employer ZIP Code",
+                "type": "text",
+                "required": false,
+                "ui": {
+                  "group": "1st Job"
+                }
+              },
+              {
+                "id": "applicant_2nd_job_start_date",
+                "label": "2nd Job - Start Date",
+                "type": "date",
+                "required": false,
+                "ui": {
+                  "group": "2nd Job"
+                }
+              },
+              {
+                "id": "applicant_2nd_job_rotating_shift",
+                "label": "2nd Job - Has Rotating Shift?",
+                "type": "radio",
+                "required": false,
+                "ui": {
+                  "options": [
+                    "Yes",
+                    "No"
+                  ],
+                  "group": "2nd Job"
+                }
+              },
+              {
+                "id": "applicant_2nd_job_requires_overtime",
+                "label": "2nd Job - Requires Overtime?",
+                "type": "radio",
+                "required": false,
+                "ui": {
+                  "options": [
+                    "Yes",
+                    "No"
+                  ],
+                  "group": "2nd Job"
+                }
+              },
+              {
+                "id": "applicant_2nd_job_employer_name",
+                "label": "2nd Job - Employer Name",
+                "type": "text",
+                "required": false,
+                "ui": {
+                  "group": "2nd Job"
+                }
+              },
+              {
+                "id": "applicant_2nd_job_employer_phone",
+                "label": "2nd Job - Employer Phone",
+                "type": "tel",
+                "required": false,
+                "ui": {
+                  "group": "2nd Job"
+                }
+              },
+              {
+                "id": "applicant_2nd_job_employer_street",
+                "label": "2nd Job - Employer Street Address",
+                "type": "text",
+                "required": false,
+                "ui": {
+                  "group": "2nd Job"
+                }
+              },
+              {
+                "id": "applicant_2nd_job_employer_city",
+                "label": "2nd Job - Employer City",
+                "type": "text",
+                "required": false,
+                "ui": {
+                  "group": "2nd Job"
+                }
+              },
+              {
+                "id": "applicant_2nd_job_employer_state",
+                "label": "2nd Job - Employer State",
+                "type": "text",
+                "required": false,
+                "ui": {
+                  "group": "2nd Job"
+                }
+              },
+              {
+                "id": "applicant_2nd_job_employer_zipcode",
+                "label": "2nd Job - Employer ZIP Code",
+                "type": "text",
+                "required": false,
+                "ui": {
+                  "group": "2nd Job"
+                }
+              }
+            ]
+          },
+          {
+            "id": "second_parent_jobs",
+            "title": "Second Parent Employment Information",
+            "description": "Enter details for up to two jobs held by the second parent (if applicable).",
+            "visibilityCondition": {
+              "field": "coparent_emp_income_indicator",
+              "operator": "equals",
+              "value": "Yes"
+            },
+            "fields": [
+              {
+                "id": "second_parent_1st_job_start_date",
+                "label": "1st Job - Start Date",
+                "type": "date",
+                "required": false
+              },
+              {
+                "id": "second_parent_1st_job_rotating_shift",
+                "label": "1st Job - Has Rotating Shift?",
+                "type": "radio",
+                "required": false,
+                "ui": {
+                  "options": [
+                    "Yes",
+                    "No"
+                  ]
+                }
+              },
+              {
+                "id": "second_parent_1st_job_requires_overtime",
+                "label": "1st Job - Requires Overtime?",
+                "type": "radio",
+                "required": false,
+                "ui": {
+                  "options": [
+                    "Yes",
+                    "No"
+                  ]
+                }
+              },
+              {
+                "id": "second_parent_1st_job_employer_name",
+                "label": "1st Job - Employer Name",
+                "type": "text",
+                "required": false
+              },
+              {
+                "id": "second_parent_1st_job_employer_phone",
+                "label": "1st Job - Employer Phone",
+                "type": "tel",
+                "required": false
+              },
+              {
+                "id": "second_parent_1st_job_employer_street",
+                "label": "1st Job - Employer Street Address",
+                "type": "text",
+                "required": false
+              },
+              {
+                "id": "second_parent_1st_job_employer_city",
+                "label": "1st Job - Employer City",
+                "type": "text",
+                "required": false
+              },
+              {
+                "id": "second_parent_1st_job_employer_state",
+                "label": "1st Job - Employer State",
+                "type": "text",
+                "required": false
+              },
+              {
+                "id": "second_parent_1st_job_employer_zipcode",
+                "label": "1st Job - Employer ZIP Code",
+                "type": "text",
+                "required": false
+              },
+              {
+                "id": "second_parent_2nd_job_start_date",
+                "label": "2nd Job - Start Date",
+                "type": "date",
+                "required": false
+              },
+              {
+                "id": "second_parent_2nd_job_rotating_shift",
+                "label": "2nd Job - Has Rotating Shift?",
+                "type": "radio",
+                "required": false,
+                "ui": {
+                  "options": [
+                    "Yes",
+                    "No"
+                  ]
+                }
+              },
+              {
+                "id": "second_parent_2nd_job_requires_overtime",
+                "label": "2nd Job - Requires Overtime?",
+                "type": "radio",
+                "required": false,
+                "ui": {
+                  "options": [
+                    "Yes",
+                    "No"
+                  ]
+                }
+              },
+              {
+                "id": "second_parent_2nd_job_employer_name",
+                "label": "2nd Job - Employer Name",
+                "type": "text",
+                "required": false
+              },
+              {
+                "id": "second_parent_2nd_job_employer_phone",
+                "label": "2nd Job - Employer Phone",
+                "type": "tel",
+                "required": false
+              },
+              {
+                "id": "second_parent_2nd_job_employer_street",
+                "label": "2nd Job - Employer Street Address",
+                "type": "text",
+                "required": false
+              },
+              {
+                "id": "second_parent_2nd_job_employer_city",
+                "label": "2nd Job - Employer City",
+                "type": "text",
+                "required": false
+              },
+              {
+                "id": "second_parent_2nd_job_employer_state",
+                "label": "2nd Job - Employer State",
+                "type": "text",
+                "required": false
+              },
+              {
+                "id": "second_parent_2nd_job_employer_zipcode",
+                "label": "2nd Job - Employer ZIP Code",
+                "type": "text",
+                "required": false
+              }
+            ]
+          }
+        ]
+      },
+      {
+        "id": "schedule",
+        "title": "Work/Activity/Travel Time Schedule",
+        "sections": [
+          {
+            "id": "schedule_section_info",
+            "title": "Schedule Information",
+            "type": "info",
+            "ui": {
+              "markdown": true,
+              "collapsible": false,
+              "defaultCollapsed": false
+            },
+            "content": "Please indicate what days and hours you will need child care for based on your reason for care.\\n\\n- **Employed**: Indicate the hours you attend work\\n- **Educational or Vocational Program**: Indicate the hours you attend school or your program\\n- **Looking for Work**: Indicate the hours you spend looking for work\\n- **Homeless**: Indicate the hours you spend looking for housing\\n- **Attending Services for Domestic Violence**: Indicate the hours you attend services.\\n- **Attending Services for Substance Abuse Treatment**: Indicate the hours you attend services."
+          },
+          {
+            "id": "first_parent_activity_schedule",
+            "title": "First Parent Activity Schedule",
+            "description": "Enter the start and end times for each day of the week for the first parent's activities.",
+            "ui": {
+              "layout": "table",
+              "columns": [
+                "Start Time",
+                "End Time"
+              ],
+              "rowCopy": {
+                "enableUserPickSource": true,
+                "rowIdentifier": "ui.rowGroup",
+                "fieldsToCopy": [
+                  1,
+                  2
+                ],
+                "targetRowValues": [
+                  "Monday",
+                  "Tuesday",
+                  "Wednesday",
+                  "Thursday",
+                  "Friday"
+                ],
+                "copyControlLabel": "Apply selected schedule to other weekdays",
+                "sourceOptions": [
+                  "Monday",
+                  "Tuesday",
+                  "Wednesday",
+                  "Thursday",
+                  "Friday",
+                  "Saturday",
+                  "Sunday"
+                ]
+              }
+            },
+            "fields": [
+              {
+                "id": "fp_monday_from",
+                "label": "Monday From",
+                "type": "time",
+                "ui": {
+                  "rowGroup": "Monday",
+                  "column": 1
+                }
+              },
+              {
+                "id": "fp_monday_to",
+                "label": "Monday To",
+                "type": "time",
+                "ui": {
+                  "rowGroup": "Monday",
+                  "column": 2
+                }
+              },
+              {
+                "id": "fp_tuesday_from",
+                "label": "Tuesday From",
+                "type": "time",
+                "ui": {
+                  "rowGroup": "Tuesday",
+                  "column": 1
+                }
+              },
+              {
+                "id": "fp_tuesday_to",
+                "label": "Tuesday To",
+                "type": "time",
+                "ui": {
+                  "rowGroup": "Tuesday",
+                  "column": 2
+                }
+              },
+              {
+                "id": "fp_wednesday_from",
+                "label": "Wednesday From",
+                "type": "time",
+                "ui": {
+                  "rowGroup": "Wednesday",
+                  "column": 1
+                }
+              },
+              {
+                "id": "fp_wednesday_to",
+                "label": "Wednesday To",
+                "type": "time",
+                "ui": {
+                  "rowGroup": "Wednesday",
+                  "column": 2
+                }
+              },
+              {
+                "id": "fp_thursday_from",
+                "label": "Thursday From",
+                "type": "time",
+                "ui": {
+                  "rowGroup": "Thursday",
+                  "column": 1
+                }
+              },
+              {
+                "id": "fp_thursday_to",
+                "label": "Thursday To",
+                "type": "time",
+                "ui": {
+                  "rowGroup": "Thursday",
+                  "column": 2
+                }
+              },
+              {
+                "id": "fp_friday_from",
+                "label": "Friday From",
+                "type": "time",
+                "ui": {
+                  "rowGroup": "Friday",
+                  "column": 1
+                }
+              },
+              {
+                "id": "fp_friday_to",
+                "label": "Friday To",
+                "type": "time",
+                "ui": {
+                  "rowGroup": "Friday",
+                  "column": 2
+                }
+              },
+              {
+                "id": "fp_saturday_from",
+                "label": "Saturday From",
+                "type": "time",
+                "ui": {
+                  "rowGroup": "Saturday",
+                  "column": 1
+                }
+              },
+              {
+                "id": "fp_saturday_to",
+                "label": "Saturday To",
+                "type": "time",
+                "ui": {
+                  "rowGroup": "Saturday",
+                  "column": 2
+                }
+              },
+              {
+                "id": "fp_sunday_from",
+                "label": "Sunday From",
+                "type": "time",
+                "ui": {
+                  "rowGroup": "Sunday",
+                  "column": 1
+                }
+              },
+              {
+                "id": "fp_sunday_to",
+                "label": "Sunday To",
+                "type": "time",
+                "ui": {
+                  "rowGroup": "Sunday",
+                  "column": 2
+                }
+              }
+            ]
+          },
+          {
+            "id": "second_parent_activity_schedule",
+            "title": "Second Parent Activity Schedule",
+            "description": "Enter the start and end times for each day of the week for the second parent's activities.",
+            "ui": {
+              "layout": "table",
+              "columns": [
+                "Start Time",
+                "End Time"
+              ],
+              "rowCopy": {
+                "enableUserPickSource": true,
+                "rowIdentifier": "ui.rowGroup",
+                "fieldsToCopy": [
+                  1,
+                  2
+                ],
+                "targetRowValues": [
+                  "Monday",
+                  "Tuesday",
+                  "Wednesday",
+                  "Thursday",
+                  "Friday"
+                ],
+                "copyControlLabel": "Apply selected schedule to other weekdays",
+                "sourceOptions": [
+                  "Monday",
+                  "Tuesday",
+                  "Wednesday",
+                  "Thursday",
+                  "Friday",
+                  "Saturday",
+                  "Sunday"
+                ]
+              }
+            },
+            "fields": [
+              {
+                "id": "sp_monday_from",
+                "label": "Monday From",
+                "type": "time",
+                "ui": {
+                  "rowGroup": "Monday",
+                  "column": 1
+                }
+              },
+              {
+                "id": "sp_monday_to",
+                "label": "Monday To",
+                "type": "time",
+                "ui": {
+                  "rowGroup": "Monday",
+                  "column": 2
+                }
+              },
+              {
+                "id": "sp_tuesday_from",
+                "label": "Tuesday From",
+                "type": "time",
+                "ui": {
+                  "rowGroup": "Tuesday",
+                  "column": 1
+                }
+              },
+              {
+                "id": "sp_tuesday_to",
+                "label": "Tuesday To",
+                "type": "time",
+                "ui": {
+                  "rowGroup": "Tuesday",
+                  "column": 2
+                }
+              },
+              {
+                "id": "sp_wednesday_from",
+                "label": "Wednesday From",
+                "type": "time",
+                "ui": {
+                  "rowGroup": "Wednesday",
+                  "column": 1
+                }
+              },
+              {
+                "id": "sp_wednesday_to",
+                "label": "Wednesday To",
+                "type": "time",
+                "ui": {
+                  "rowGroup": "Wednesday",
+                  "column": 2
+                }
+              },
+              {
+                "id": "sp_thursday_from",
+                "label": "Thursday From",
+                "type": "time",
+                "ui": {
+                  "rowGroup": "Thursday",
+                  "column": 1
+                }
+              },
+              {
+                "id": "sp_thursday_to",
+                "label": "Thursday To",
+                "type": "time",
+                "ui": {
+                  "rowGroup": "Thursday",
+                  "column": 2
+                }
+              },
+              {
+                "id": "sp_friday_from",
+                "label": "Friday From",
+                "type": "time",
+                "ui": {
+                  "rowGroup": "Friday",
+                  "column": 1
+                }
+              },
+              {
+                "id": "sp_friday_to",
+                "label": "Friday To",
+                "type": "time",
+                "ui": {
+                  "rowGroup": "Friday",
+                  "column": 2
+                }
+              },
+              {
+                "id": "sp_saturday_from",
+                "label": "Saturday From",
+                "type": "time",
+                "ui": {
+                  "rowGroup": "Saturday",
+                  "column": 1
+                }
+              },
+              {
+                "id": "sp_saturday_to",
+                "label": "Saturday To",
+                "type": "time",
+                "ui": {
+                  "rowGroup": "Saturday",
+                  "column": 2
+                }
+              },
+              {
+                "id": "sp_sunday_from",
+                "label": "Sunday From",
+                "type": "time",
+                "ui": {
+                  "rowGroup": "Sunday",
+                  "column": 1
+                }
+              },
+              {
+                "id": "sp_sunday_to",
+                "label": "Sunday To",
+                "type": "time",
+                "ui": {
+                  "rowGroup": "Sunday",
+                  "column": 2
+                }
+              }
+            ]
+          },
+          {
+            "id": "first_parent_travel_time",
+            "title": "First Parent Travel Time",
+            "description": "Enter the travel times and method of transport for the first parent.",
+            "fields": [
+              {
+                "id": "fp_dropoff_travel_time",
+                "label": "Drop-off Travel Time",
+                "type": "select",
+                "tooltip": "Select your typical travel time from work/activity to your child care provider",
+                "ui": {
+                  "options": [
+                    "",
+                    "15 min",
+                    "30 min",
+                    "45 min",
+                    "1 hour",
+                    "More than 1 hour"
+                  ]
+                }
+              },
+              {
+                "id": "fp_dropoff_time_gt_1hr",
+                "label": "Drop-off Time (if > 1 hour)",
+                "type": "text",
+                "requiredCondition": {
+                  "field": "fp_dropoff_travel_time",
+                  "operator": "equals",
+                  "value": "More than 1 hour"
+                }
+              },
+              {
+                "id": "fp_pickup_travel_time",
+                "label": "Pick-up Travel Time",
+                "type": "select",
+                "tooltip": "Select your typical travel time from work/activity to your child care provider",
+                "ui": {
+                  "options": [
+                    "",
+                    "15 min",
+                    "30 min",
+                    "45 min",
+                    "1 hour",
+                    "More than 1 hour"
+                  ]
+                }
+              },
+              {
+                "id": "fp_pickup_time_gt_1hr",
+                "label": "Pick-up Time (if > 1 hour)",
+                "type": "text",
+                "requiredCondition": {
+                  "field": "fp_pickup_travel_time",
+                  "operator": "equals",
+                  "value": "More than 1 hour"
+                }
+              },
+              {
+                "id": "fp_public_transport_dropoff",
+                "label": "Public Transport for Drop-off?",
+                "type": "radio",
+                "tooltip": "Indicate if the applicant uses public transportation to travel to and from work/activity to provider.",
+                "ui": {
+                  "options": [
+                    "Yes",
+                    "No"
+                  ]
+                }
+              },
+              {
+                "id": "fp_public_transport_pickup",
+                "label": "Public Transport for Pick-up?",
+                "tooltip": "Indicate if the applicant uses public transportation to travel to and from work/activity to provider.",
+                "type": "radio",
+                "ui": {
+                  "options": [
+                    "Yes",
+                    "No"
+                  ]
+                }
+              }
+            ]
+          },
+          {
+            "id": "second_parent_travel_time",
+            "title": "Second Parent Travel Time",
+            "description": "Enter the travel times and method of transport for the second parent.",
+            "fields": [
+              {
+                "id": "sp_dropoff_travel_time",
+                "label": "Drop-off Travel Time",
+                "type": "select",
+                "ui": {
+                  "options": [
+                    "",
+                    "15 min",
+                    "30 min",
+                    "45 min",
+                    "1 hour",
+                    "More than 1 hour"
+                  ]
+                }
+              },
+              {
+                "id": "sp_pickup_travel_time",
+                "label": "Pick-up Travel Time",
+                "type": "select",
+                "ui": {
+                  "options": [
+                    "",
+                    "15 min",
+                    "30 min",
+                    "45 min",
+                    "1 hour",
+                    "More than 1 hour"
+                  ]
+                }
+              },
+              {
+                "id": "sp_dropoff_time_gt_1hr",
+                "label": "Drop-off Time (if > 1 hour)",
+                "type": "text",
+                "requiredCondition": {
+                  "field": "sp_dropoff_travel_time",
+                  "operator": "equals",
+                  "value": "More than 1 hour"
+                }
+              },
+              {
+                "id": "sp_pickup_time_gt_1hr",
+                "label": "Pick-up Time (if > 1 hour)",
+                "type": "text",
+                "requiredCondition": {
+                  "field": "sp_pickup_travel_time",
+                  "operator": "equals",
+                  "value": "More than 1 hour"
+                }
+              },
+              {
+                "id": "sp_public_transport_dropoff",
+                "label": "Public Transport for Drop-off?",
+                "type": "radio",
+                "ui": {
+                  "options": [
+                    "Yes",
+                    "No"
+                  ]
+                }
+              },
+              {
+                "id": "sp_public_transport_pickup",
+                "label": "Public Transport for Pick-up?",
+                "type": "radio",
+                "ui": {
+                  "options": [
+                    "Yes",
+                    "No"
+                  ]
+                }
+              }
+            ]
+          }
+        ]
+      },
+      {
+        "id": "income",
+        "title": "Income Information",
+        "sections": [
+          {
+            "id": "income_step_info",
+            "title": "Instructions",
+            "type": "info",
+            "ui": {
+              "markdown": true,
+              "collapsible": false,
+              "defaultCollapsed": false
+            },
+            "content": "Please include income/benefits information for yourself and, if applicable, your spouse, your child’s second caretaker, and/or any other adult with whom you share a child, if they live in your home.\\n\\nIndicate if you receive money from the following sources by selecting “Yes” or “No.” If you select “Yes,” you will be asked for additional information.\\n\\nIf the second caretaker in the household also receives the same income source, add a separate line for their income."
+          },
+          {
+            "id": "income_sources",
+            "title": "Income Sources",
+            "description": "Provide details about all income sources applicable to the applicant or household.",
+            "fields": [
+              {
+                "id": "income_sources",
+                "label": "List of Income Sources",
+                "type": "group",
+                "metadata": {
+                  "multiple": true,
+                  "tableColumns": [
+                    "name_ref",
+                    "how_often",
+                    "recipient",
+                    "monthly_amount"
+                  ]
+                },
+                "fields": [
+                  {
+                    "id": "name_ref",
+                    "label": "Income Source Type",
+                    "type": "select",
+                    "required": true,
+                    "ui": {
+                      "options": [
+                        "",
+                        "ApplicantWages",
+                        "SecondParentWages",
+                        "SelfEmployment",
+                        "ChildSupport",
+                        "Alimony",
+                        "Unemployment",
+                        "SocialSecurity",
+                        "Disability",
+                        "Rental",
+                        "Dividends",
+                        "Retirement",
+                        "CashAssistance",
+                        "Other"
+                      ]
+                    }
+                  },
+                  {
+                    "id": "other_source_text",
+                    "label": "Other Source (If applicable)",
+                    "type": "text",
+                    "visibilityCondition": {
+                      "field": "name_ref",
+                      "operator": "equals",
+                      "value": "Other"
+                    },
+                    "requiredCondition": {
+                      "condition": {
+                        "field": "name_ref",
+                        "operator": "equals",
+                        "value": "Other"
+                      }
+                    }
+                  },
+                  {
+                    "id": "is_source_applicable",
+                    "label": "Is this Source Applicable?",
+                    "type": "radio",
+                    "required": true,
+                    "ui": {
+                      "options": [
+                        "Yes",
+                        "No"
+                      ]
+                    }
+                  },
+                  {
+                    "id": "gross_amount",
+                    "label": "Gross Amount ($)",
+                    "type": "number",
+                    "required": true
+                  },
+                  {
+                    "id": "how_often",
+                    "label": "Frequency of Income",
+                    "type": "radio",
+                    "required": true,
+                    "ui": {
+                      "options": [
+                        "Weekly",
+                        "Bi-weekly",
+                        "Monthly",
+                        "Other"
+                      ]
+                    }
+                  },
+                  {
+                    "id": "recipient",
+                    "label": "Recipient of Income",
+                    "type": "text",
+                    "required": true
+                  },
+                  {
+                    "id": "monthly_amount",
+                    "label": "Monthly Amount ($)",
+                    "type": "number",
+                    "required": true
+                  }
+                ]
+              }
+            ]
+          },
+          {
+            "id": "total_income",
+            "title": "Total Household Income",
+            "description": "Sum of all monthly income across sources.",
+            "fields": [
+              {
+                "id": "total_income",
+                "label": "Total Monthly Income ($)",
+                "type": "number",
+                "required": true
+              }
+            ]
+          },
+          {
+            "id": "income_proof_section",
+            "title": "Income Proof",
+            "fields": [
+              {
+                "id": "income_proof",
+                "label": "Upload Income Proof",
+                "type": "file",
+                "requiredCondition": {
+                  "condition": {
+                    "field": "assistance_reason",
+                    "operator": "includes",
+                    "value": "Employment"
+                  }
+                },
+                "constraints": {
+                  "maxFileSizeMB": 5,
+                  "allowedTypes": [
+                    "application/pdf",
+                    "image/jpeg"
+                  ],
+                  "imageResolution": {
+                    "minWidth": 800,
+                    "minHeight": 600
+                  }
+                },
+                "metadata": {
+                  "proofCategory": "Income Verification",
+                  "examples": [
+                    "Pay Stub",
+                    "W-2"
+                  ],
+                  "multiple": true
+                }
+              }
+            ]
+          }
+        ]
+      },
+      {
+        "id": "provider",
+        "title": "Provider",
+        "sections": [
+          {
+            "id": "provider_step_info",
+            "title": "Instructions",
+            "type": "info",
+            "ui": {
+              "markdown": true,
+              "collapsible": false,
+              "defaultCollapsed": false
+            },
+            "content": "If you are found eligible for child care assistance, you can choose center-based or home-based care from a licensed, registered, or legally exempt provider. If you choose a provider that is not licensed or registered, the provider must be enrolled as a legally exempt provider.\\n\\nIf you know which child care providers you would like your child to attend, provide the names and addresses of your choice of providers. You can leave this section blank if you do not know (it will not impact your eligibility and you will have an opportunity to select a provider if determined eligible)."
+          },
+          {
+            "id": "provider_choices",
+            "title": "Provider Choices",
+            "description": "Specify details of the provider where you intend to enroll the child(ren).",
+            "fields": [
+              {
+                "id": "provider_choices",
+                "label": "List of Providers",
+                "type": "group",
+                "metadata": {
+                  "multiple": true,
+                  "tableColumns": [
+                    "provider_name",
+                    "program_number",
+                    "provider_zip_code"
+                  ]
+                },
+                "fields": [
+                  {
+                    "id": "provider_name",
+                    "label": "Provider Name",
+                    "type": "text",
+                    "required": true
+                  },
+                  {
+                    "id": "program_number",
+                    "label": "Program Number (If Applicable)",
+                    "type": "text",
+                    "required": false
+                  },
+                  {
+                    "id": "provider_street",
+                    "label": "Street Address",
+                    "type": "text",
+                    "required": true
+                  },
+                  {
+                    "id": "provider_city",
+                    "label": "City",
+                    "type": "text",
+                    "required": true
+                  },
+                  {
+                    "id": "provider_state",
+                    "label": "State",
+                    "type": "text",
+                    "required": true
+                  },
+                  {
+                    "id": "provider_zip_code",
+                    "label": "Zip Code",
+                    "type": "text",
+                    "required": true
+                  }
+                ]
+              }
+            ]
+          }
+        ]
+      },
+      {
+        "id": "document_upload_step",
+        "title": "Document Upload",
+        "description": "The Application for Child Care Assistance (CFWB-012) must include supporting documentation. Check to ensure that documentation is provided for each requirement of subsidy eligibility.",
+        "sections": [
+          {
+            "id": "nyc_residency",
+            "title": "New York City Residency",
+            "description": "These documents confirm that you live in New York City. Please upload one of the following documents.",
+            "fields": [
+              {
+                "id": "nyc_residency_type",
+                "label": "Select one of the following:",
+                "type": "radio",
+                "required": true,
+                "ui": {
+                  "options": [
+                    "IDNYC",
+                    "Utility Bill",
+                    "Section 8 Award Letter",
+                    "Driver’s License",
+                    "Rent Receipt",
+                    "NYCHA Certificate",
+                    "CFWB-067 Residency Attestation",
+                    "CFWB-027 Housing Attestation with address listed",
+                    "Shelter Residency Letter with address listed",
+                    "Other"
+                  ]
+                }
+              },
+              {
+                "id": "nyc_residency_file",
+                "label": "Upload Residency Proof Document",
+                "description": "To add a document to your application, you can upload an image or scanned file from your phone or device. Accepted formats include .pdf, .gif, .jpeg, .jpg and .png up to 25 MB. Learn how to upload your files with this Tutorial Video.",
+                "type": "file",
+                "required": true, 
+                "constraints": {
+                  "maxFileSizeMB": 25,
+                  "allowedTypes": [
+                    "application/pdf",
+                    "image/jpeg",
+                    "image/jpg",
+                    "image/png",
+                    "image/gif"
+                  ]
+                },
+                "metadata": {
+                  "proofCategory": "NYC Residency",
+                  "multiple": false
+                }
+              }
+            ]
+          },
+          {
+            "id": "citizenship_status",
+            "title": "Citizenship or Immigration Status",
+            "description": "These documents confirm the citizenship/immigration status of the children in your family for whom you’re applying for child care assistance. Please upload one of the following documents for ONLY each child needing care.",
+            "fields": [
+              {
+                "id": "citizenship_doc_type",
+                "label": "Select one of the following:",
+                "type": "radio",
+                "required": true,
+                "ui": {
+                  "options": [
+                    "US Birth Certificate",
+                    "Alien Registration Card including Permanent Resident or Green Card",
+                    "Passport",
+                    "FS-240 (Report of Birth Abroad of a U.S. Citizen)",
+                    "Naturalization Certificate",
+                    "Other"
+                  ]
+                }
+              },
+              {
+                "id": "citizenship_doc_file",
+                "label": "Upload Citizenship/Immigration Document",
+                "description": "To add a document to your application, you can upload an image or scanned file from your phone or device. Accepted formats include .pdf, .gif, .jpeg, .jpg and .png up to 25 MB. Learn how to upload your files with this Tutorial Video.",
+                "type": "file",
+                "required": true,
+                "constraints": {
+                  "maxFileSizeMB": 25,
+                  "allowedTypes": [
+                    "application/pdf",
+                    "image/jpeg",
+                    "image/jpg",
+                    "image/png",
+                    "image/gif"
+                  ]
+                },
+                "metadata": {
+                  "proofCategory": "Citizenship/Immigration Status",
+                  "multiple": false
+                }
+              }
+            ]
+          },
+          {
+            "id": "child_relationship",
+            "title": "Child’s Relationship to Parent/Applicant",
+            "description": "These documents confirm your relationship to the children in your household under age 18. Please upload one of the following documents for every child in the household under age 18, regardless of whether child care is needed for them or not. If you are a legal guardian with financial responsibility, you must upload a Court order OR a letter of guardianship.",
+            "fields": [
+              {
+                "id": "relationship_doc_type",
+                "label": "Select one of the following:",
+                "type": "radio",
+                "required": true,
+                "ui": {
+                  "options": [
+                    "Birth Certificate",
+                    "Adoption record",
+                    "Baptismal record",
+                    "Passport with parent's signature",
+                    "Court order for legal guardian with financial responsibility",
+                    "Letter of Guardianship",
+                    "Other - CFWB-058 Caretaker Attestation"
+                  ]
+                }
+              },
+              {
+                "id": "relationship_doc_file",
+                "label": "Upload Relationship Document",
+                "description": "To add a document to your application, you can upload an image or scanned file from your phone or device. Accepted formats include .pdf, .gif, .jpeg, .jpg and .png up to 25 MB. Learn how to upload your files with this Tutorial Video.",
+                "type": "file",
+                "required": true,
+                "constraints": {
+                  "maxFileSizeMB": 25,
+                  "allowedTypes": [
+                    "application/pdf",
+                    "image/jpeg",
+                    "image/jpg",
+                    "image/png",
+                    "image/gif"
+                  ]
+                },
+                "metadata": {
+                  "proofCategory": "Child Relationship",
+                  "multiple": false
+                }
+              }
+            ]
+          },
+          {
+            "id": "age_proof",
+            "title": "Age",
+            "description": "These documents confirm the age of the children in your household. Please upload one of the following documents for every child in the household under age 18, regardless of whether child care is needed for them:",
+            "fields": [
+              {
+                "id": "age_doc_type",
+                "label": "Select one of the following:",
+                "type": "radio",
+                "required": true,
+                "ui": {
+                  "options": [
+                    "Birth Certificate",
+                    "Adoption record",
+                    "Baptismal record",
+                    "Alien Registration Card",
+                    "Passport",
+                    "Official hospital documentation of the child’s birth"
+                  ]
+                }
+              },
+              {
+                "id": "age_doc_file",
+                "label": "Upload Age Proof Document",
+                "description": "To add a document to your application, you can upload an image or scanned file from your phone or device. Accepted formats include .pdf, .gif, .jpeg, .jpg and .png up to 25 MB. Learn how to upload your files with this Tutorial Video.",
+                "type": "file",
+                "required": true,
+                "constraints": {
+                  "maxFileSizeMB": 25,
+                  "allowedTypes": [
+                    "application/pdf",
+                    "image/jpeg",
+                    "image/jpg",
+                    "image/png",
+                    "image/gif"
+                  ]
+                },
+                "metadata": {
+                  "proofCategory": "Child Age",
+                  "multiple": false
+                }
+              }
+            ]
+          }
+        ]
+      },
+      {
+        "id": "review",
+        "title": "Review & Submit",
+        "type": "review",
+        "sections": []
+      }
+    ]
+  }
+}

--- a/test-form/public/data/childcare_form.ru.json
+++ b/test-form/public/data/childcare_form.ru.json
@@ -1,0 +1,2287 @@
+{
+  "form": {
+    "title": "Childcare Voucher Application",
+    "description": "Step-by-step form for applying for Childcare Assistance",
+    "layout": {
+      "stepperPosition": "left"
+    },
+    "steps": [
+      {
+        "id": "consent_step",
+        "title": "Consent",
+        "sections": [
+          {
+            "id": "mycity_consent_info",
+            "title": "ModelCity Consent",
+            "type": "info",
+            "ui": {
+              "markdown": true,
+              "collapsible": false,
+              "defaultCollapsed": false
+            },
+            "content": "In connection with this application for child care services, **ModelCity**:\\n\\n- Collects, processes, stores, and shares the information you submit to screen you when you apply for child care services;\\n- Receives, processes, and stores the information the City already knows about you to screen you when you apply for child care services;\\n- Uses your information to improve ModelCity; and\\n- Communicates with you about your ModelCity account.\\n\\n---\\n\\nIf you consent, the following information may be shared between child care services agencies:\\n\\n- Demographic and background information, including address, phone number, household composition.\\n- Housing information, including benefits awarded/received, current housing/shelter status.\\n- Benefits information, including public assistance awarded/received, child care program participation.\\n\\n---\\n\\nIf you choose not to consent, **you will not be denied** any benefits or services you are receiving or any benefits for which you are eligible.\\n\\nThe [ModelCity Privacy Policy](https://www.nyc.gov/privacy) details how ModelCity handles the information you submit through ModelCity."
+          }
+        ]
+      },
+      {
+        "id": "instructions_step",
+        "title": "Instructions",
+        "sections": [
+          {
+            "id": "application_instructions",
+            "title": "Application Instructions",
+            "type": "info",
+            "ui": {
+              "markdown": true,
+              "collapsible": false,
+              "defaultCollapsed": false
+            },
+            "content": "**Let’s get started on your application!**\\n\\nTo complete this application, you will be asked for information about:\\n\\n- Yourself\\n- Your household\\n- Your employment or reason for care\\n- Your income\\n\\nAll required fields are marked and must be filled out to move forward with the application. The pages of the application are shown on the right-hand side of the screen and will be highlighted as you move through the application.\\n\\nYour application will be saved automatically as you progress to each page.  \\nIf you need to pause at any time, click the **“Save for later”** button at the bottom of each page to save your application.  \\nYou can log back in to resume your application.\\n\\nWhen you’re ready to begin, click **“Next”** below.\\n\\n---\\n\\n⚠️ **Important:**  \\nTo keep your information current and safe, applications in draft status that you have not edited for **30 days** will be deleted.  \\nIf your draft application is deleted, you can still create and submit a new application when you're ready to apply."
+          },
+          {
+            "id": "new_york_city_residency",
+            "title": "New York City Residency",
+            "type": "info",
+            "ui": {
+              "markdown": true,
+              "collapsible": true,
+              "defaultCollapsed": true
+            },
+            "content": "You will need to upload **ONE** of the following documents to confirm your NYC residency:\\n\\n- IDNYC\\n- Driver’s License\\n- Utility Bill (dated within the last 60 days, with your address)\\n- Current lease, rent, or mortgage statement (dated within the last 60 days, with your address)\\n- Section 8 Award Letter\\n- NYCHA Certificate\\n- CFWB-027 Housing Attestation with address listed\\n- Shelter Residency Letter with address listed\\n\\nIf you do not have any of those documents, you must submit a **CFWB-067 Residency Attestation**."
+          },
+          {
+            "id": "children_documents",
+            "title": "Children Documents",
+            "type": "info",
+            "ui": {
+              "markdown": true,
+              "collapsible": true,
+              "defaultCollapsed": true
+            },
+            "content": "### Citizenship or Immigration Status\\nThese documents confirm the citizenship or immigration status of the children in your family for whom you’re applying for child care assistance. Please upload one of the following documents for each child needing care. *Do not upload these documents for children who do not need care.*\\n\\n- Birth Certificate from US state or territory\\n- Alien Registration Card including Permanent Resident or Green Card\\n- Passport\\n- FS-240 (Consular Report of Birth Abroad)\\n- Naturalization Certificate\\n- Other documentation that proves child’s immigration status\\n\\n### Child's Relationship to Applicant\\nThese documents confirm your relationship to the children in your household under age 18. Please upload one of the following documents for every child in the household under age 18, regardless of whether they need child care.\\n\\n- Birth certificate\\n- Adoption record\\n- Baptismal record\\n- Passport with parent's signature\\n- Court order for legal guardian with financial responsibility\\n- Letter of guardianship\\n- Other - CFWB-058 Caretaker Attestation\\n\\nIf you are not the child's parent or stepparent, you must submit a **CFWB-058 Caretaker Attestation Form**.\\n\\n### Age of Children\\nYou will need to upload **ONE** of the following documents for every child in the household under age 18, regardless of whether child care is needed for them:\\n\\n- Birth certificate\\n- Adoption record\\n- Baptismal record\\n- Alien Registration Card\\n- Passport\\n- Official hospital documentation of the child’s birth"
+          },
+          {
+            "id": "employment_income",
+            "title": "Employment & Income",
+            "type": "info",
+            "ui": {
+              "markdown": true,
+              "collapsible": true,
+              "defaultCollapsed": true
+            },
+            "content": "### Income\\nThese documents confirm your family’s income.\\n\\n---\\n\\n### If You Are Employed\\nIf you are employed and receive paystubs, you must submit them to confirm your income. The number of paystubs you must submit varies by how often you get paid and whether your payment amount is the same or different each time you are paid – see the table below for details. Submit the most recent paystub you have received, followed by others in consecutive order.\\n\\n**Income Information**\\n\\n| How Often Do You Get Paid? | Always the SAME Amount | DIFFERENT Amounts Each Time |\\n|----------------------------|-------------------------|------------------------------|\\n| Weekly (Every Week) | 4 most recent, consecutive pay stubs | 12 most recent, consecutive pay stubs |\\n| Bi-Weekly (Every Two Weeks) | 2 most recent, consecutive pay stubs | 6 most recent, consecutive pay stubs |\\n| Semi-Monthly (Two Times Per Month) | 2 most recent, consecutive pay stubs | 6 most recent, consecutive pay stubs |\\n| Monthly (One Time Per Month) | 3 most recent, consecutive pay stubs | 3 most recent, consecutive pay stubs |\\n\\nIf you do not have any paystubs, you must submit a **CFWB-015 Referral to Employer for Employee Income Information Form**.\\n\\n---\\n\\n### If You Are Self-Employed\\nIf you have been self-employed for **one year or more**, you must submit a current, complete and signed income tax package (e.g., 1040, 1065, Schedule C, SE for partnership, K-1, etc.).\\n\\nIf you have been self-employed for **less than one year**, you must submit a **CFWB-031 Self-Employment Income Information Attestation Form**.\\n\\n---\\n\\n### Other Income\\nIf you receive other types of income outside or instead of employment income, you must submit your most recent check, pay stub, or current award letter that indicates the amount you receive. If your other income fluctuates, **3 months of documentation is required**.\\n\\nThis includes, but is not limited to:\\n- Income from SSI, SSD\\n- Unemployment benefits\\n- Rental income\\n- Pensions\\n- Annuities\\n- Worker’s compensation\\n- Alimony\\n- Child support"
+          },
+          {
+            "id": "reason_for_care",
+            "title": "Reason for Care",
+            "type": "info",
+            "ui": {
+              "markdown": true,
+              "collapsible": true,
+              "defaultCollapsed": true
+            },
+            "content": "### Reason for Care\\nThese documents confirm your reason for care. Every applicant must have a qualified reason for care; in a two-parent household, parents or caretakers can have the same or different reasons for care. Only the documents related to your stated reasons for care need to be uploaded, and documentation must be uploaded for all parent or caretakers in the household.\\n\\n---\\n\\n### Working 10+ Hours Per Week\\nYour employment or self-employment income documents will cover this reason for care. You do not need to submit additional documentation.\\n\\n---\\n\\n### Participating in an Educational or Vocational Training Program\\nYou will need to upload **ONE** of the following documents to confirm your participation in vocational school, two-year college, or four-year college.\\n\\n- CFWB-005 Vocational, Education and Training Verification Form\\n- A letter from the educational or vocational training program on their official letterhead; this letter must contain all the information required in the CFWB-005 Vocational, Education and Training Verification Form.\\n\\n---\\n\\n### Looking for Work\\nYou will need to upload **ONE** of the following documents to confirm that you are looking for work.\\n\\n- CFWB-026 Work Search Record Form\\n- Approved work search plan from the NYS Dept. of Labor\\n- Proof of receipt of unemployment insurance\\n\\n---\\n\\n### Experiencing Homelessness\\nYou will need to upload **ONE** of the following documents to confirm that you are experiencing homelessness. This includes families who may be living in shelter or sharing the housing of others due to loss of housing, economic hardship, or similar reason.\\n\\n- Shelter Residency Letter (If living in Shelter, including Humanitarian Emergency Relief Centers)\\n- CFWB-027 Housing Attestation (If living doubled-up, in a place not meant for human habitation, in a hotel/motel, or in another living situation)\\n\\n---\\n\\n### Attending Services for Domestic Violence\\nYou will need to upload a referral for services from a domestic violence service provider to confirm that you are attending services for domestic violence.\\n\\n---\\n\\n### Attending Services for Substance Abuse Treatment\\nYou will need to upload a referral for a substance abuse treatment service provider to confirm that you are attending services for substance abuse treatment."
+          },
+          {
+            "id": "additional_details",
+            "title": "Additional Details",
+            "type": "info",
+            "ui": {
+              "markdown": true,
+              "collapsible": true,
+              "defaultCollapsed": true
+            },
+            "content": "### Application Scope\\nThis application is used to apply **only** for **Category 2 or 3 child care assistance** (for families not in receipt of cash assistance). To apply for **Cash Assistance** or other benefits, including **Category 1 Child Care Assistance** (for families in receipt of cash assistance), you must use the **New York State Application for Certain Benefits and Services (LDSS-2921)**.\\n\\n---\\n\\n### Exempt Applicants\\nThe following applicants may be eligible for child care assistance **without regard to income** and do not need to complete this application:\\n\\n- Foster parents who need child care assistance to allow them to work and are only applying for assistance for the foster children;\\n- Families in receipt of protective or preventive services.\\n\\n---\\n\\n### Application Completion\\nAll sections of this form must be filled out to be considered complete **unless the section is identified as optional**. If you do not complete all required sections of this form, you may not be considered for Child Care Assistance.\\n\\n---\\n\\n### Rights and Responsibilities\\nYou may obtain information about your rights and responsibilities [here](https://otda.ny.gov/programs/applications/). If you do not have access to the internet, you can call the **Administration for Children’s Services at 212-835-7610** to request that physical copies of the booklets which highlight your rights and responsibilities be mailed to you, including:\\n\\n- **LDSS-4148A**: What You Should Know About Your Rights and Responsibilities\\n- **LDSS-4148B**: What You Should Know About Social Services Programs\\n- **LDSS-4148C**: What You Should Know If You Have an Emergency"
+          }
+        ]
+      },
+      {
+        "id": "applicant",
+        "title": "Applicant",
+        "sections": [
+          {
+            "id": "personal_info",
+            "title": "Personal Information",
+            "fields": [
+              {
+                "id": "first_name",
+                "label": "First Name",
+                "type": "text",
+                "required": true
+              },
+              {
+                "id": "last_name",
+                "label": "Last Name",
+                "type": "text",
+                "required": true
+              },
+              {
+                "id": "mi",
+                "label": "Middle Initial",
+                "type": "text",
+                "required": false
+              },
+              {
+                "id": "date_of_birth",
+                "label": "Date of Birth",
+                "type": "date",
+                "required": true,
+                "tooltip": "To edit Date of Birth click on NYC ModelCity in the top-left corner then click on Account Settings."
+              },
+              {
+                "id": "sex",
+                "label": "Sex",
+                "type": "radio",
+                "required": true,
+                "ui": {
+                  "options": [
+                    "Male",
+                    "Female"
+                  ]
+                }
+              },
+              {
+                "id": "marital_status",
+                "label": "Marital Status",
+                "type": "select",
+                "required": true,
+                "tooltip": "Indicate your marital status (single, married, divorced, separated or widowed).",
+                "ui": {
+                  "options": [
+                    "",
+                    "Single",
+                    "Married",
+                    "Divorced",
+                    "Widowed",
+                    "Separated"
+                  ]
+                }
+              }
+            ]
+          },
+          {
+            "id": "contact_info",
+            "title": "Contact Information",
+            "fields": [
+              {
+                "id": "telephone_home",
+                "label": "Home Phone",
+                "type": "tel",
+                "required": false,
+                "constraints": {
+                  "pattern": "^\\\\(?[0-9]{3}\\\\)?[-. ]?[0-9]{3}[-. ]?[0-9]{4}$"
+                },
+                "ui": {
+                  "placeholder": "(123) 456-7890"
+                }
+              },
+              {
+                "id": "telephone_work",
+                "label": "Work Phone",
+                "type": "tel",
+                "required": false,
+                "constraints": {
+                  "pattern": "^\\\\(?[0-9]{3}\\\\)?[-. ]?[0-9]{3}[-. ]?[0-9]{4}$"
+                },
+                "ui": {
+                  "placeholder": "(123) 456-7890"
+                }
+              },
+              {
+                "id": "telephone_mobile_or_other",
+                "label": "Mobile or Other Phone",
+                "type": "tel",
+                "required": false,
+                "tooltip": "To edit Telephone (Cell or Other) click on NYC ModelCity in the top-left corner then click on Account Settings and then click on Contact.",
+                "constraints": {
+                  "pattern": "^\\\\(?[0-9]{3}\\\\)?[-. ]?[0-9]{3}[-. ]?[0-9]{4}$"
+                },
+                "ui": {
+                  "placeholder": "(123) 456-7890"
+                }
+              },
+              {
+                "id": "email",
+                "label": "Email",
+                "type": "email",
+                "required": true,
+                "tooltip": "To edit email, go to NYC ID Profile tab by clicking your name at the top right corner"
+              }
+            ]
+          },
+          {
+            "id": "address_info",
+            "title": "Address",
+            "tooltip": "To edit home address click on NYC ModelCity in the top-left corner then click on Account Settings.",
+            "ui": {
+              "autocomplete": "street",
+              "placeholder": "Start typing your street address",
+              "overrideComponent": "AddressAutocomplete"
+            },
+            "metadata": {
+              "integration": {
+                "provider": "Google",
+                "feature": "AddressAutocomplete"
+              },
+              "autofillTargets": [
+                {
+                  "fieldId": "city",
+                  "source": "locality",
+                  "fallbackSources": [
+                    "postal_town",
+                    "sublocality_level_1",
+                    "administrative_area_level_2"
+                  ]
+                },
+                {
+                  "fieldId": "borough",
+                  "source": "sublocality_level_1",
+                  "fallbackSources": [
+                    "administrative_area_level_2"
+                  ],
+                  "mapping": "boroughMap"
+                },
+                { "fieldId": "state", "source": "administrative_area_level_1" },
+                { "fieldId": "zip_code", "source": "postal_code" },
+                { "fieldId": "latitude", "source": "location.latitude" },
+                { "fieldId": "longitude", "source": "location.longitude" }
+              ]
+            },
+            "fields": [
+              {
+                "id": "street",
+                "label": "Street Address",
+                "type": "text",
+                "required": true,
+                "tooltip": "To edit home address click on NYC ModelCity in the top-left corner then click on Account Settings."
+              },
+              {
+                "id": "apt",
+                "label": "Apt #",
+                "type": "text",
+                "required": false
+              },
+              {
+                "id": "city",
+                "label": "City",
+                "type": "text",
+                "required": true
+              },
+              {
+                "id": "borough",
+                "label": "Borough",
+                "type": "select",
+                "required": true,
+                "ui": {
+                  "options": [
+                    "",
+                    "Bronx",
+                    "Brooklyn",
+                    "Manhattan",
+                    "Queens",
+                    "Staten Island"
+                  ]
+                }
+              },
+              {
+                "id": "state",
+                "label": "State",
+                "type": "text",
+                "required": true
+              },
+              {
+                "id": "zip_code",
+                "label": "Zip Code",
+                "type": "text",
+                "required": true
+              },
+              {
+                "id": "latitude",
+                "label": "Latitude",
+                "type": "number",
+                "required": false
+              },
+              {
+                "id": "longitude",
+                "label": "Longitude",
+                "type": "number",
+                "required": false
+              },
+              {
+                "id": "is_temporary_address",
+                "label": "Is Temporary Address",
+                "type": "radio",
+                "required": true,
+                "tooltip": "Check YES if you are currently living in a homeless shelter, doubled-up with another family, in a hotel/motel, in a car/ bus/ train, in a park/campsite, or other temporary accomodation.",
+                "ui": {
+                  "options": [
+                    "Yes",
+                    "No"
+                  ]
+                }
+              },
+              {
+                "id": "currently_living_in",
+                "label": "Currently Living In",
+                "type": "select",
+                "required": false,
+                "requiredCondition": {
+                  "field": "is_temporary_address",
+                  "operator": "equals",
+                  "value": "Yes"
+                },
+                "ui": {
+                  "options": [
+                    "",
+                    "Homeless Shelter",
+                    "Doubled-up with another Family",
+                    "Hotel/Motel",
+                    "Car, Bus, Train",
+                    "Park",
+                    "Campsite",
+                    "Other"
+                  ]
+                }
+              }
+            ]
+          },
+          {
+            "id": "demographics",
+            "title": "Demographics",
+            "fields": [
+              {
+                "id": "ethnicity",
+                "label": "Ethnicity",
+                "type": "select",
+                "required": false,
+                "ui": {
+                  "options": [
+                    "",
+                    "Hispanic",
+                    "Latino",
+                    "No",
+                    "Prefer not to answer"
+                  ]
+                }
+              },
+              {
+                "id": "race",
+                "label": "Race",
+                "type": "checkbox",
+                "required": false,
+                "tooltip": "You may choose multiple race categories. Providing race information is voluntary and will not affect your eligibility for Child Care Assistance or the amount of assistance that you will be given by this agency.",
+                "ui": {
+                  "options": [
+                    {
+                      "value": "AI",
+                      "label": "American Indian or Alaska Native"
+                    },
+                    {
+                      "value": "AS",
+                      "label": "Asian"
+                    },
+                    {
+                      "value": "BL",
+                      "label": "Black or African American"
+                    },
+                    {
+                      "value": "HP",
+                      "label": "Native Hawaiian or Pacific Islander"
+                    },
+                    {
+                      "value": "WH",
+                      "label": "White"
+                    }
+                  ]
+                },
+                "metadata": {
+                  "multiple": true
+                }
+              },
+              {
+                "id": "ssn",
+                "label": "Social Security Number",
+                "type": "text",
+                "tooltip": "To edit social security number click on NYC ModelCity in the top-left corner then click on Account Settings.",
+                "required": false,
+                "constraints": {
+                  "pattern": "^\\\\d{3}-\\\\d{2}-\\\\d{4}$"
+                },
+                "ui": {
+                  "placeholder": "123-45-6789"
+                }
+              }
+            ]
+          },
+          {
+            "id": "language_info",
+            "title": "Language Preferences",
+            "fields": [
+              {
+                "id": "primary_language",
+                "label": "Primary Language",
+                "type": "radio",
+                "required": true,
+                "tooltip": "Select the language that is spoken most often in your household. If “other”, provide the name of the language.",
+                "ui": {
+                  "options": [
+                    "English",
+                    "Spanish",
+                    "Other"
+                  ]
+                }
+              },
+              {
+                "id": "preferred_language",
+                "label": "Preferred Language",
+                "type": "radio",
+                "required": true,
+                "tooltip": "Select the language you prefer to communicate in. If “other”, provide the name of the language.",
+                "ui": {
+                  "options": [
+                    "English",
+                    "Spanish",
+                    "Other"
+                  ]
+                }
+              },
+              {
+                "id": "other_primary_language",
+                "label": "Other Primary Language",
+                "type": "text",
+                "required": false,
+                "requiredCondition": {
+                  "field": "primary_language",
+                  "operator": "equals",
+                  "value": "Other"
+                }
+              },
+              {
+                "id": "other_preferred_language",
+                "label": "Other Preferred Language",
+                "type": "text",
+                "required": false,
+                "requiredCondition": {
+                  "field": "preferred_language",
+                  "operator": "equals",
+                  "value": "Other"
+                }
+              }
+            ]
+          },
+          {
+            "id": "cash_assistance",
+            "title": "Cash Assistance",
+            "fields": [
+              {
+                "id": "has_cash_assistance",
+                "label": "Do you receive Cash Assistance?",
+                "type": "radio",
+                "required": false,
+                "ui": {
+                  "options": [
+                    "Yes",
+                    "No"
+                  ]
+                }
+              },
+              {
+                "id": "ca_number",
+                "label": "Cash Assistance Number",
+                "type": "text",
+                "required": false,
+                "requiredCondition": {
+                  "condition": {
+                    "field": "has_cash_assistance",
+                    "operator": "equals",
+                    "value": "Yes"
+                  }
+                }
+              }
+            ]
+          }
+        ]
+      },
+      {
+        "id": "children_needing_care",
+        "title": "Children Needing Care",
+        "sections": [
+          {
+            "id": "child_details",
+            "title": "Child Details",
+            "required": true,
+            "fields": [
+              {
+                "id": "children",
+                "label": "Children Needing Care",
+                "type": "group",
+                "metadata": {
+                  "multiple": true,
+                  "tableColumns": [
+                  "first_name",
+                  "last_name",
+                  "date_of_birth",
+                  "relationship_to_applicant"
+                  ]
+                },
+                "fields": [
+                  {
+                    "id": "first_name",
+                    "label": "First Name",
+                    "type": "text",
+                    "required": true,
+                    "tooltip": "Provide the first name, last name, and middle initial of each child you are applying for child care assistance for."
+                  },
+                  {
+                    "id": "last_name",
+                    "label": "Last Name",
+                    "type": "text",
+                    "required": true
+                  },
+                  {
+                    "id": "mi",
+                    "label": "Middle Initial",
+                    "type": "text",
+                    "required": false
+                  },
+                  {
+                    "id": "relationship_to_applicant",
+                    "label": "Relationship to Applicant",
+                    "type": "select",
+                    "required": true,
+                    "ui": {
+                      "options": [
+                        "",
+                        "Child",
+                        "Grandchild",
+                        "Foster Child",
+                        "Other"
+                      ]
+                    }
+                  },
+                  {
+                    "id": "date_of_birth",
+                    "label": "Date of Birth",
+                    "type": "date",
+                    "required": true,
+                    "tooltip": "Provide the date of birth."
+                  },
+                  {
+                    "id": "sex",
+                    "label": "Sex",
+                    "type": "radio",
+                    "required": true,
+                    "tooltip": "Select to indicate the sex.",
+                    "ui": {
+                      "options": [
+                        "Male",
+                        "Female"
+                      ]
+                    }
+                  },
+                  {
+                    "id": "ethnicity",
+                    "label": "Ethnicity Hispanic or Latino",
+                    "type": "select",
+                    "required": false,
+                    "tooltip": "Check “YES” or “NO” to indicate if each child in need of child care is Hispanic or Latino or not. Providing ethnicity information is voluntary and will not affect your eligibility for child care assistance or the amount of assistance that you will be given by this agency.",
+                    "ui": {
+                      "options": [
+                        "",
+                        "Yes",
+                        "No",
+                        "Prefer not to answer"
+                      ]
+                    }
+                  },
+                  {
+                    "id": "race",
+                    "label": "Race",
+                    "type": "checkbox",
+                    "required": false,
+                    "tooltip": "You may choose multiple race categories for a single child. Providing race information is voluntary and will not affect your eligibility for Child Care Assistance or the amount of assistance that you will be given by this agency.",
+                    "ui": {
+                      "options": [
+                        {
+                          "value": "AI",
+                          "label": "American Indian or Alaska Native"
+                        },
+                        {
+                          "value": "AS",
+                          "label": "Asian"
+                        },
+                        {
+                          "value": "BL",
+                          "label": "Black or African American"
+                        },
+                        {
+                          "value": "HP",
+                          "label": "Native Hawaiian or Pacific Islander"
+                        },
+                        {
+                          "value": "WH",
+                          "label": "White"
+                        }
+                      ]
+                    },
+                    "metadata": {
+                      "multiple": true
+                    }
+                  },
+                  {
+                    "id": "ssn",
+                    "label": "Social Security Number",
+                    "type": "text",
+                    "required": false,
+                    "tooltip": "Provide each child’s Social Security Number (SSN). You are not required to provide SSNs. They may be used by federal, state, and local agencies to prevent duplication of services and fraud, and for Federal Reporting.",
+                    "constraints": {
+                      "pattern": "^\\\\d{3}-\\\\d{2}-\\\\d{4}$"
+                    },
+                    "ui": {
+                      "placeholder": "123-45-6789"
+                    }
+                  },
+                  {
+                    "id": "do_both_parents_reside_in_home",
+                    "label": "Do both parents reside in the home?",
+                    "type": "radio",
+                    "required": true,
+                    "tooltip": "Check “YES” or “NO” to indicate whether both of the child’s parents live in the home.",
+                    "ui": {
+                      "options": [
+                        "Yes",
+                        "No"
+                      ]
+                    }
+                  },
+                  {
+                    "id": "has_disability",
+                    "label": "Does the child have a disability?",
+                    "type": "radio",
+                    "required": true,
+                    "tooltip": "Check “YES” or “NO” to indicate whether the child needing child care has a disability.",
+                    "ui": {
+                      "options": [
+                        "Yes",
+                        "No"
+                      ]
+                    }
+                  },
+                  {
+                    "id": "is_immigration_status_satisfactory",
+                    "label": "Is child U.S. Citizen, U.S. National, or person with satisfactory immigration status?",
+                    "type": "radio",
+                    "required": true,
+                    "tooltip": "You will only be asked about the immigration status of the children in need of care. Other members of the family will not need to state or prove their immigration status. Your child will be eligible for care if they are a U.S. citizen, a legal permanent resident (green card holder), a refugee, or an asylee; have a T-visa; or hold another qualified immigration status. Please select “Yes” if your child holds one of these statuses.",
+                    "ui": {
+                      "options": [
+                        "Yes",
+                        "No"
+                      ]
+                    }
+                  }
+                ]
+              }
+            ]
+          }
+        ]
+      },
+      {
+        "id": "family_members",
+        "title": "Family Members",
+        "sections": [
+          {
+            "id": "household_members_info",
+            "title": "Household Members Information",
+            "type": "info",
+            "ui": {
+              "markdown": true,
+              "collapsible": false,
+              "defaultCollapsed": false
+            },
+            "content": "**List the household members who do _not_ need child care.**\\n\\nIf applicable, list:\\n\\n- Your **spouse**, your child’s **second parent**, **caretaker**, or **step-parent**\\n- Any other **adult with whom you share a child**, if they live in your home\\n\\nThen, if applicable, list:\\n\\n- Any **siblings under the age of 18** who live in your home\\n\\n> **Only list other household members** — such as **aunts, uncles, cousins, grandparents, or friends** — _if they have financial responsibility_ for the child.\\n\\nA household member with financial responsibility, other than a parent or step-parent, is one who has a **letter or order of guardianship**.\\n\\n**Otherwise, do not include them.**"
+          },
+          {
+            "id": "family_member_details",
+            "title": "Household Member Details",
+            "description": "Include household members who do not need child care assistance (e.g., spouse, partner, other children).",
+            "fields": [
+              {
+                "id": "familymember",
+                "label": "Family Members",
+                "type": "group",
+                "requiredCondition": {
+                  "repeatingGroup": "children",
+                  "operator": "ANY",
+                  "condition": { "field": "do_both_parents_reside_in_home", "operator": "equals", "value": "Yes" }
+                },  
+                "metadata": {
+                  "multiple": true,
+                  "tableColumns": [
+                    "first_name",
+                    "last_name",
+                    "relationship_to_applicant",
+                    "date_of_birth"
+                  ]
+                },
+                "fields": [
+                  {
+                    "id": "first_name",
+                    "label": "First Name",
+                    "type": "text",
+                    "required": true,
+                    "tooltip": "Provide last and first name, and middle initial if applicable."
+                  },
+                  {
+                    "id": "last_name",
+                    "label": "Last Name",
+                    "type": "text",
+                    "required": true
+                  },
+                  {
+                    "id": "mi",
+                    "label": "Middle Initial",
+                    "type": "text",
+                    "required": false
+                  },
+                  {
+                    "id": "relationship_to_applicant",
+                    "label": "Relationship to Applicant",
+                    "type": "select",
+                    "required": true,
+                    "tooltip": "Provide each person’s relationship to you (e.g. spouse, partner, child, foster parent, other).",
+                    "ui": {
+                      "options": [
+                        "",
+                        "Spouse",
+                        "Partner",
+                        "Foster Parent",
+                        "Child",
+                        "Other"
+                      ]
+                    }
+                  },
+                  {
+                    "id": "date_of_birth",
+                    "label": "Date of Birth",
+                    "type": "date",
+                    "required": true,
+                    "tooltip": "Provide the family member's date of birth."
+                  },
+                  {
+                    "id": "sex",
+                    "label": "Sex",
+                    "type": "radio",
+                    "required": true,
+                    "tooltip": "Indicate the sex for each family member listed.",
+                    "ui": {
+                      "options": [
+                        "Male",
+                        "Female"
+                      ]
+                    }
+                  },
+                  {
+                    "id": "ethnicity",
+                    "label": "Ethnicity Hispanic or Latino",
+                    "type": "select",
+                    "required": false,
+                    "tooltip": "Check “YES” or “NO” to indicate if each member in the household is Hispanic or Latino or not. Providing ethnicity information is voluntary and will not affect your eligibility for Child Care Assistance or the amount of assistance that you will be given by this agency.",
+                    "ui": {
+                      "options": [
+                        "",
+                        "Yes",
+                        "No",
+                        "Prefer not to answer"
+                      ]
+                    }
+                  },
+                  {
+                    "id": "race",
+                    "label": "Race",
+                    "type": "checkbox",
+                    "required": false,
+                    "tooltip": "You may choose multiple race categories for a single person. Providing race information is voluntary and will not affect your eligibility for Child Care Assistance or the amount of assistance that you will be given by this agency.",
+                    "ui": {
+                      "options": [
+                        {
+                          "value": "AI",
+                          "label": "American Indian or Alaska Native"
+                        },
+                        {
+                          "value": "AS",
+                          "label": "Asian"
+                        },
+                        {
+                          "value": "BL",
+                          "label": "Black or African American"
+                        },
+                        {
+                          "value": "HP",
+                          "label": "Native Hawaiian or Pacific Islander"
+                        },
+                        {
+                          "value": "WH",
+                          "label": "White"
+                        }
+                      ]
+                    },
+                    "metadata": {
+                      "multiple": true
+                    }
+                  },
+                  {
+                    "id": "ssn",
+                    "label": "Social Security Number",
+                    "type": "text",
+                    "required": false,
+                    "tooltip": "Fill in the Social Security Number (SSN) for your family members. SSN is optional. SSN may be used by federal, state, and local agencies to prevent duplication of services and fraud, and for Federal Reporting.",
+                    "constraints": {
+                      "pattern": "^\\\\d{3}-\\\\d{2}-\\\\d{4}$"
+                    },
+                    "ui": {
+                      "placeholder": "123-45-6789"
+                    }
+                  }
+                ]
+              }
+            ]
+          }
+        ]
+      },
+      {
+        "id": "child_family_needs",
+        "title": "Child / Family Needs",
+        "sections": [
+          {
+            "id": "assistance_reason",
+            "title": "Reason for Child Care Assistance",
+            "description": "Select one or two reasons you are requesting Child Care Assistance.",
+            "tooltip": "Select one reason. In a two-parent household, parents/caretakers can have the same or different reasons for needing child care. Both parents/caretakers will be required to submit documentation in support of their own reason. If you are living in temporary housing, please select Homelessness even if you have another reason that applies to you.",
+            "fields": [
+              {
+                "id": "assistance_reason",
+                "label": "Reason(s) for Assistance",
+                "type": "select",
+                "required": true,
+                "ui": {
+                  "options": [
+                    "",
+                    "Employment",
+                    "Looking for Work",
+                    "Vocational Training/Educational Activities",
+                    "Receiving Domestic Violence Services",
+                    "Homelessness"
+                  ]
+                },
+                "constraints": {
+                  "minSelections": 1,
+                  "maxSelections": 2
+                },
+                "metadata": {
+                  "multiple": true
+                }
+              }
+            ]
+          },
+          {
+            "id": "military_status",
+            "title": "Military and Parental Availability",
+            "description": "Provide information about parental military status and availability for child care.",
+            "fields": [
+              {
+                "id": "is_parent_currently_active_in_military",
+                "label": "Is a Parent Currently Active Full-Time in the U.S. Military?",
+                "tooltip": "Check “YES” or “NO” to indicate whether a parent is currently active full-time in the U.S. Military.",
+                "type": "radio",
+                "required": true,
+                "ui": {
+                  "options": [
+                    "Yes",
+                    "No"
+                  ]
+                }
+              },
+              {
+                "id": "is_parent_mem_of_guard_or_mru",
+                "label": "Is a Parent a Member of National Guard or Military Reserve Unit?",
+                "tooltip": "Check “YES” or “NO” to indicate whether a parent is currently a member of a National Guard or Military Reserve Unit.",
+                "type": "radio",
+                "required": true,
+                "ui": {
+                  "options": [
+                    "Yes",
+                    "No"
+                  ]
+                }
+              },
+              {
+                "id": "is_non_custodial_parent_available",
+                "label": "Is the Non-Custodial Parent Available to Provide Care?",
+                "tooltip": "Check “YES” or “NO” to indicate whether there is a non-custodial parent available to provide child care.",
+                "type": "radio",
+                "required": true,
+                "ui": {
+                  "options": [
+                    "Yes",
+                    "No"
+                  ]
+                }
+              }
+            ]
+          },
+          {
+            "id": "duplicate_application",
+            "title": "Other Applications",
+            "description": "Indicate if you are also applying for or receiving child care from other agencies.",
+            "tooltip": "Indicate whether you are currently receiving or have applied for child care assistance with one of the agencies or organizations listed below. Note: If you are receiving Cash Assistance and are interested in child care assistance, you must apply through the Human Resources Administration. Reach out to your Benefits Access Center or visit the Human Resources Administration webpage.",
+            "fields": [
+              {
+                "id": "duplicate_app",
+                "label": "Are You Receiving or Applying for Child Care Through Another Agency?",
+                "type": "select",
+                "required": false,
+                "ui": {
+                  "options": [
+                    "",
+                    "Not Applicable",
+                    "Department of Education (DOE)",
+                    "Human Resources Administration (HRA)",
+                    "Department of Youth and Community Development (DYCD)",
+                    "Department of Homeless Services (DHS)",
+                    "Consortium for Worker Education (CWE)",
+                    "Administration for Children's Services (ACS)"
+                  ]
+                }
+              }
+            ]
+          }
+        ]
+      },
+      {
+        "id": "employment",
+        "title": "Employment",
+        "sections": [
+          {
+            "id": "employment_precheck",
+            "title": "Tell us about your employment",
+            "description": "Tell us about your employment",
+            "fields": [
+              {
+                "id": "applicant_emp_income_indicator",
+                "label": "Does applicant earn any income/ wages from employment? ",
+                "type": "radio",
+                "required": false,
+                "ui": {
+                  "options": [
+                    "Yes",
+                    "No"
+                  ]
+                }
+              },
+              {
+                "id": "coparent_emp_income_indicator",
+                "label": "Does Coparent/2nd Guardian earn any income/ wages from employment? ",
+                "type": "radio",
+                "required": false,
+                "ui": {
+                  "options": [
+                    "Yes",
+                    "No"
+                  ]
+                }
+              }
+            ]
+          },
+          {
+            "id": "applicant_jobs",
+            "title": "Applicant Employment Information",
+            "description": "Enter details for up to two jobs held by the applicant.",
+            "visibilityCondition": {
+              "field": "applicant_emp_income_indicator",
+              "operator": "equals",
+              "value": "Yes"
+            },
+            "fields": [
+              {
+                "id": "applicant_1st_job_start_date",
+                "label": "1st Job - Start Date",
+                "type": "date",
+                "required": false,
+                "ui": {
+                  "group": "1st Job"
+                }
+              },
+              {
+                "id": "applicant_1st_job_rotating_shift",
+                "label": "1st Job - Has Rotating Shift?",
+                "type": "radio",
+                "required": false,
+                "ui": {
+                  "options": [
+                    "Yes",
+                    "No"
+                  ],
+                  "group": "1st Job"
+                }
+              },
+              {
+                "id": "applicant_1st_job_requires_overtime",
+                "label": "1st Job - Requires Overtime?",
+                "type": "radio",
+                "required": false,
+                "ui": {
+                  "options": [
+                    "Yes",
+                    "No"
+                  ],
+                  "group": "1st Job"
+                }
+              },
+              {
+                "id": "applicant_1st_job_employer_name",
+                "label": "1st Job - Employer Name",
+                "type": "text",
+                "required": false,
+                "ui": {
+                  "group": "1st Job"
+                }
+              },
+              {
+                "id": "applicant_1st_job_employer_phone",
+                "label": "1st Job - Employer Phone",
+                "type": "tel",
+                "required": false,
+                "ui": {
+                  "group": "1st Job"
+                }
+              },
+              {
+                "id": "applicant_1st_job_employer_street",
+                "label": "1st Job - Employer Street Address",
+                "type": "text",
+                "required": false,
+                "ui": {
+                  "group": "1st Job"
+                }
+              },
+              {
+                "id": "applicant_1st_job_employer_city",
+                "label": "1st Job - Employer City",
+                "type": "text",
+                "required": false,
+                "ui": {
+                  "group": "1st Job"
+                }
+              },
+              {
+                "id": "applicant_1st_job_employer_state",
+                "label": "1st Job - Employer State",
+                "type": "text",
+                "required": false,
+                "ui": {
+                  "group": "1st Job"
+                }
+              },
+              {
+                "id": "applicant_1st_job_employer_zipcode",
+                "label": "1st Job - Employer ZIP Code",
+                "type": "text",
+                "required": false,
+                "ui": {
+                  "group": "1st Job"
+                }
+              },
+              {
+                "id": "applicant_2nd_job_start_date",
+                "label": "2nd Job - Start Date",
+                "type": "date",
+                "required": false,
+                "ui": {
+                  "group": "2nd Job"
+                }
+              },
+              {
+                "id": "applicant_2nd_job_rotating_shift",
+                "label": "2nd Job - Has Rotating Shift?",
+                "type": "radio",
+                "required": false,
+                "ui": {
+                  "options": [
+                    "Yes",
+                    "No"
+                  ],
+                  "group": "2nd Job"
+                }
+              },
+              {
+                "id": "applicant_2nd_job_requires_overtime",
+                "label": "2nd Job - Requires Overtime?",
+                "type": "radio",
+                "required": false,
+                "ui": {
+                  "options": [
+                    "Yes",
+                    "No"
+                  ],
+                  "group": "2nd Job"
+                }
+              },
+              {
+                "id": "applicant_2nd_job_employer_name",
+                "label": "2nd Job - Employer Name",
+                "type": "text",
+                "required": false,
+                "ui": {
+                  "group": "2nd Job"
+                }
+              },
+              {
+                "id": "applicant_2nd_job_employer_phone",
+                "label": "2nd Job - Employer Phone",
+                "type": "tel",
+                "required": false,
+                "ui": {
+                  "group": "2nd Job"
+                }
+              },
+              {
+                "id": "applicant_2nd_job_employer_street",
+                "label": "2nd Job - Employer Street Address",
+                "type": "text",
+                "required": false,
+                "ui": {
+                  "group": "2nd Job"
+                }
+              },
+              {
+                "id": "applicant_2nd_job_employer_city",
+                "label": "2nd Job - Employer City",
+                "type": "text",
+                "required": false,
+                "ui": {
+                  "group": "2nd Job"
+                }
+              },
+              {
+                "id": "applicant_2nd_job_employer_state",
+                "label": "2nd Job - Employer State",
+                "type": "text",
+                "required": false,
+                "ui": {
+                  "group": "2nd Job"
+                }
+              },
+              {
+                "id": "applicant_2nd_job_employer_zipcode",
+                "label": "2nd Job - Employer ZIP Code",
+                "type": "text",
+                "required": false,
+                "ui": {
+                  "group": "2nd Job"
+                }
+              }
+            ]
+          },
+          {
+            "id": "second_parent_jobs",
+            "title": "Second Parent Employment Information",
+            "description": "Enter details for up to two jobs held by the second parent (if applicable).",
+            "visibilityCondition": {
+              "field": "coparent_emp_income_indicator",
+              "operator": "equals",
+              "value": "Yes"
+            },
+            "fields": [
+              {
+                "id": "second_parent_1st_job_start_date",
+                "label": "1st Job - Start Date",
+                "type": "date",
+                "required": false
+              },
+              {
+                "id": "second_parent_1st_job_rotating_shift",
+                "label": "1st Job - Has Rotating Shift?",
+                "type": "radio",
+                "required": false,
+                "ui": {
+                  "options": [
+                    "Yes",
+                    "No"
+                  ]
+                }
+              },
+              {
+                "id": "second_parent_1st_job_requires_overtime",
+                "label": "1st Job - Requires Overtime?",
+                "type": "radio",
+                "required": false,
+                "ui": {
+                  "options": [
+                    "Yes",
+                    "No"
+                  ]
+                }
+              },
+              {
+                "id": "second_parent_1st_job_employer_name",
+                "label": "1st Job - Employer Name",
+                "type": "text",
+                "required": false
+              },
+              {
+                "id": "second_parent_1st_job_employer_phone",
+                "label": "1st Job - Employer Phone",
+                "type": "tel",
+                "required": false
+              },
+              {
+                "id": "second_parent_1st_job_employer_street",
+                "label": "1st Job - Employer Street Address",
+                "type": "text",
+                "required": false
+              },
+              {
+                "id": "second_parent_1st_job_employer_city",
+                "label": "1st Job - Employer City",
+                "type": "text",
+                "required": false
+              },
+              {
+                "id": "second_parent_1st_job_employer_state",
+                "label": "1st Job - Employer State",
+                "type": "text",
+                "required": false
+              },
+              {
+                "id": "second_parent_1st_job_employer_zipcode",
+                "label": "1st Job - Employer ZIP Code",
+                "type": "text",
+                "required": false
+              },
+              {
+                "id": "second_parent_2nd_job_start_date",
+                "label": "2nd Job - Start Date",
+                "type": "date",
+                "required": false
+              },
+              {
+                "id": "second_parent_2nd_job_rotating_shift",
+                "label": "2nd Job - Has Rotating Shift?",
+                "type": "radio",
+                "required": false,
+                "ui": {
+                  "options": [
+                    "Yes",
+                    "No"
+                  ]
+                }
+              },
+              {
+                "id": "second_parent_2nd_job_requires_overtime",
+                "label": "2nd Job - Requires Overtime?",
+                "type": "radio",
+                "required": false,
+                "ui": {
+                  "options": [
+                    "Yes",
+                    "No"
+                  ]
+                }
+              },
+              {
+                "id": "second_parent_2nd_job_employer_name",
+                "label": "2nd Job - Employer Name",
+                "type": "text",
+                "required": false
+              },
+              {
+                "id": "second_parent_2nd_job_employer_phone",
+                "label": "2nd Job - Employer Phone",
+                "type": "tel",
+                "required": false
+              },
+              {
+                "id": "second_parent_2nd_job_employer_street",
+                "label": "2nd Job - Employer Street Address",
+                "type": "text",
+                "required": false
+              },
+              {
+                "id": "second_parent_2nd_job_employer_city",
+                "label": "2nd Job - Employer City",
+                "type": "text",
+                "required": false
+              },
+              {
+                "id": "second_parent_2nd_job_employer_state",
+                "label": "2nd Job - Employer State",
+                "type": "text",
+                "required": false
+              },
+              {
+                "id": "second_parent_2nd_job_employer_zipcode",
+                "label": "2nd Job - Employer ZIP Code",
+                "type": "text",
+                "required": false
+              }
+            ]
+          }
+        ]
+      },
+      {
+        "id": "schedule",
+        "title": "Work/Activity/Travel Time Schedule",
+        "sections": [
+          {
+            "id": "schedule_section_info",
+            "title": "Schedule Information",
+            "type": "info",
+            "ui": {
+              "markdown": true,
+              "collapsible": false,
+              "defaultCollapsed": false
+            },
+            "content": "Please indicate what days and hours you will need child care for based on your reason for care.\\n\\n- **Employed**: Indicate the hours you attend work\\n- **Educational or Vocational Program**: Indicate the hours you attend school or your program\\n- **Looking for Work**: Indicate the hours you spend looking for work\\n- **Homeless**: Indicate the hours you spend looking for housing\\n- **Attending Services for Domestic Violence**: Indicate the hours you attend services.\\n- **Attending Services for Substance Abuse Treatment**: Indicate the hours you attend services."
+          },
+          {
+            "id": "first_parent_activity_schedule",
+            "title": "First Parent Activity Schedule",
+            "description": "Enter the start and end times for each day of the week for the first parent's activities.",
+            "ui": {
+              "layout": "table",
+              "columns": [
+                "Start Time",
+                "End Time"
+              ],
+              "rowCopy": {
+                "enableUserPickSource": true,
+                "rowIdentifier": "ui.rowGroup",
+                "fieldsToCopy": [
+                  1,
+                  2
+                ],
+                "targetRowValues": [
+                  "Monday",
+                  "Tuesday",
+                  "Wednesday",
+                  "Thursday",
+                  "Friday"
+                ],
+                "copyControlLabel": "Apply selected schedule to other weekdays",
+                "sourceOptions": [
+                  "Monday",
+                  "Tuesday",
+                  "Wednesday",
+                  "Thursday",
+                  "Friday",
+                  "Saturday",
+                  "Sunday"
+                ]
+              }
+            },
+            "fields": [
+              {
+                "id": "fp_monday_from",
+                "label": "Monday From",
+                "type": "time",
+                "ui": {
+                  "rowGroup": "Monday",
+                  "column": 1
+                }
+              },
+              {
+                "id": "fp_monday_to",
+                "label": "Monday To",
+                "type": "time",
+                "ui": {
+                  "rowGroup": "Monday",
+                  "column": 2
+                }
+              },
+              {
+                "id": "fp_tuesday_from",
+                "label": "Tuesday From",
+                "type": "time",
+                "ui": {
+                  "rowGroup": "Tuesday",
+                  "column": 1
+                }
+              },
+              {
+                "id": "fp_tuesday_to",
+                "label": "Tuesday To",
+                "type": "time",
+                "ui": {
+                  "rowGroup": "Tuesday",
+                  "column": 2
+                }
+              },
+              {
+                "id": "fp_wednesday_from",
+                "label": "Wednesday From",
+                "type": "time",
+                "ui": {
+                  "rowGroup": "Wednesday",
+                  "column": 1
+                }
+              },
+              {
+                "id": "fp_wednesday_to",
+                "label": "Wednesday To",
+                "type": "time",
+                "ui": {
+                  "rowGroup": "Wednesday",
+                  "column": 2
+                }
+              },
+              {
+                "id": "fp_thursday_from",
+                "label": "Thursday From",
+                "type": "time",
+                "ui": {
+                  "rowGroup": "Thursday",
+                  "column": 1
+                }
+              },
+              {
+                "id": "fp_thursday_to",
+                "label": "Thursday To",
+                "type": "time",
+                "ui": {
+                  "rowGroup": "Thursday",
+                  "column": 2
+                }
+              },
+              {
+                "id": "fp_friday_from",
+                "label": "Friday From",
+                "type": "time",
+                "ui": {
+                  "rowGroup": "Friday",
+                  "column": 1
+                }
+              },
+              {
+                "id": "fp_friday_to",
+                "label": "Friday To",
+                "type": "time",
+                "ui": {
+                  "rowGroup": "Friday",
+                  "column": 2
+                }
+              },
+              {
+                "id": "fp_saturday_from",
+                "label": "Saturday From",
+                "type": "time",
+                "ui": {
+                  "rowGroup": "Saturday",
+                  "column": 1
+                }
+              },
+              {
+                "id": "fp_saturday_to",
+                "label": "Saturday To",
+                "type": "time",
+                "ui": {
+                  "rowGroup": "Saturday",
+                  "column": 2
+                }
+              },
+              {
+                "id": "fp_sunday_from",
+                "label": "Sunday From",
+                "type": "time",
+                "ui": {
+                  "rowGroup": "Sunday",
+                  "column": 1
+                }
+              },
+              {
+                "id": "fp_sunday_to",
+                "label": "Sunday To",
+                "type": "time",
+                "ui": {
+                  "rowGroup": "Sunday",
+                  "column": 2
+                }
+              }
+            ]
+          },
+          {
+            "id": "second_parent_activity_schedule",
+            "title": "Second Parent Activity Schedule",
+            "description": "Enter the start and end times for each day of the week for the second parent's activities.",
+            "ui": {
+              "layout": "table",
+              "columns": [
+                "Start Time",
+                "End Time"
+              ],
+              "rowCopy": {
+                "enableUserPickSource": true,
+                "rowIdentifier": "ui.rowGroup",
+                "fieldsToCopy": [
+                  1,
+                  2
+                ],
+                "targetRowValues": [
+                  "Monday",
+                  "Tuesday",
+                  "Wednesday",
+                  "Thursday",
+                  "Friday"
+                ],
+                "copyControlLabel": "Apply selected schedule to other weekdays",
+                "sourceOptions": [
+                  "Monday",
+                  "Tuesday",
+                  "Wednesday",
+                  "Thursday",
+                  "Friday",
+                  "Saturday",
+                  "Sunday"
+                ]
+              }
+            },
+            "fields": [
+              {
+                "id": "sp_monday_from",
+                "label": "Monday From",
+                "type": "time",
+                "ui": {
+                  "rowGroup": "Monday",
+                  "column": 1
+                }
+              },
+              {
+                "id": "sp_monday_to",
+                "label": "Monday To",
+                "type": "time",
+                "ui": {
+                  "rowGroup": "Monday",
+                  "column": 2
+                }
+              },
+              {
+                "id": "sp_tuesday_from",
+                "label": "Tuesday From",
+                "type": "time",
+                "ui": {
+                  "rowGroup": "Tuesday",
+                  "column": 1
+                }
+              },
+              {
+                "id": "sp_tuesday_to",
+                "label": "Tuesday To",
+                "type": "time",
+                "ui": {
+                  "rowGroup": "Tuesday",
+                  "column": 2
+                }
+              },
+              {
+                "id": "sp_wednesday_from",
+                "label": "Wednesday From",
+                "type": "time",
+                "ui": {
+                  "rowGroup": "Wednesday",
+                  "column": 1
+                }
+              },
+              {
+                "id": "sp_wednesday_to",
+                "label": "Wednesday To",
+                "type": "time",
+                "ui": {
+                  "rowGroup": "Wednesday",
+                  "column": 2
+                }
+              },
+              {
+                "id": "sp_thursday_from",
+                "label": "Thursday From",
+                "type": "time",
+                "ui": {
+                  "rowGroup": "Thursday",
+                  "column": 1
+                }
+              },
+              {
+                "id": "sp_thursday_to",
+                "label": "Thursday To",
+                "type": "time",
+                "ui": {
+                  "rowGroup": "Thursday",
+                  "column": 2
+                }
+              },
+              {
+                "id": "sp_friday_from",
+                "label": "Friday From",
+                "type": "time",
+                "ui": {
+                  "rowGroup": "Friday",
+                  "column": 1
+                }
+              },
+              {
+                "id": "sp_friday_to",
+                "label": "Friday To",
+                "type": "time",
+                "ui": {
+                  "rowGroup": "Friday",
+                  "column": 2
+                }
+              },
+              {
+                "id": "sp_saturday_from",
+                "label": "Saturday From",
+                "type": "time",
+                "ui": {
+                  "rowGroup": "Saturday",
+                  "column": 1
+                }
+              },
+              {
+                "id": "sp_saturday_to",
+                "label": "Saturday To",
+                "type": "time",
+                "ui": {
+                  "rowGroup": "Saturday",
+                  "column": 2
+                }
+              },
+              {
+                "id": "sp_sunday_from",
+                "label": "Sunday From",
+                "type": "time",
+                "ui": {
+                  "rowGroup": "Sunday",
+                  "column": 1
+                }
+              },
+              {
+                "id": "sp_sunday_to",
+                "label": "Sunday To",
+                "type": "time",
+                "ui": {
+                  "rowGroup": "Sunday",
+                  "column": 2
+                }
+              }
+            ]
+          },
+          {
+            "id": "first_parent_travel_time",
+            "title": "First Parent Travel Time",
+            "description": "Enter the travel times and method of transport for the first parent.",
+            "fields": [
+              {
+                "id": "fp_dropoff_travel_time",
+                "label": "Drop-off Travel Time",
+                "type": "select",
+                "tooltip": "Select your typical travel time from work/activity to your child care provider",
+                "ui": {
+                  "options": [
+                    "",
+                    "15 min",
+                    "30 min",
+                    "45 min",
+                    "1 hour",
+                    "More than 1 hour"
+                  ]
+                }
+              },
+              {
+                "id": "fp_dropoff_time_gt_1hr",
+                "label": "Drop-off Time (if > 1 hour)",
+                "type": "text",
+                "requiredCondition": {
+                  "field": "fp_dropoff_travel_time",
+                  "operator": "equals",
+                  "value": "More than 1 hour"
+                }
+              },
+              {
+                "id": "fp_pickup_travel_time",
+                "label": "Pick-up Travel Time",
+                "type": "select",
+                "tooltip": "Select your typical travel time from work/activity to your child care provider",
+                "ui": {
+                  "options": [
+                    "",
+                    "15 min",
+                    "30 min",
+                    "45 min",
+                    "1 hour",
+                    "More than 1 hour"
+                  ]
+                }
+              },
+              {
+                "id": "fp_pickup_time_gt_1hr",
+                "label": "Pick-up Time (if > 1 hour)",
+                "type": "text",
+                "requiredCondition": {
+                  "field": "fp_pickup_travel_time",
+                  "operator": "equals",
+                  "value": "More than 1 hour"
+                }
+              },
+              {
+                "id": "fp_public_transport_dropoff",
+                "label": "Public Transport for Drop-off?",
+                "type": "radio",
+                "tooltip": "Indicate if the applicant uses public transportation to travel to and from work/activity to provider.",
+                "ui": {
+                  "options": [
+                    "Yes",
+                    "No"
+                  ]
+                }
+              },
+              {
+                "id": "fp_public_transport_pickup",
+                "label": "Public Transport for Pick-up?",
+                "tooltip": "Indicate if the applicant uses public transportation to travel to and from work/activity to provider.",
+                "type": "radio",
+                "ui": {
+                  "options": [
+                    "Yes",
+                    "No"
+                  ]
+                }
+              }
+            ]
+          },
+          {
+            "id": "second_parent_travel_time",
+            "title": "Second Parent Travel Time",
+            "description": "Enter the travel times and method of transport for the second parent.",
+            "fields": [
+              {
+                "id": "sp_dropoff_travel_time",
+                "label": "Drop-off Travel Time",
+                "type": "select",
+                "ui": {
+                  "options": [
+                    "",
+                    "15 min",
+                    "30 min",
+                    "45 min",
+                    "1 hour",
+                    "More than 1 hour"
+                  ]
+                }
+              },
+              {
+                "id": "sp_pickup_travel_time",
+                "label": "Pick-up Travel Time",
+                "type": "select",
+                "ui": {
+                  "options": [
+                    "",
+                    "15 min",
+                    "30 min",
+                    "45 min",
+                    "1 hour",
+                    "More than 1 hour"
+                  ]
+                }
+              },
+              {
+                "id": "sp_dropoff_time_gt_1hr",
+                "label": "Drop-off Time (if > 1 hour)",
+                "type": "text",
+                "requiredCondition": {
+                  "field": "sp_dropoff_travel_time",
+                  "operator": "equals",
+                  "value": "More than 1 hour"
+                }
+              },
+              {
+                "id": "sp_pickup_time_gt_1hr",
+                "label": "Pick-up Time (if > 1 hour)",
+                "type": "text",
+                "requiredCondition": {
+                  "field": "sp_pickup_travel_time",
+                  "operator": "equals",
+                  "value": "More than 1 hour"
+                }
+              },
+              {
+                "id": "sp_public_transport_dropoff",
+                "label": "Public Transport for Drop-off?",
+                "type": "radio",
+                "ui": {
+                  "options": [
+                    "Yes",
+                    "No"
+                  ]
+                }
+              },
+              {
+                "id": "sp_public_transport_pickup",
+                "label": "Public Transport for Pick-up?",
+                "type": "radio",
+                "ui": {
+                  "options": [
+                    "Yes",
+                    "No"
+                  ]
+                }
+              }
+            ]
+          }
+        ]
+      },
+      {
+        "id": "income",
+        "title": "Income Information",
+        "sections": [
+          {
+            "id": "income_step_info",
+            "title": "Instructions",
+            "type": "info",
+            "ui": {
+              "markdown": true,
+              "collapsible": false,
+              "defaultCollapsed": false
+            },
+            "content": "Please include income/benefits information for yourself and, if applicable, your spouse, your child’s second caretaker, and/or any other adult with whom you share a child, if they live in your home.\\n\\nIndicate if you receive money from the following sources by selecting “Yes” or “No.” If you select “Yes,” you will be asked for additional information.\\n\\nIf the second caretaker in the household also receives the same income source, add a separate line for their income."
+          },
+          {
+            "id": "income_sources",
+            "title": "Income Sources",
+            "description": "Provide details about all income sources applicable to the applicant or household.",
+            "fields": [
+              {
+                "id": "income_sources",
+                "label": "List of Income Sources",
+                "type": "group",
+                "metadata": {
+                  "multiple": true,
+                  "tableColumns": [
+                    "name_ref",
+                    "how_often",
+                    "recipient",
+                    "monthly_amount"
+                  ]
+                },
+                "fields": [
+                  {
+                    "id": "name_ref",
+                    "label": "Income Source Type",
+                    "type": "select",
+                    "required": true,
+                    "ui": {
+                      "options": [
+                        "",
+                        "ApplicantWages",
+                        "SecondParentWages",
+                        "SelfEmployment",
+                        "ChildSupport",
+                        "Alimony",
+                        "Unemployment",
+                        "SocialSecurity",
+                        "Disability",
+                        "Rental",
+                        "Dividends",
+                        "Retirement",
+                        "CashAssistance",
+                        "Other"
+                      ]
+                    }
+                  },
+                  {
+                    "id": "other_source_text",
+                    "label": "Other Source (If applicable)",
+                    "type": "text",
+                    "visibilityCondition": {
+                      "field": "name_ref",
+                      "operator": "equals",
+                      "value": "Other"
+                    },
+                    "requiredCondition": {
+                      "condition": {
+                        "field": "name_ref",
+                        "operator": "equals",
+                        "value": "Other"
+                      }
+                    }
+                  },
+                  {
+                    "id": "is_source_applicable",
+                    "label": "Is this Source Applicable?",
+                    "type": "radio",
+                    "required": true,
+                    "ui": {
+                      "options": [
+                        "Yes",
+                        "No"
+                      ]
+                    }
+                  },
+                  {
+                    "id": "gross_amount",
+                    "label": "Gross Amount ($)",
+                    "type": "number",
+                    "required": true
+                  },
+                  {
+                    "id": "how_often",
+                    "label": "Frequency of Income",
+                    "type": "radio",
+                    "required": true,
+                    "ui": {
+                      "options": [
+                        "Weekly",
+                        "Bi-weekly",
+                        "Monthly",
+                        "Other"
+                      ]
+                    }
+                  },
+                  {
+                    "id": "recipient",
+                    "label": "Recipient of Income",
+                    "type": "text",
+                    "required": true
+                  },
+                  {
+                    "id": "monthly_amount",
+                    "label": "Monthly Amount ($)",
+                    "type": "number",
+                    "required": true
+                  }
+                ]
+              }
+            ]
+          },
+          {
+            "id": "total_income",
+            "title": "Total Household Income",
+            "description": "Sum of all monthly income across sources.",
+            "fields": [
+              {
+                "id": "total_income",
+                "label": "Total Monthly Income ($)",
+                "type": "number",
+                "required": true
+              }
+            ]
+          },
+          {
+            "id": "income_proof_section",
+            "title": "Income Proof",
+            "fields": [
+              {
+                "id": "income_proof",
+                "label": "Upload Income Proof",
+                "type": "file",
+                "requiredCondition": {
+                  "condition": {
+                    "field": "assistance_reason",
+                    "operator": "includes",
+                    "value": "Employment"
+                  }
+                },
+                "constraints": {
+                  "maxFileSizeMB": 5,
+                  "allowedTypes": [
+                    "application/pdf",
+                    "image/jpeg"
+                  ],
+                  "imageResolution": {
+                    "minWidth": 800,
+                    "minHeight": 600
+                  }
+                },
+                "metadata": {
+                  "proofCategory": "Income Verification",
+                  "examples": [
+                    "Pay Stub",
+                    "W-2"
+                  ],
+                  "multiple": true
+                }
+              }
+            ]
+          }
+        ]
+      },
+      {
+        "id": "provider",
+        "title": "Provider",
+        "sections": [
+          {
+            "id": "provider_step_info",
+            "title": "Instructions",
+            "type": "info",
+            "ui": {
+              "markdown": true,
+              "collapsible": false,
+              "defaultCollapsed": false
+            },
+            "content": "If you are found eligible for child care assistance, you can choose center-based or home-based care from a licensed, registered, or legally exempt provider. If you choose a provider that is not licensed or registered, the provider must be enrolled as a legally exempt provider.\\n\\nIf you know which child care providers you would like your child to attend, provide the names and addresses of your choice of providers. You can leave this section blank if you do not know (it will not impact your eligibility and you will have an opportunity to select a provider if determined eligible)."
+          },
+          {
+            "id": "provider_choices",
+            "title": "Provider Choices",
+            "description": "Specify details of the provider where you intend to enroll the child(ren).",
+            "fields": [
+              {
+                "id": "provider_choices",
+                "label": "List of Providers",
+                "type": "group",
+                "metadata": {
+                  "multiple": true,
+                  "tableColumns": [
+                    "provider_name",
+                    "program_number",
+                    "provider_zip_code"
+                  ]
+                },
+                "fields": [
+                  {
+                    "id": "provider_name",
+                    "label": "Provider Name",
+                    "type": "text",
+                    "required": true
+                  },
+                  {
+                    "id": "program_number",
+                    "label": "Program Number (If Applicable)",
+                    "type": "text",
+                    "required": false
+                  },
+                  {
+                    "id": "provider_street",
+                    "label": "Street Address",
+                    "type": "text",
+                    "required": true
+                  },
+                  {
+                    "id": "provider_city",
+                    "label": "City",
+                    "type": "text",
+                    "required": true
+                  },
+                  {
+                    "id": "provider_state",
+                    "label": "State",
+                    "type": "text",
+                    "required": true
+                  },
+                  {
+                    "id": "provider_zip_code",
+                    "label": "Zip Code",
+                    "type": "text",
+                    "required": true
+                  }
+                ]
+              }
+            ]
+          }
+        ]
+      },
+      {
+        "id": "document_upload_step",
+        "title": "Document Upload",
+        "description": "The Application for Child Care Assistance (CFWB-012) must include supporting documentation. Check to ensure that documentation is provided for each requirement of subsidy eligibility.",
+        "sections": [
+          {
+            "id": "nyc_residency",
+            "title": "New York City Residency",
+            "description": "These documents confirm that you live in New York City. Please upload one of the following documents.",
+            "fields": [
+              {
+                "id": "nyc_residency_type",
+                "label": "Select one of the following:",
+                "type": "radio",
+                "required": true,
+                "ui": {
+                  "options": [
+                    "IDNYC",
+                    "Utility Bill",
+                    "Section 8 Award Letter",
+                    "Driver’s License",
+                    "Rent Receipt",
+                    "NYCHA Certificate",
+                    "CFWB-067 Residency Attestation",
+                    "CFWB-027 Housing Attestation with address listed",
+                    "Shelter Residency Letter with address listed",
+                    "Other"
+                  ]
+                }
+              },
+              {
+                "id": "nyc_residency_file",
+                "label": "Upload Residency Proof Document",
+                "description": "To add a document to your application, you can upload an image or scanned file from your phone or device. Accepted formats include .pdf, .gif, .jpeg, .jpg and .png up to 25 MB. Learn how to upload your files with this Tutorial Video.",
+                "type": "file",
+                "required": true, 
+                "constraints": {
+                  "maxFileSizeMB": 25,
+                  "allowedTypes": [
+                    "application/pdf",
+                    "image/jpeg",
+                    "image/jpg",
+                    "image/png",
+                    "image/gif"
+                  ]
+                },
+                "metadata": {
+                  "proofCategory": "NYC Residency",
+                  "multiple": false
+                }
+              }
+            ]
+          },
+          {
+            "id": "citizenship_status",
+            "title": "Citizenship or Immigration Status",
+            "description": "These documents confirm the citizenship/immigration status of the children in your family for whom you’re applying for child care assistance. Please upload one of the following documents for ONLY each child needing care.",
+            "fields": [
+              {
+                "id": "citizenship_doc_type",
+                "label": "Select one of the following:",
+                "type": "radio",
+                "required": true,
+                "ui": {
+                  "options": [
+                    "US Birth Certificate",
+                    "Alien Registration Card including Permanent Resident or Green Card",
+                    "Passport",
+                    "FS-240 (Report of Birth Abroad of a U.S. Citizen)",
+                    "Naturalization Certificate",
+                    "Other"
+                  ]
+                }
+              },
+              {
+                "id": "citizenship_doc_file",
+                "label": "Upload Citizenship/Immigration Document",
+                "description": "To add a document to your application, you can upload an image or scanned file from your phone or device. Accepted formats include .pdf, .gif, .jpeg, .jpg and .png up to 25 MB. Learn how to upload your files with this Tutorial Video.",
+                "type": "file",
+                "required": true,
+                "constraints": {
+                  "maxFileSizeMB": 25,
+                  "allowedTypes": [
+                    "application/pdf",
+                    "image/jpeg",
+                    "image/jpg",
+                    "image/png",
+                    "image/gif"
+                  ]
+                },
+                "metadata": {
+                  "proofCategory": "Citizenship/Immigration Status",
+                  "multiple": false
+                }
+              }
+            ]
+          },
+          {
+            "id": "child_relationship",
+            "title": "Child’s Relationship to Parent/Applicant",
+            "description": "These documents confirm your relationship to the children in your household under age 18. Please upload one of the following documents for every child in the household under age 18, regardless of whether child care is needed for them or not. If you are a legal guardian with financial responsibility, you must upload a Court order OR a letter of guardianship.",
+            "fields": [
+              {
+                "id": "relationship_doc_type",
+                "label": "Select one of the following:",
+                "type": "radio",
+                "required": true,
+                "ui": {
+                  "options": [
+                    "Birth Certificate",
+                    "Adoption record",
+                    "Baptismal record",
+                    "Passport with parent's signature",
+                    "Court order for legal guardian with financial responsibility",
+                    "Letter of Guardianship",
+                    "Other - CFWB-058 Caretaker Attestation"
+                  ]
+                }
+              },
+              {
+                "id": "relationship_doc_file",
+                "label": "Upload Relationship Document",
+                "description": "To add a document to your application, you can upload an image or scanned file from your phone or device. Accepted formats include .pdf, .gif, .jpeg, .jpg and .png up to 25 MB. Learn how to upload your files with this Tutorial Video.",
+                "type": "file",
+                "required": true,
+                "constraints": {
+                  "maxFileSizeMB": 25,
+                  "allowedTypes": [
+                    "application/pdf",
+                    "image/jpeg",
+                    "image/jpg",
+                    "image/png",
+                    "image/gif"
+                  ]
+                },
+                "metadata": {
+                  "proofCategory": "Child Relationship",
+                  "multiple": false
+                }
+              }
+            ]
+          },
+          {
+            "id": "age_proof",
+            "title": "Age",
+            "description": "These documents confirm the age of the children in your household. Please upload one of the following documents for every child in the household under age 18, regardless of whether child care is needed for them:",
+            "fields": [
+              {
+                "id": "age_doc_type",
+                "label": "Select one of the following:",
+                "type": "radio",
+                "required": true,
+                "ui": {
+                  "options": [
+                    "Birth Certificate",
+                    "Adoption record",
+                    "Baptismal record",
+                    "Alien Registration Card",
+                    "Passport",
+                    "Official hospital documentation of the child’s birth"
+                  ]
+                }
+              },
+              {
+                "id": "age_doc_file",
+                "label": "Upload Age Proof Document",
+                "description": "To add a document to your application, you can upload an image or scanned file from your phone or device. Accepted formats include .pdf, .gif, .jpeg, .jpg and .png up to 25 MB. Learn how to upload your files with this Tutorial Video.",
+                "type": "file",
+                "required": true,
+                "constraints": {
+                  "maxFileSizeMB": 25,
+                  "allowedTypes": [
+                    "application/pdf",
+                    "image/jpeg",
+                    "image/jpg",
+                    "image/png",
+                    "image/gif"
+                  ]
+                },
+                "metadata": {
+                  "proofCategory": "Child Age",
+                  "multiple": false
+                }
+              }
+            ]
+          }
+        ]
+      },
+      {
+        "id": "review",
+        "title": "Review & Submit",
+        "type": "review",
+        "sections": []
+      }
+    ]
+  }
+}

--- a/test-form/public/data/childcare_form.ur.json
+++ b/test-form/public/data/childcare_form.ur.json
@@ -1,0 +1,2287 @@
+{
+  "form": {
+    "title": "Childcare Voucher Application",
+    "description": "Step-by-step form for applying for Childcare Assistance",
+    "layout": {
+      "stepperPosition": "left"
+    },
+    "steps": [
+      {
+        "id": "consent_step",
+        "title": "Consent",
+        "sections": [
+          {
+            "id": "mycity_consent_info",
+            "title": "ModelCity Consent",
+            "type": "info",
+            "ui": {
+              "markdown": true,
+              "collapsible": false,
+              "defaultCollapsed": false
+            },
+            "content": "In connection with this application for child care services, **ModelCity**:\\n\\n- Collects, processes, stores, and shares the information you submit to screen you when you apply for child care services;\\n- Receives, processes, and stores the information the City already knows about you to screen you when you apply for child care services;\\n- Uses your information to improve ModelCity; and\\n- Communicates with you about your ModelCity account.\\n\\n---\\n\\nIf you consent, the following information may be shared between child care services agencies:\\n\\n- Demographic and background information, including address, phone number, household composition.\\n- Housing information, including benefits awarded/received, current housing/shelter status.\\n- Benefits information, including public assistance awarded/received, child care program participation.\\n\\n---\\n\\nIf you choose not to consent, **you will not be denied** any benefits or services you are receiving or any benefits for which you are eligible.\\n\\nThe [ModelCity Privacy Policy](https://www.nyc.gov/privacy) details how ModelCity handles the information you submit through ModelCity."
+          }
+        ]
+      },
+      {
+        "id": "instructions_step",
+        "title": "Instructions",
+        "sections": [
+          {
+            "id": "application_instructions",
+            "title": "Application Instructions",
+            "type": "info",
+            "ui": {
+              "markdown": true,
+              "collapsible": false,
+              "defaultCollapsed": false
+            },
+            "content": "**Let’s get started on your application!**\\n\\nTo complete this application, you will be asked for information about:\\n\\n- Yourself\\n- Your household\\n- Your employment or reason for care\\n- Your income\\n\\nAll required fields are marked and must be filled out to move forward with the application. The pages of the application are shown on the right-hand side of the screen and will be highlighted as you move through the application.\\n\\nYour application will be saved automatically as you progress to each page.  \\nIf you need to pause at any time, click the **“Save for later”** button at the bottom of each page to save your application.  \\nYou can log back in to resume your application.\\n\\nWhen you’re ready to begin, click **“Next”** below.\\n\\n---\\n\\n⚠️ **Important:**  \\nTo keep your information current and safe, applications in draft status that you have not edited for **30 days** will be deleted.  \\nIf your draft application is deleted, you can still create and submit a new application when you're ready to apply."
+          },
+          {
+            "id": "new_york_city_residency",
+            "title": "New York City Residency",
+            "type": "info",
+            "ui": {
+              "markdown": true,
+              "collapsible": true,
+              "defaultCollapsed": true
+            },
+            "content": "You will need to upload **ONE** of the following documents to confirm your NYC residency:\\n\\n- IDNYC\\n- Driver’s License\\n- Utility Bill (dated within the last 60 days, with your address)\\n- Current lease, rent, or mortgage statement (dated within the last 60 days, with your address)\\n- Section 8 Award Letter\\n- NYCHA Certificate\\n- CFWB-027 Housing Attestation with address listed\\n- Shelter Residency Letter with address listed\\n\\nIf you do not have any of those documents, you must submit a **CFWB-067 Residency Attestation**."
+          },
+          {
+            "id": "children_documents",
+            "title": "Children Documents",
+            "type": "info",
+            "ui": {
+              "markdown": true,
+              "collapsible": true,
+              "defaultCollapsed": true
+            },
+            "content": "### Citizenship or Immigration Status\\nThese documents confirm the citizenship or immigration status of the children in your family for whom you’re applying for child care assistance. Please upload one of the following documents for each child needing care. *Do not upload these documents for children who do not need care.*\\n\\n- Birth Certificate from US state or territory\\n- Alien Registration Card including Permanent Resident or Green Card\\n- Passport\\n- FS-240 (Consular Report of Birth Abroad)\\n- Naturalization Certificate\\n- Other documentation that proves child’s immigration status\\n\\n### Child's Relationship to Applicant\\nThese documents confirm your relationship to the children in your household under age 18. Please upload one of the following documents for every child in the household under age 18, regardless of whether they need child care.\\n\\n- Birth certificate\\n- Adoption record\\n- Baptismal record\\n- Passport with parent's signature\\n- Court order for legal guardian with financial responsibility\\n- Letter of guardianship\\n- Other - CFWB-058 Caretaker Attestation\\n\\nIf you are not the child's parent or stepparent, you must submit a **CFWB-058 Caretaker Attestation Form**.\\n\\n### Age of Children\\nYou will need to upload **ONE** of the following documents for every child in the household under age 18, regardless of whether child care is needed for them:\\n\\n- Birth certificate\\n- Adoption record\\n- Baptismal record\\n- Alien Registration Card\\n- Passport\\n- Official hospital documentation of the child’s birth"
+          },
+          {
+            "id": "employment_income",
+            "title": "Employment & Income",
+            "type": "info",
+            "ui": {
+              "markdown": true,
+              "collapsible": true,
+              "defaultCollapsed": true
+            },
+            "content": "### Income\\nThese documents confirm your family’s income.\\n\\n---\\n\\n### If You Are Employed\\nIf you are employed and receive paystubs, you must submit them to confirm your income. The number of paystubs you must submit varies by how often you get paid and whether your payment amount is the same or different each time you are paid – see the table below for details. Submit the most recent paystub you have received, followed by others in consecutive order.\\n\\n**Income Information**\\n\\n| How Often Do You Get Paid? | Always the SAME Amount | DIFFERENT Amounts Each Time |\\n|----------------------------|-------------------------|------------------------------|\\n| Weekly (Every Week) | 4 most recent, consecutive pay stubs | 12 most recent, consecutive pay stubs |\\n| Bi-Weekly (Every Two Weeks) | 2 most recent, consecutive pay stubs | 6 most recent, consecutive pay stubs |\\n| Semi-Monthly (Two Times Per Month) | 2 most recent, consecutive pay stubs | 6 most recent, consecutive pay stubs |\\n| Monthly (One Time Per Month) | 3 most recent, consecutive pay stubs | 3 most recent, consecutive pay stubs |\\n\\nIf you do not have any paystubs, you must submit a **CFWB-015 Referral to Employer for Employee Income Information Form**.\\n\\n---\\n\\n### If You Are Self-Employed\\nIf you have been self-employed for **one year or more**, you must submit a current, complete and signed income tax package (e.g., 1040, 1065, Schedule C, SE for partnership, K-1, etc.).\\n\\nIf you have been self-employed for **less than one year**, you must submit a **CFWB-031 Self-Employment Income Information Attestation Form**.\\n\\n---\\n\\n### Other Income\\nIf you receive other types of income outside or instead of employment income, you must submit your most recent check, pay stub, or current award letter that indicates the amount you receive. If your other income fluctuates, **3 months of documentation is required**.\\n\\nThis includes, but is not limited to:\\n- Income from SSI, SSD\\n- Unemployment benefits\\n- Rental income\\n- Pensions\\n- Annuities\\n- Worker’s compensation\\n- Alimony\\n- Child support"
+          },
+          {
+            "id": "reason_for_care",
+            "title": "Reason for Care",
+            "type": "info",
+            "ui": {
+              "markdown": true,
+              "collapsible": true,
+              "defaultCollapsed": true
+            },
+            "content": "### Reason for Care\\nThese documents confirm your reason for care. Every applicant must have a qualified reason for care; in a two-parent household, parents or caretakers can have the same or different reasons for care. Only the documents related to your stated reasons for care need to be uploaded, and documentation must be uploaded for all parent or caretakers in the household.\\n\\n---\\n\\n### Working 10+ Hours Per Week\\nYour employment or self-employment income documents will cover this reason for care. You do not need to submit additional documentation.\\n\\n---\\n\\n### Participating in an Educational or Vocational Training Program\\nYou will need to upload **ONE** of the following documents to confirm your participation in vocational school, two-year college, or four-year college.\\n\\n- CFWB-005 Vocational, Education and Training Verification Form\\n- A letter from the educational or vocational training program on their official letterhead; this letter must contain all the information required in the CFWB-005 Vocational, Education and Training Verification Form.\\n\\n---\\n\\n### Looking for Work\\nYou will need to upload **ONE** of the following documents to confirm that you are looking for work.\\n\\n- CFWB-026 Work Search Record Form\\n- Approved work search plan from the NYS Dept. of Labor\\n- Proof of receipt of unemployment insurance\\n\\n---\\n\\n### Experiencing Homelessness\\nYou will need to upload **ONE** of the following documents to confirm that you are experiencing homelessness. This includes families who may be living in shelter or sharing the housing of others due to loss of housing, economic hardship, or similar reason.\\n\\n- Shelter Residency Letter (If living in Shelter, including Humanitarian Emergency Relief Centers)\\n- CFWB-027 Housing Attestation (If living doubled-up, in a place not meant for human habitation, in a hotel/motel, or in another living situation)\\n\\n---\\n\\n### Attending Services for Domestic Violence\\nYou will need to upload a referral for services from a domestic violence service provider to confirm that you are attending services for domestic violence.\\n\\n---\\n\\n### Attending Services for Substance Abuse Treatment\\nYou will need to upload a referral for a substance abuse treatment service provider to confirm that you are attending services for substance abuse treatment."
+          },
+          {
+            "id": "additional_details",
+            "title": "Additional Details",
+            "type": "info",
+            "ui": {
+              "markdown": true,
+              "collapsible": true,
+              "defaultCollapsed": true
+            },
+            "content": "### Application Scope\\nThis application is used to apply **only** for **Category 2 or 3 child care assistance** (for families not in receipt of cash assistance). To apply for **Cash Assistance** or other benefits, including **Category 1 Child Care Assistance** (for families in receipt of cash assistance), you must use the **New York State Application for Certain Benefits and Services (LDSS-2921)**.\\n\\n---\\n\\n### Exempt Applicants\\nThe following applicants may be eligible for child care assistance **without regard to income** and do not need to complete this application:\\n\\n- Foster parents who need child care assistance to allow them to work and are only applying for assistance for the foster children;\\n- Families in receipt of protective or preventive services.\\n\\n---\\n\\n### Application Completion\\nAll sections of this form must be filled out to be considered complete **unless the section is identified as optional**. If you do not complete all required sections of this form, you may not be considered for Child Care Assistance.\\n\\n---\\n\\n### Rights and Responsibilities\\nYou may obtain information about your rights and responsibilities [here](https://otda.ny.gov/programs/applications/). If you do not have access to the internet, you can call the **Administration for Children’s Services at 212-835-7610** to request that physical copies of the booklets which highlight your rights and responsibilities be mailed to you, including:\\n\\n- **LDSS-4148A**: What You Should Know About Your Rights and Responsibilities\\n- **LDSS-4148B**: What You Should Know About Social Services Programs\\n- **LDSS-4148C**: What You Should Know If You Have an Emergency"
+          }
+        ]
+      },
+      {
+        "id": "applicant",
+        "title": "Applicant",
+        "sections": [
+          {
+            "id": "personal_info",
+            "title": "Personal Information",
+            "fields": [
+              {
+                "id": "first_name",
+                "label": "First Name",
+                "type": "text",
+                "required": true
+              },
+              {
+                "id": "last_name",
+                "label": "Last Name",
+                "type": "text",
+                "required": true
+              },
+              {
+                "id": "mi",
+                "label": "Middle Initial",
+                "type": "text",
+                "required": false
+              },
+              {
+                "id": "date_of_birth",
+                "label": "Date of Birth",
+                "type": "date",
+                "required": true,
+                "tooltip": "To edit Date of Birth click on NYC ModelCity in the top-left corner then click on Account Settings."
+              },
+              {
+                "id": "sex",
+                "label": "Sex",
+                "type": "radio",
+                "required": true,
+                "ui": {
+                  "options": [
+                    "Male",
+                    "Female"
+                  ]
+                }
+              },
+              {
+                "id": "marital_status",
+                "label": "Marital Status",
+                "type": "select",
+                "required": true,
+                "tooltip": "Indicate your marital status (single, married, divorced, separated or widowed).",
+                "ui": {
+                  "options": [
+                    "",
+                    "Single",
+                    "Married",
+                    "Divorced",
+                    "Widowed",
+                    "Separated"
+                  ]
+                }
+              }
+            ]
+          },
+          {
+            "id": "contact_info",
+            "title": "Contact Information",
+            "fields": [
+              {
+                "id": "telephone_home",
+                "label": "Home Phone",
+                "type": "tel",
+                "required": false,
+                "constraints": {
+                  "pattern": "^\\\\(?[0-9]{3}\\\\)?[-. ]?[0-9]{3}[-. ]?[0-9]{4}$"
+                },
+                "ui": {
+                  "placeholder": "(123) 456-7890"
+                }
+              },
+              {
+                "id": "telephone_work",
+                "label": "Work Phone",
+                "type": "tel",
+                "required": false,
+                "constraints": {
+                  "pattern": "^\\\\(?[0-9]{3}\\\\)?[-. ]?[0-9]{3}[-. ]?[0-9]{4}$"
+                },
+                "ui": {
+                  "placeholder": "(123) 456-7890"
+                }
+              },
+              {
+                "id": "telephone_mobile_or_other",
+                "label": "Mobile or Other Phone",
+                "type": "tel",
+                "required": false,
+                "tooltip": "To edit Telephone (Cell or Other) click on NYC ModelCity in the top-left corner then click on Account Settings and then click on Contact.",
+                "constraints": {
+                  "pattern": "^\\\\(?[0-9]{3}\\\\)?[-. ]?[0-9]{3}[-. ]?[0-9]{4}$"
+                },
+                "ui": {
+                  "placeholder": "(123) 456-7890"
+                }
+              },
+              {
+                "id": "email",
+                "label": "Email",
+                "type": "email",
+                "required": true,
+                "tooltip": "To edit email, go to NYC ID Profile tab by clicking your name at the top right corner"
+              }
+            ]
+          },
+          {
+            "id": "address_info",
+            "title": "Address",
+            "tooltip": "To edit home address click on NYC ModelCity in the top-left corner then click on Account Settings.",
+            "ui": {
+              "autocomplete": "street",
+              "placeholder": "Start typing your street address",
+              "overrideComponent": "AddressAutocomplete"
+            },
+            "metadata": {
+              "integration": {
+                "provider": "Google",
+                "feature": "AddressAutocomplete"
+              },
+              "autofillTargets": [
+                {
+                  "fieldId": "city",
+                  "source": "locality",
+                  "fallbackSources": [
+                    "postal_town",
+                    "sublocality_level_1",
+                    "administrative_area_level_2"
+                  ]
+                },
+                {
+                  "fieldId": "borough",
+                  "source": "sublocality_level_1",
+                  "fallbackSources": [
+                    "administrative_area_level_2"
+                  ],
+                  "mapping": "boroughMap"
+                },
+                { "fieldId": "state", "source": "administrative_area_level_1" },
+                { "fieldId": "zip_code", "source": "postal_code" },
+                { "fieldId": "latitude", "source": "location.latitude" },
+                { "fieldId": "longitude", "source": "location.longitude" }
+              ]
+            },
+            "fields": [
+              {
+                "id": "street",
+                "label": "Street Address",
+                "type": "text",
+                "required": true,
+                "tooltip": "To edit home address click on NYC ModelCity in the top-left corner then click on Account Settings."
+              },
+              {
+                "id": "apt",
+                "label": "Apt #",
+                "type": "text",
+                "required": false
+              },
+              {
+                "id": "city",
+                "label": "City",
+                "type": "text",
+                "required": true
+              },
+              {
+                "id": "borough",
+                "label": "Borough",
+                "type": "select",
+                "required": true,
+                "ui": {
+                  "options": [
+                    "",
+                    "Bronx",
+                    "Brooklyn",
+                    "Manhattan",
+                    "Queens",
+                    "Staten Island"
+                  ]
+                }
+              },
+              {
+                "id": "state",
+                "label": "State",
+                "type": "text",
+                "required": true
+              },
+              {
+                "id": "zip_code",
+                "label": "Zip Code",
+                "type": "text",
+                "required": true
+              },
+              {
+                "id": "latitude",
+                "label": "Latitude",
+                "type": "number",
+                "required": false
+              },
+              {
+                "id": "longitude",
+                "label": "Longitude",
+                "type": "number",
+                "required": false
+              },
+              {
+                "id": "is_temporary_address",
+                "label": "Is Temporary Address",
+                "type": "radio",
+                "required": true,
+                "tooltip": "Check YES if you are currently living in a homeless shelter, doubled-up with another family, in a hotel/motel, in a car/ bus/ train, in a park/campsite, or other temporary accomodation.",
+                "ui": {
+                  "options": [
+                    "Yes",
+                    "No"
+                  ]
+                }
+              },
+              {
+                "id": "currently_living_in",
+                "label": "Currently Living In",
+                "type": "select",
+                "required": false,
+                "requiredCondition": {
+                  "field": "is_temporary_address",
+                  "operator": "equals",
+                  "value": "Yes"
+                },
+                "ui": {
+                  "options": [
+                    "",
+                    "Homeless Shelter",
+                    "Doubled-up with another Family",
+                    "Hotel/Motel",
+                    "Car, Bus, Train",
+                    "Park",
+                    "Campsite",
+                    "Other"
+                  ]
+                }
+              }
+            ]
+          },
+          {
+            "id": "demographics",
+            "title": "Demographics",
+            "fields": [
+              {
+                "id": "ethnicity",
+                "label": "Ethnicity",
+                "type": "select",
+                "required": false,
+                "ui": {
+                  "options": [
+                    "",
+                    "Hispanic",
+                    "Latino",
+                    "No",
+                    "Prefer not to answer"
+                  ]
+                }
+              },
+              {
+                "id": "race",
+                "label": "Race",
+                "type": "checkbox",
+                "required": false,
+                "tooltip": "You may choose multiple race categories. Providing race information is voluntary and will not affect your eligibility for Child Care Assistance or the amount of assistance that you will be given by this agency.",
+                "ui": {
+                  "options": [
+                    {
+                      "value": "AI",
+                      "label": "American Indian or Alaska Native"
+                    },
+                    {
+                      "value": "AS",
+                      "label": "Asian"
+                    },
+                    {
+                      "value": "BL",
+                      "label": "Black or African American"
+                    },
+                    {
+                      "value": "HP",
+                      "label": "Native Hawaiian or Pacific Islander"
+                    },
+                    {
+                      "value": "WH",
+                      "label": "White"
+                    }
+                  ]
+                },
+                "metadata": {
+                  "multiple": true
+                }
+              },
+              {
+                "id": "ssn",
+                "label": "Social Security Number",
+                "type": "text",
+                "tooltip": "To edit social security number click on NYC ModelCity in the top-left corner then click on Account Settings.",
+                "required": false,
+                "constraints": {
+                  "pattern": "^\\\\d{3}-\\\\d{2}-\\\\d{4}$"
+                },
+                "ui": {
+                  "placeholder": "123-45-6789"
+                }
+              }
+            ]
+          },
+          {
+            "id": "language_info",
+            "title": "Language Preferences",
+            "fields": [
+              {
+                "id": "primary_language",
+                "label": "Primary Language",
+                "type": "radio",
+                "required": true,
+                "tooltip": "Select the language that is spoken most often in your household. If “other”, provide the name of the language.",
+                "ui": {
+                  "options": [
+                    "English",
+                    "Spanish",
+                    "Other"
+                  ]
+                }
+              },
+              {
+                "id": "preferred_language",
+                "label": "Preferred Language",
+                "type": "radio",
+                "required": true,
+                "tooltip": "Select the language you prefer to communicate in. If “other”, provide the name of the language.",
+                "ui": {
+                  "options": [
+                    "English",
+                    "Spanish",
+                    "Other"
+                  ]
+                }
+              },
+              {
+                "id": "other_primary_language",
+                "label": "Other Primary Language",
+                "type": "text",
+                "required": false,
+                "requiredCondition": {
+                  "field": "primary_language",
+                  "operator": "equals",
+                  "value": "Other"
+                }
+              },
+              {
+                "id": "other_preferred_language",
+                "label": "Other Preferred Language",
+                "type": "text",
+                "required": false,
+                "requiredCondition": {
+                  "field": "preferred_language",
+                  "operator": "equals",
+                  "value": "Other"
+                }
+              }
+            ]
+          },
+          {
+            "id": "cash_assistance",
+            "title": "Cash Assistance",
+            "fields": [
+              {
+                "id": "has_cash_assistance",
+                "label": "Do you receive Cash Assistance?",
+                "type": "radio",
+                "required": false,
+                "ui": {
+                  "options": [
+                    "Yes",
+                    "No"
+                  ]
+                }
+              },
+              {
+                "id": "ca_number",
+                "label": "Cash Assistance Number",
+                "type": "text",
+                "required": false,
+                "requiredCondition": {
+                  "condition": {
+                    "field": "has_cash_assistance",
+                    "operator": "equals",
+                    "value": "Yes"
+                  }
+                }
+              }
+            ]
+          }
+        ]
+      },
+      {
+        "id": "children_needing_care",
+        "title": "Children Needing Care",
+        "sections": [
+          {
+            "id": "child_details",
+            "title": "Child Details",
+            "required": true,
+            "fields": [
+              {
+                "id": "children",
+                "label": "Children Needing Care",
+                "type": "group",
+                "metadata": {
+                  "multiple": true,
+                  "tableColumns": [
+                  "first_name",
+                  "last_name",
+                  "date_of_birth",
+                  "relationship_to_applicant"
+                  ]
+                },
+                "fields": [
+                  {
+                    "id": "first_name",
+                    "label": "First Name",
+                    "type": "text",
+                    "required": true,
+                    "tooltip": "Provide the first name, last name, and middle initial of each child you are applying for child care assistance for."
+                  },
+                  {
+                    "id": "last_name",
+                    "label": "Last Name",
+                    "type": "text",
+                    "required": true
+                  },
+                  {
+                    "id": "mi",
+                    "label": "Middle Initial",
+                    "type": "text",
+                    "required": false
+                  },
+                  {
+                    "id": "relationship_to_applicant",
+                    "label": "Relationship to Applicant",
+                    "type": "select",
+                    "required": true,
+                    "ui": {
+                      "options": [
+                        "",
+                        "Child",
+                        "Grandchild",
+                        "Foster Child",
+                        "Other"
+                      ]
+                    }
+                  },
+                  {
+                    "id": "date_of_birth",
+                    "label": "Date of Birth",
+                    "type": "date",
+                    "required": true,
+                    "tooltip": "Provide the date of birth."
+                  },
+                  {
+                    "id": "sex",
+                    "label": "Sex",
+                    "type": "radio",
+                    "required": true,
+                    "tooltip": "Select to indicate the sex.",
+                    "ui": {
+                      "options": [
+                        "Male",
+                        "Female"
+                      ]
+                    }
+                  },
+                  {
+                    "id": "ethnicity",
+                    "label": "Ethnicity Hispanic or Latino",
+                    "type": "select",
+                    "required": false,
+                    "tooltip": "Check “YES” or “NO” to indicate if each child in need of child care is Hispanic or Latino or not. Providing ethnicity information is voluntary and will not affect your eligibility for child care assistance or the amount of assistance that you will be given by this agency.",
+                    "ui": {
+                      "options": [
+                        "",
+                        "Yes",
+                        "No",
+                        "Prefer not to answer"
+                      ]
+                    }
+                  },
+                  {
+                    "id": "race",
+                    "label": "Race",
+                    "type": "checkbox",
+                    "required": false,
+                    "tooltip": "You may choose multiple race categories for a single child. Providing race information is voluntary and will not affect your eligibility for Child Care Assistance or the amount of assistance that you will be given by this agency.",
+                    "ui": {
+                      "options": [
+                        {
+                          "value": "AI",
+                          "label": "American Indian or Alaska Native"
+                        },
+                        {
+                          "value": "AS",
+                          "label": "Asian"
+                        },
+                        {
+                          "value": "BL",
+                          "label": "Black or African American"
+                        },
+                        {
+                          "value": "HP",
+                          "label": "Native Hawaiian or Pacific Islander"
+                        },
+                        {
+                          "value": "WH",
+                          "label": "White"
+                        }
+                      ]
+                    },
+                    "metadata": {
+                      "multiple": true
+                    }
+                  },
+                  {
+                    "id": "ssn",
+                    "label": "Social Security Number",
+                    "type": "text",
+                    "required": false,
+                    "tooltip": "Provide each child’s Social Security Number (SSN). You are not required to provide SSNs. They may be used by federal, state, and local agencies to prevent duplication of services and fraud, and for Federal Reporting.",
+                    "constraints": {
+                      "pattern": "^\\\\d{3}-\\\\d{2}-\\\\d{4}$"
+                    },
+                    "ui": {
+                      "placeholder": "123-45-6789"
+                    }
+                  },
+                  {
+                    "id": "do_both_parents_reside_in_home",
+                    "label": "Do both parents reside in the home?",
+                    "type": "radio",
+                    "required": true,
+                    "tooltip": "Check “YES” or “NO” to indicate whether both of the child’s parents live in the home.",
+                    "ui": {
+                      "options": [
+                        "Yes",
+                        "No"
+                      ]
+                    }
+                  },
+                  {
+                    "id": "has_disability",
+                    "label": "Does the child have a disability?",
+                    "type": "radio",
+                    "required": true,
+                    "tooltip": "Check “YES” or “NO” to indicate whether the child needing child care has a disability.",
+                    "ui": {
+                      "options": [
+                        "Yes",
+                        "No"
+                      ]
+                    }
+                  },
+                  {
+                    "id": "is_immigration_status_satisfactory",
+                    "label": "Is child U.S. Citizen, U.S. National, or person with satisfactory immigration status?",
+                    "type": "radio",
+                    "required": true,
+                    "tooltip": "You will only be asked about the immigration status of the children in need of care. Other members of the family will not need to state or prove their immigration status. Your child will be eligible for care if they are a U.S. citizen, a legal permanent resident (green card holder), a refugee, or an asylee; have a T-visa; or hold another qualified immigration status. Please select “Yes” if your child holds one of these statuses.",
+                    "ui": {
+                      "options": [
+                        "Yes",
+                        "No"
+                      ]
+                    }
+                  }
+                ]
+              }
+            ]
+          }
+        ]
+      },
+      {
+        "id": "family_members",
+        "title": "Family Members",
+        "sections": [
+          {
+            "id": "household_members_info",
+            "title": "Household Members Information",
+            "type": "info",
+            "ui": {
+              "markdown": true,
+              "collapsible": false,
+              "defaultCollapsed": false
+            },
+            "content": "**List the household members who do _not_ need child care.**\\n\\nIf applicable, list:\\n\\n- Your **spouse**, your child’s **second parent**, **caretaker**, or **step-parent**\\n- Any other **adult with whom you share a child**, if they live in your home\\n\\nThen, if applicable, list:\\n\\n- Any **siblings under the age of 18** who live in your home\\n\\n> **Only list other household members** — such as **aunts, uncles, cousins, grandparents, or friends** — _if they have financial responsibility_ for the child.\\n\\nA household member with financial responsibility, other than a parent or step-parent, is one who has a **letter or order of guardianship**.\\n\\n**Otherwise, do not include them.**"
+          },
+          {
+            "id": "family_member_details",
+            "title": "Household Member Details",
+            "description": "Include household members who do not need child care assistance (e.g., spouse, partner, other children).",
+            "fields": [
+              {
+                "id": "familymember",
+                "label": "Family Members",
+                "type": "group",
+                "requiredCondition": {
+                  "repeatingGroup": "children",
+                  "operator": "ANY",
+                  "condition": { "field": "do_both_parents_reside_in_home", "operator": "equals", "value": "Yes" }
+                },  
+                "metadata": {
+                  "multiple": true,
+                  "tableColumns": [
+                    "first_name",
+                    "last_name",
+                    "relationship_to_applicant",
+                    "date_of_birth"
+                  ]
+                },
+                "fields": [
+                  {
+                    "id": "first_name",
+                    "label": "First Name",
+                    "type": "text",
+                    "required": true,
+                    "tooltip": "Provide last and first name, and middle initial if applicable."
+                  },
+                  {
+                    "id": "last_name",
+                    "label": "Last Name",
+                    "type": "text",
+                    "required": true
+                  },
+                  {
+                    "id": "mi",
+                    "label": "Middle Initial",
+                    "type": "text",
+                    "required": false
+                  },
+                  {
+                    "id": "relationship_to_applicant",
+                    "label": "Relationship to Applicant",
+                    "type": "select",
+                    "required": true,
+                    "tooltip": "Provide each person’s relationship to you (e.g. spouse, partner, child, foster parent, other).",
+                    "ui": {
+                      "options": [
+                        "",
+                        "Spouse",
+                        "Partner",
+                        "Foster Parent",
+                        "Child",
+                        "Other"
+                      ]
+                    }
+                  },
+                  {
+                    "id": "date_of_birth",
+                    "label": "Date of Birth",
+                    "type": "date",
+                    "required": true,
+                    "tooltip": "Provide the family member's date of birth."
+                  },
+                  {
+                    "id": "sex",
+                    "label": "Sex",
+                    "type": "radio",
+                    "required": true,
+                    "tooltip": "Indicate the sex for each family member listed.",
+                    "ui": {
+                      "options": [
+                        "Male",
+                        "Female"
+                      ]
+                    }
+                  },
+                  {
+                    "id": "ethnicity",
+                    "label": "Ethnicity Hispanic or Latino",
+                    "type": "select",
+                    "required": false,
+                    "tooltip": "Check “YES” or “NO” to indicate if each member in the household is Hispanic or Latino or not. Providing ethnicity information is voluntary and will not affect your eligibility for Child Care Assistance or the amount of assistance that you will be given by this agency.",
+                    "ui": {
+                      "options": [
+                        "",
+                        "Yes",
+                        "No",
+                        "Prefer not to answer"
+                      ]
+                    }
+                  },
+                  {
+                    "id": "race",
+                    "label": "Race",
+                    "type": "checkbox",
+                    "required": false,
+                    "tooltip": "You may choose multiple race categories for a single person. Providing race information is voluntary and will not affect your eligibility for Child Care Assistance or the amount of assistance that you will be given by this agency.",
+                    "ui": {
+                      "options": [
+                        {
+                          "value": "AI",
+                          "label": "American Indian or Alaska Native"
+                        },
+                        {
+                          "value": "AS",
+                          "label": "Asian"
+                        },
+                        {
+                          "value": "BL",
+                          "label": "Black or African American"
+                        },
+                        {
+                          "value": "HP",
+                          "label": "Native Hawaiian or Pacific Islander"
+                        },
+                        {
+                          "value": "WH",
+                          "label": "White"
+                        }
+                      ]
+                    },
+                    "metadata": {
+                      "multiple": true
+                    }
+                  },
+                  {
+                    "id": "ssn",
+                    "label": "Social Security Number",
+                    "type": "text",
+                    "required": false,
+                    "tooltip": "Fill in the Social Security Number (SSN) for your family members. SSN is optional. SSN may be used by federal, state, and local agencies to prevent duplication of services and fraud, and for Federal Reporting.",
+                    "constraints": {
+                      "pattern": "^\\\\d{3}-\\\\d{2}-\\\\d{4}$"
+                    },
+                    "ui": {
+                      "placeholder": "123-45-6789"
+                    }
+                  }
+                ]
+              }
+            ]
+          }
+        ]
+      },
+      {
+        "id": "child_family_needs",
+        "title": "Child / Family Needs",
+        "sections": [
+          {
+            "id": "assistance_reason",
+            "title": "Reason for Child Care Assistance",
+            "description": "Select one or two reasons you are requesting Child Care Assistance.",
+            "tooltip": "Select one reason. In a two-parent household, parents/caretakers can have the same or different reasons for needing child care. Both parents/caretakers will be required to submit documentation in support of their own reason. If you are living in temporary housing, please select Homelessness even if you have another reason that applies to you.",
+            "fields": [
+              {
+                "id": "assistance_reason",
+                "label": "Reason(s) for Assistance",
+                "type": "select",
+                "required": true,
+                "ui": {
+                  "options": [
+                    "",
+                    "Employment",
+                    "Looking for Work",
+                    "Vocational Training/Educational Activities",
+                    "Receiving Domestic Violence Services",
+                    "Homelessness"
+                  ]
+                },
+                "constraints": {
+                  "minSelections": 1,
+                  "maxSelections": 2
+                },
+                "metadata": {
+                  "multiple": true
+                }
+              }
+            ]
+          },
+          {
+            "id": "military_status",
+            "title": "Military and Parental Availability",
+            "description": "Provide information about parental military status and availability for child care.",
+            "fields": [
+              {
+                "id": "is_parent_currently_active_in_military",
+                "label": "Is a Parent Currently Active Full-Time in the U.S. Military?",
+                "tooltip": "Check “YES” or “NO” to indicate whether a parent is currently active full-time in the U.S. Military.",
+                "type": "radio",
+                "required": true,
+                "ui": {
+                  "options": [
+                    "Yes",
+                    "No"
+                  ]
+                }
+              },
+              {
+                "id": "is_parent_mem_of_guard_or_mru",
+                "label": "Is a Parent a Member of National Guard or Military Reserve Unit?",
+                "tooltip": "Check “YES” or “NO” to indicate whether a parent is currently a member of a National Guard or Military Reserve Unit.",
+                "type": "radio",
+                "required": true,
+                "ui": {
+                  "options": [
+                    "Yes",
+                    "No"
+                  ]
+                }
+              },
+              {
+                "id": "is_non_custodial_parent_available",
+                "label": "Is the Non-Custodial Parent Available to Provide Care?",
+                "tooltip": "Check “YES” or “NO” to indicate whether there is a non-custodial parent available to provide child care.",
+                "type": "radio",
+                "required": true,
+                "ui": {
+                  "options": [
+                    "Yes",
+                    "No"
+                  ]
+                }
+              }
+            ]
+          },
+          {
+            "id": "duplicate_application",
+            "title": "Other Applications",
+            "description": "Indicate if you are also applying for or receiving child care from other agencies.",
+            "tooltip": "Indicate whether you are currently receiving or have applied for child care assistance with one of the agencies or organizations listed below. Note: If you are receiving Cash Assistance and are interested in child care assistance, you must apply through the Human Resources Administration. Reach out to your Benefits Access Center or visit the Human Resources Administration webpage.",
+            "fields": [
+              {
+                "id": "duplicate_app",
+                "label": "Are You Receiving or Applying for Child Care Through Another Agency?",
+                "type": "select",
+                "required": false,
+                "ui": {
+                  "options": [
+                    "",
+                    "Not Applicable",
+                    "Department of Education (DOE)",
+                    "Human Resources Administration (HRA)",
+                    "Department of Youth and Community Development (DYCD)",
+                    "Department of Homeless Services (DHS)",
+                    "Consortium for Worker Education (CWE)",
+                    "Administration for Children's Services (ACS)"
+                  ]
+                }
+              }
+            ]
+          }
+        ]
+      },
+      {
+        "id": "employment",
+        "title": "Employment",
+        "sections": [
+          {
+            "id": "employment_precheck",
+            "title": "Tell us about your employment",
+            "description": "Tell us about your employment",
+            "fields": [
+              {
+                "id": "applicant_emp_income_indicator",
+                "label": "Does applicant earn any income/ wages from employment? ",
+                "type": "radio",
+                "required": false,
+                "ui": {
+                  "options": [
+                    "Yes",
+                    "No"
+                  ]
+                }
+              },
+              {
+                "id": "coparent_emp_income_indicator",
+                "label": "Does Coparent/2nd Guardian earn any income/ wages from employment? ",
+                "type": "radio",
+                "required": false,
+                "ui": {
+                  "options": [
+                    "Yes",
+                    "No"
+                  ]
+                }
+              }
+            ]
+          },
+          {
+            "id": "applicant_jobs",
+            "title": "Applicant Employment Information",
+            "description": "Enter details for up to two jobs held by the applicant.",
+            "visibilityCondition": {
+              "field": "applicant_emp_income_indicator",
+              "operator": "equals",
+              "value": "Yes"
+            },
+            "fields": [
+              {
+                "id": "applicant_1st_job_start_date",
+                "label": "1st Job - Start Date",
+                "type": "date",
+                "required": false,
+                "ui": {
+                  "group": "1st Job"
+                }
+              },
+              {
+                "id": "applicant_1st_job_rotating_shift",
+                "label": "1st Job - Has Rotating Shift?",
+                "type": "radio",
+                "required": false,
+                "ui": {
+                  "options": [
+                    "Yes",
+                    "No"
+                  ],
+                  "group": "1st Job"
+                }
+              },
+              {
+                "id": "applicant_1st_job_requires_overtime",
+                "label": "1st Job - Requires Overtime?",
+                "type": "radio",
+                "required": false,
+                "ui": {
+                  "options": [
+                    "Yes",
+                    "No"
+                  ],
+                  "group": "1st Job"
+                }
+              },
+              {
+                "id": "applicant_1st_job_employer_name",
+                "label": "1st Job - Employer Name",
+                "type": "text",
+                "required": false,
+                "ui": {
+                  "group": "1st Job"
+                }
+              },
+              {
+                "id": "applicant_1st_job_employer_phone",
+                "label": "1st Job - Employer Phone",
+                "type": "tel",
+                "required": false,
+                "ui": {
+                  "group": "1st Job"
+                }
+              },
+              {
+                "id": "applicant_1st_job_employer_street",
+                "label": "1st Job - Employer Street Address",
+                "type": "text",
+                "required": false,
+                "ui": {
+                  "group": "1st Job"
+                }
+              },
+              {
+                "id": "applicant_1st_job_employer_city",
+                "label": "1st Job - Employer City",
+                "type": "text",
+                "required": false,
+                "ui": {
+                  "group": "1st Job"
+                }
+              },
+              {
+                "id": "applicant_1st_job_employer_state",
+                "label": "1st Job - Employer State",
+                "type": "text",
+                "required": false,
+                "ui": {
+                  "group": "1st Job"
+                }
+              },
+              {
+                "id": "applicant_1st_job_employer_zipcode",
+                "label": "1st Job - Employer ZIP Code",
+                "type": "text",
+                "required": false,
+                "ui": {
+                  "group": "1st Job"
+                }
+              },
+              {
+                "id": "applicant_2nd_job_start_date",
+                "label": "2nd Job - Start Date",
+                "type": "date",
+                "required": false,
+                "ui": {
+                  "group": "2nd Job"
+                }
+              },
+              {
+                "id": "applicant_2nd_job_rotating_shift",
+                "label": "2nd Job - Has Rotating Shift?",
+                "type": "radio",
+                "required": false,
+                "ui": {
+                  "options": [
+                    "Yes",
+                    "No"
+                  ],
+                  "group": "2nd Job"
+                }
+              },
+              {
+                "id": "applicant_2nd_job_requires_overtime",
+                "label": "2nd Job - Requires Overtime?",
+                "type": "radio",
+                "required": false,
+                "ui": {
+                  "options": [
+                    "Yes",
+                    "No"
+                  ],
+                  "group": "2nd Job"
+                }
+              },
+              {
+                "id": "applicant_2nd_job_employer_name",
+                "label": "2nd Job - Employer Name",
+                "type": "text",
+                "required": false,
+                "ui": {
+                  "group": "2nd Job"
+                }
+              },
+              {
+                "id": "applicant_2nd_job_employer_phone",
+                "label": "2nd Job - Employer Phone",
+                "type": "tel",
+                "required": false,
+                "ui": {
+                  "group": "2nd Job"
+                }
+              },
+              {
+                "id": "applicant_2nd_job_employer_street",
+                "label": "2nd Job - Employer Street Address",
+                "type": "text",
+                "required": false,
+                "ui": {
+                  "group": "2nd Job"
+                }
+              },
+              {
+                "id": "applicant_2nd_job_employer_city",
+                "label": "2nd Job - Employer City",
+                "type": "text",
+                "required": false,
+                "ui": {
+                  "group": "2nd Job"
+                }
+              },
+              {
+                "id": "applicant_2nd_job_employer_state",
+                "label": "2nd Job - Employer State",
+                "type": "text",
+                "required": false,
+                "ui": {
+                  "group": "2nd Job"
+                }
+              },
+              {
+                "id": "applicant_2nd_job_employer_zipcode",
+                "label": "2nd Job - Employer ZIP Code",
+                "type": "text",
+                "required": false,
+                "ui": {
+                  "group": "2nd Job"
+                }
+              }
+            ]
+          },
+          {
+            "id": "second_parent_jobs",
+            "title": "Second Parent Employment Information",
+            "description": "Enter details for up to two jobs held by the second parent (if applicable).",
+            "visibilityCondition": {
+              "field": "coparent_emp_income_indicator",
+              "operator": "equals",
+              "value": "Yes"
+            },
+            "fields": [
+              {
+                "id": "second_parent_1st_job_start_date",
+                "label": "1st Job - Start Date",
+                "type": "date",
+                "required": false
+              },
+              {
+                "id": "second_parent_1st_job_rotating_shift",
+                "label": "1st Job - Has Rotating Shift?",
+                "type": "radio",
+                "required": false,
+                "ui": {
+                  "options": [
+                    "Yes",
+                    "No"
+                  ]
+                }
+              },
+              {
+                "id": "second_parent_1st_job_requires_overtime",
+                "label": "1st Job - Requires Overtime?",
+                "type": "radio",
+                "required": false,
+                "ui": {
+                  "options": [
+                    "Yes",
+                    "No"
+                  ]
+                }
+              },
+              {
+                "id": "second_parent_1st_job_employer_name",
+                "label": "1st Job - Employer Name",
+                "type": "text",
+                "required": false
+              },
+              {
+                "id": "second_parent_1st_job_employer_phone",
+                "label": "1st Job - Employer Phone",
+                "type": "tel",
+                "required": false
+              },
+              {
+                "id": "second_parent_1st_job_employer_street",
+                "label": "1st Job - Employer Street Address",
+                "type": "text",
+                "required": false
+              },
+              {
+                "id": "second_parent_1st_job_employer_city",
+                "label": "1st Job - Employer City",
+                "type": "text",
+                "required": false
+              },
+              {
+                "id": "second_parent_1st_job_employer_state",
+                "label": "1st Job - Employer State",
+                "type": "text",
+                "required": false
+              },
+              {
+                "id": "second_parent_1st_job_employer_zipcode",
+                "label": "1st Job - Employer ZIP Code",
+                "type": "text",
+                "required": false
+              },
+              {
+                "id": "second_parent_2nd_job_start_date",
+                "label": "2nd Job - Start Date",
+                "type": "date",
+                "required": false
+              },
+              {
+                "id": "second_parent_2nd_job_rotating_shift",
+                "label": "2nd Job - Has Rotating Shift?",
+                "type": "radio",
+                "required": false,
+                "ui": {
+                  "options": [
+                    "Yes",
+                    "No"
+                  ]
+                }
+              },
+              {
+                "id": "second_parent_2nd_job_requires_overtime",
+                "label": "2nd Job - Requires Overtime?",
+                "type": "radio",
+                "required": false,
+                "ui": {
+                  "options": [
+                    "Yes",
+                    "No"
+                  ]
+                }
+              },
+              {
+                "id": "second_parent_2nd_job_employer_name",
+                "label": "2nd Job - Employer Name",
+                "type": "text",
+                "required": false
+              },
+              {
+                "id": "second_parent_2nd_job_employer_phone",
+                "label": "2nd Job - Employer Phone",
+                "type": "tel",
+                "required": false
+              },
+              {
+                "id": "second_parent_2nd_job_employer_street",
+                "label": "2nd Job - Employer Street Address",
+                "type": "text",
+                "required": false
+              },
+              {
+                "id": "second_parent_2nd_job_employer_city",
+                "label": "2nd Job - Employer City",
+                "type": "text",
+                "required": false
+              },
+              {
+                "id": "second_parent_2nd_job_employer_state",
+                "label": "2nd Job - Employer State",
+                "type": "text",
+                "required": false
+              },
+              {
+                "id": "second_parent_2nd_job_employer_zipcode",
+                "label": "2nd Job - Employer ZIP Code",
+                "type": "text",
+                "required": false
+              }
+            ]
+          }
+        ]
+      },
+      {
+        "id": "schedule",
+        "title": "Work/Activity/Travel Time Schedule",
+        "sections": [
+          {
+            "id": "schedule_section_info",
+            "title": "Schedule Information",
+            "type": "info",
+            "ui": {
+              "markdown": true,
+              "collapsible": false,
+              "defaultCollapsed": false
+            },
+            "content": "Please indicate what days and hours you will need child care for based on your reason for care.\\n\\n- **Employed**: Indicate the hours you attend work\\n- **Educational or Vocational Program**: Indicate the hours you attend school or your program\\n- **Looking for Work**: Indicate the hours you spend looking for work\\n- **Homeless**: Indicate the hours you spend looking for housing\\n- **Attending Services for Domestic Violence**: Indicate the hours you attend services.\\n- **Attending Services for Substance Abuse Treatment**: Indicate the hours you attend services."
+          },
+          {
+            "id": "first_parent_activity_schedule",
+            "title": "First Parent Activity Schedule",
+            "description": "Enter the start and end times for each day of the week for the first parent's activities.",
+            "ui": {
+              "layout": "table",
+              "columns": [
+                "Start Time",
+                "End Time"
+              ],
+              "rowCopy": {
+                "enableUserPickSource": true,
+                "rowIdentifier": "ui.rowGroup",
+                "fieldsToCopy": [
+                  1,
+                  2
+                ],
+                "targetRowValues": [
+                  "Monday",
+                  "Tuesday",
+                  "Wednesday",
+                  "Thursday",
+                  "Friday"
+                ],
+                "copyControlLabel": "Apply selected schedule to other weekdays",
+                "sourceOptions": [
+                  "Monday",
+                  "Tuesday",
+                  "Wednesday",
+                  "Thursday",
+                  "Friday",
+                  "Saturday",
+                  "Sunday"
+                ]
+              }
+            },
+            "fields": [
+              {
+                "id": "fp_monday_from",
+                "label": "Monday From",
+                "type": "time",
+                "ui": {
+                  "rowGroup": "Monday",
+                  "column": 1
+                }
+              },
+              {
+                "id": "fp_monday_to",
+                "label": "Monday To",
+                "type": "time",
+                "ui": {
+                  "rowGroup": "Monday",
+                  "column": 2
+                }
+              },
+              {
+                "id": "fp_tuesday_from",
+                "label": "Tuesday From",
+                "type": "time",
+                "ui": {
+                  "rowGroup": "Tuesday",
+                  "column": 1
+                }
+              },
+              {
+                "id": "fp_tuesday_to",
+                "label": "Tuesday To",
+                "type": "time",
+                "ui": {
+                  "rowGroup": "Tuesday",
+                  "column": 2
+                }
+              },
+              {
+                "id": "fp_wednesday_from",
+                "label": "Wednesday From",
+                "type": "time",
+                "ui": {
+                  "rowGroup": "Wednesday",
+                  "column": 1
+                }
+              },
+              {
+                "id": "fp_wednesday_to",
+                "label": "Wednesday To",
+                "type": "time",
+                "ui": {
+                  "rowGroup": "Wednesday",
+                  "column": 2
+                }
+              },
+              {
+                "id": "fp_thursday_from",
+                "label": "Thursday From",
+                "type": "time",
+                "ui": {
+                  "rowGroup": "Thursday",
+                  "column": 1
+                }
+              },
+              {
+                "id": "fp_thursday_to",
+                "label": "Thursday To",
+                "type": "time",
+                "ui": {
+                  "rowGroup": "Thursday",
+                  "column": 2
+                }
+              },
+              {
+                "id": "fp_friday_from",
+                "label": "Friday From",
+                "type": "time",
+                "ui": {
+                  "rowGroup": "Friday",
+                  "column": 1
+                }
+              },
+              {
+                "id": "fp_friday_to",
+                "label": "Friday To",
+                "type": "time",
+                "ui": {
+                  "rowGroup": "Friday",
+                  "column": 2
+                }
+              },
+              {
+                "id": "fp_saturday_from",
+                "label": "Saturday From",
+                "type": "time",
+                "ui": {
+                  "rowGroup": "Saturday",
+                  "column": 1
+                }
+              },
+              {
+                "id": "fp_saturday_to",
+                "label": "Saturday To",
+                "type": "time",
+                "ui": {
+                  "rowGroup": "Saturday",
+                  "column": 2
+                }
+              },
+              {
+                "id": "fp_sunday_from",
+                "label": "Sunday From",
+                "type": "time",
+                "ui": {
+                  "rowGroup": "Sunday",
+                  "column": 1
+                }
+              },
+              {
+                "id": "fp_sunday_to",
+                "label": "Sunday To",
+                "type": "time",
+                "ui": {
+                  "rowGroup": "Sunday",
+                  "column": 2
+                }
+              }
+            ]
+          },
+          {
+            "id": "second_parent_activity_schedule",
+            "title": "Second Parent Activity Schedule",
+            "description": "Enter the start and end times for each day of the week for the second parent's activities.",
+            "ui": {
+              "layout": "table",
+              "columns": [
+                "Start Time",
+                "End Time"
+              ],
+              "rowCopy": {
+                "enableUserPickSource": true,
+                "rowIdentifier": "ui.rowGroup",
+                "fieldsToCopy": [
+                  1,
+                  2
+                ],
+                "targetRowValues": [
+                  "Monday",
+                  "Tuesday",
+                  "Wednesday",
+                  "Thursday",
+                  "Friday"
+                ],
+                "copyControlLabel": "Apply selected schedule to other weekdays",
+                "sourceOptions": [
+                  "Monday",
+                  "Tuesday",
+                  "Wednesday",
+                  "Thursday",
+                  "Friday",
+                  "Saturday",
+                  "Sunday"
+                ]
+              }
+            },
+            "fields": [
+              {
+                "id": "sp_monday_from",
+                "label": "Monday From",
+                "type": "time",
+                "ui": {
+                  "rowGroup": "Monday",
+                  "column": 1
+                }
+              },
+              {
+                "id": "sp_monday_to",
+                "label": "Monday To",
+                "type": "time",
+                "ui": {
+                  "rowGroup": "Monday",
+                  "column": 2
+                }
+              },
+              {
+                "id": "sp_tuesday_from",
+                "label": "Tuesday From",
+                "type": "time",
+                "ui": {
+                  "rowGroup": "Tuesday",
+                  "column": 1
+                }
+              },
+              {
+                "id": "sp_tuesday_to",
+                "label": "Tuesday To",
+                "type": "time",
+                "ui": {
+                  "rowGroup": "Tuesday",
+                  "column": 2
+                }
+              },
+              {
+                "id": "sp_wednesday_from",
+                "label": "Wednesday From",
+                "type": "time",
+                "ui": {
+                  "rowGroup": "Wednesday",
+                  "column": 1
+                }
+              },
+              {
+                "id": "sp_wednesday_to",
+                "label": "Wednesday To",
+                "type": "time",
+                "ui": {
+                  "rowGroup": "Wednesday",
+                  "column": 2
+                }
+              },
+              {
+                "id": "sp_thursday_from",
+                "label": "Thursday From",
+                "type": "time",
+                "ui": {
+                  "rowGroup": "Thursday",
+                  "column": 1
+                }
+              },
+              {
+                "id": "sp_thursday_to",
+                "label": "Thursday To",
+                "type": "time",
+                "ui": {
+                  "rowGroup": "Thursday",
+                  "column": 2
+                }
+              },
+              {
+                "id": "sp_friday_from",
+                "label": "Friday From",
+                "type": "time",
+                "ui": {
+                  "rowGroup": "Friday",
+                  "column": 1
+                }
+              },
+              {
+                "id": "sp_friday_to",
+                "label": "Friday To",
+                "type": "time",
+                "ui": {
+                  "rowGroup": "Friday",
+                  "column": 2
+                }
+              },
+              {
+                "id": "sp_saturday_from",
+                "label": "Saturday From",
+                "type": "time",
+                "ui": {
+                  "rowGroup": "Saturday",
+                  "column": 1
+                }
+              },
+              {
+                "id": "sp_saturday_to",
+                "label": "Saturday To",
+                "type": "time",
+                "ui": {
+                  "rowGroup": "Saturday",
+                  "column": 2
+                }
+              },
+              {
+                "id": "sp_sunday_from",
+                "label": "Sunday From",
+                "type": "time",
+                "ui": {
+                  "rowGroup": "Sunday",
+                  "column": 1
+                }
+              },
+              {
+                "id": "sp_sunday_to",
+                "label": "Sunday To",
+                "type": "time",
+                "ui": {
+                  "rowGroup": "Sunday",
+                  "column": 2
+                }
+              }
+            ]
+          },
+          {
+            "id": "first_parent_travel_time",
+            "title": "First Parent Travel Time",
+            "description": "Enter the travel times and method of transport for the first parent.",
+            "fields": [
+              {
+                "id": "fp_dropoff_travel_time",
+                "label": "Drop-off Travel Time",
+                "type": "select",
+                "tooltip": "Select your typical travel time from work/activity to your child care provider",
+                "ui": {
+                  "options": [
+                    "",
+                    "15 min",
+                    "30 min",
+                    "45 min",
+                    "1 hour",
+                    "More than 1 hour"
+                  ]
+                }
+              },
+              {
+                "id": "fp_dropoff_time_gt_1hr",
+                "label": "Drop-off Time (if > 1 hour)",
+                "type": "text",
+                "requiredCondition": {
+                  "field": "fp_dropoff_travel_time",
+                  "operator": "equals",
+                  "value": "More than 1 hour"
+                }
+              },
+              {
+                "id": "fp_pickup_travel_time",
+                "label": "Pick-up Travel Time",
+                "type": "select",
+                "tooltip": "Select your typical travel time from work/activity to your child care provider",
+                "ui": {
+                  "options": [
+                    "",
+                    "15 min",
+                    "30 min",
+                    "45 min",
+                    "1 hour",
+                    "More than 1 hour"
+                  ]
+                }
+              },
+              {
+                "id": "fp_pickup_time_gt_1hr",
+                "label": "Pick-up Time (if > 1 hour)",
+                "type": "text",
+                "requiredCondition": {
+                  "field": "fp_pickup_travel_time",
+                  "operator": "equals",
+                  "value": "More than 1 hour"
+                }
+              },
+              {
+                "id": "fp_public_transport_dropoff",
+                "label": "Public Transport for Drop-off?",
+                "type": "radio",
+                "tooltip": "Indicate if the applicant uses public transportation to travel to and from work/activity to provider.",
+                "ui": {
+                  "options": [
+                    "Yes",
+                    "No"
+                  ]
+                }
+              },
+              {
+                "id": "fp_public_transport_pickup",
+                "label": "Public Transport for Pick-up?",
+                "tooltip": "Indicate if the applicant uses public transportation to travel to and from work/activity to provider.",
+                "type": "radio",
+                "ui": {
+                  "options": [
+                    "Yes",
+                    "No"
+                  ]
+                }
+              }
+            ]
+          },
+          {
+            "id": "second_parent_travel_time",
+            "title": "Second Parent Travel Time",
+            "description": "Enter the travel times and method of transport for the second parent.",
+            "fields": [
+              {
+                "id": "sp_dropoff_travel_time",
+                "label": "Drop-off Travel Time",
+                "type": "select",
+                "ui": {
+                  "options": [
+                    "",
+                    "15 min",
+                    "30 min",
+                    "45 min",
+                    "1 hour",
+                    "More than 1 hour"
+                  ]
+                }
+              },
+              {
+                "id": "sp_pickup_travel_time",
+                "label": "Pick-up Travel Time",
+                "type": "select",
+                "ui": {
+                  "options": [
+                    "",
+                    "15 min",
+                    "30 min",
+                    "45 min",
+                    "1 hour",
+                    "More than 1 hour"
+                  ]
+                }
+              },
+              {
+                "id": "sp_dropoff_time_gt_1hr",
+                "label": "Drop-off Time (if > 1 hour)",
+                "type": "text",
+                "requiredCondition": {
+                  "field": "sp_dropoff_travel_time",
+                  "operator": "equals",
+                  "value": "More than 1 hour"
+                }
+              },
+              {
+                "id": "sp_pickup_time_gt_1hr",
+                "label": "Pick-up Time (if > 1 hour)",
+                "type": "text",
+                "requiredCondition": {
+                  "field": "sp_pickup_travel_time",
+                  "operator": "equals",
+                  "value": "More than 1 hour"
+                }
+              },
+              {
+                "id": "sp_public_transport_dropoff",
+                "label": "Public Transport for Drop-off?",
+                "type": "radio",
+                "ui": {
+                  "options": [
+                    "Yes",
+                    "No"
+                  ]
+                }
+              },
+              {
+                "id": "sp_public_transport_pickup",
+                "label": "Public Transport for Pick-up?",
+                "type": "radio",
+                "ui": {
+                  "options": [
+                    "Yes",
+                    "No"
+                  ]
+                }
+              }
+            ]
+          }
+        ]
+      },
+      {
+        "id": "income",
+        "title": "Income Information",
+        "sections": [
+          {
+            "id": "income_step_info",
+            "title": "Instructions",
+            "type": "info",
+            "ui": {
+              "markdown": true,
+              "collapsible": false,
+              "defaultCollapsed": false
+            },
+            "content": "Please include income/benefits information for yourself and, if applicable, your spouse, your child’s second caretaker, and/or any other adult with whom you share a child, if they live in your home.\\n\\nIndicate if you receive money from the following sources by selecting “Yes” or “No.” If you select “Yes,” you will be asked for additional information.\\n\\nIf the second caretaker in the household also receives the same income source, add a separate line for their income."
+          },
+          {
+            "id": "income_sources",
+            "title": "Income Sources",
+            "description": "Provide details about all income sources applicable to the applicant or household.",
+            "fields": [
+              {
+                "id": "income_sources",
+                "label": "List of Income Sources",
+                "type": "group",
+                "metadata": {
+                  "multiple": true,
+                  "tableColumns": [
+                    "name_ref",
+                    "how_often",
+                    "recipient",
+                    "monthly_amount"
+                  ]
+                },
+                "fields": [
+                  {
+                    "id": "name_ref",
+                    "label": "Income Source Type",
+                    "type": "select",
+                    "required": true,
+                    "ui": {
+                      "options": [
+                        "",
+                        "ApplicantWages",
+                        "SecondParentWages",
+                        "SelfEmployment",
+                        "ChildSupport",
+                        "Alimony",
+                        "Unemployment",
+                        "SocialSecurity",
+                        "Disability",
+                        "Rental",
+                        "Dividends",
+                        "Retirement",
+                        "CashAssistance",
+                        "Other"
+                      ]
+                    }
+                  },
+                  {
+                    "id": "other_source_text",
+                    "label": "Other Source (If applicable)",
+                    "type": "text",
+                    "visibilityCondition": {
+                      "field": "name_ref",
+                      "operator": "equals",
+                      "value": "Other"
+                    },
+                    "requiredCondition": {
+                      "condition": {
+                        "field": "name_ref",
+                        "operator": "equals",
+                        "value": "Other"
+                      }
+                    }
+                  },
+                  {
+                    "id": "is_source_applicable",
+                    "label": "Is this Source Applicable?",
+                    "type": "radio",
+                    "required": true,
+                    "ui": {
+                      "options": [
+                        "Yes",
+                        "No"
+                      ]
+                    }
+                  },
+                  {
+                    "id": "gross_amount",
+                    "label": "Gross Amount ($)",
+                    "type": "number",
+                    "required": true
+                  },
+                  {
+                    "id": "how_often",
+                    "label": "Frequency of Income",
+                    "type": "radio",
+                    "required": true,
+                    "ui": {
+                      "options": [
+                        "Weekly",
+                        "Bi-weekly",
+                        "Monthly",
+                        "Other"
+                      ]
+                    }
+                  },
+                  {
+                    "id": "recipient",
+                    "label": "Recipient of Income",
+                    "type": "text",
+                    "required": true
+                  },
+                  {
+                    "id": "monthly_amount",
+                    "label": "Monthly Amount ($)",
+                    "type": "number",
+                    "required": true
+                  }
+                ]
+              }
+            ]
+          },
+          {
+            "id": "total_income",
+            "title": "Total Household Income",
+            "description": "Sum of all monthly income across sources.",
+            "fields": [
+              {
+                "id": "total_income",
+                "label": "Total Monthly Income ($)",
+                "type": "number",
+                "required": true
+              }
+            ]
+          },
+          {
+            "id": "income_proof_section",
+            "title": "Income Proof",
+            "fields": [
+              {
+                "id": "income_proof",
+                "label": "Upload Income Proof",
+                "type": "file",
+                "requiredCondition": {
+                  "condition": {
+                    "field": "assistance_reason",
+                    "operator": "includes",
+                    "value": "Employment"
+                  }
+                },
+                "constraints": {
+                  "maxFileSizeMB": 5,
+                  "allowedTypes": [
+                    "application/pdf",
+                    "image/jpeg"
+                  ],
+                  "imageResolution": {
+                    "minWidth": 800,
+                    "minHeight": 600
+                  }
+                },
+                "metadata": {
+                  "proofCategory": "Income Verification",
+                  "examples": [
+                    "Pay Stub",
+                    "W-2"
+                  ],
+                  "multiple": true
+                }
+              }
+            ]
+          }
+        ]
+      },
+      {
+        "id": "provider",
+        "title": "Provider",
+        "sections": [
+          {
+            "id": "provider_step_info",
+            "title": "Instructions",
+            "type": "info",
+            "ui": {
+              "markdown": true,
+              "collapsible": false,
+              "defaultCollapsed": false
+            },
+            "content": "If you are found eligible for child care assistance, you can choose center-based or home-based care from a licensed, registered, or legally exempt provider. If you choose a provider that is not licensed or registered, the provider must be enrolled as a legally exempt provider.\\n\\nIf you know which child care providers you would like your child to attend, provide the names and addresses of your choice of providers. You can leave this section blank if you do not know (it will not impact your eligibility and you will have an opportunity to select a provider if determined eligible)."
+          },
+          {
+            "id": "provider_choices",
+            "title": "Provider Choices",
+            "description": "Specify details of the provider where you intend to enroll the child(ren).",
+            "fields": [
+              {
+                "id": "provider_choices",
+                "label": "List of Providers",
+                "type": "group",
+                "metadata": {
+                  "multiple": true,
+                  "tableColumns": [
+                    "provider_name",
+                    "program_number",
+                    "provider_zip_code"
+                  ]
+                },
+                "fields": [
+                  {
+                    "id": "provider_name",
+                    "label": "Provider Name",
+                    "type": "text",
+                    "required": true
+                  },
+                  {
+                    "id": "program_number",
+                    "label": "Program Number (If Applicable)",
+                    "type": "text",
+                    "required": false
+                  },
+                  {
+                    "id": "provider_street",
+                    "label": "Street Address",
+                    "type": "text",
+                    "required": true
+                  },
+                  {
+                    "id": "provider_city",
+                    "label": "City",
+                    "type": "text",
+                    "required": true
+                  },
+                  {
+                    "id": "provider_state",
+                    "label": "State",
+                    "type": "text",
+                    "required": true
+                  },
+                  {
+                    "id": "provider_zip_code",
+                    "label": "Zip Code",
+                    "type": "text",
+                    "required": true
+                  }
+                ]
+              }
+            ]
+          }
+        ]
+      },
+      {
+        "id": "document_upload_step",
+        "title": "Document Upload",
+        "description": "The Application for Child Care Assistance (CFWB-012) must include supporting documentation. Check to ensure that documentation is provided for each requirement of subsidy eligibility.",
+        "sections": [
+          {
+            "id": "nyc_residency",
+            "title": "New York City Residency",
+            "description": "These documents confirm that you live in New York City. Please upload one of the following documents.",
+            "fields": [
+              {
+                "id": "nyc_residency_type",
+                "label": "Select one of the following:",
+                "type": "radio",
+                "required": true,
+                "ui": {
+                  "options": [
+                    "IDNYC",
+                    "Utility Bill",
+                    "Section 8 Award Letter",
+                    "Driver’s License",
+                    "Rent Receipt",
+                    "NYCHA Certificate",
+                    "CFWB-067 Residency Attestation",
+                    "CFWB-027 Housing Attestation with address listed",
+                    "Shelter Residency Letter with address listed",
+                    "Other"
+                  ]
+                }
+              },
+              {
+                "id": "nyc_residency_file",
+                "label": "Upload Residency Proof Document",
+                "description": "To add a document to your application, you can upload an image or scanned file from your phone or device. Accepted formats include .pdf, .gif, .jpeg, .jpg and .png up to 25 MB. Learn how to upload your files with this Tutorial Video.",
+                "type": "file",
+                "required": true, 
+                "constraints": {
+                  "maxFileSizeMB": 25,
+                  "allowedTypes": [
+                    "application/pdf",
+                    "image/jpeg",
+                    "image/jpg",
+                    "image/png",
+                    "image/gif"
+                  ]
+                },
+                "metadata": {
+                  "proofCategory": "NYC Residency",
+                  "multiple": false
+                }
+              }
+            ]
+          },
+          {
+            "id": "citizenship_status",
+            "title": "Citizenship or Immigration Status",
+            "description": "These documents confirm the citizenship/immigration status of the children in your family for whom you’re applying for child care assistance. Please upload one of the following documents for ONLY each child needing care.",
+            "fields": [
+              {
+                "id": "citizenship_doc_type",
+                "label": "Select one of the following:",
+                "type": "radio",
+                "required": true,
+                "ui": {
+                  "options": [
+                    "US Birth Certificate",
+                    "Alien Registration Card including Permanent Resident or Green Card",
+                    "Passport",
+                    "FS-240 (Report of Birth Abroad of a U.S. Citizen)",
+                    "Naturalization Certificate",
+                    "Other"
+                  ]
+                }
+              },
+              {
+                "id": "citizenship_doc_file",
+                "label": "Upload Citizenship/Immigration Document",
+                "description": "To add a document to your application, you can upload an image or scanned file from your phone or device. Accepted formats include .pdf, .gif, .jpeg, .jpg and .png up to 25 MB. Learn how to upload your files with this Tutorial Video.",
+                "type": "file",
+                "required": true,
+                "constraints": {
+                  "maxFileSizeMB": 25,
+                  "allowedTypes": [
+                    "application/pdf",
+                    "image/jpeg",
+                    "image/jpg",
+                    "image/png",
+                    "image/gif"
+                  ]
+                },
+                "metadata": {
+                  "proofCategory": "Citizenship/Immigration Status",
+                  "multiple": false
+                }
+              }
+            ]
+          },
+          {
+            "id": "child_relationship",
+            "title": "Child’s Relationship to Parent/Applicant",
+            "description": "These documents confirm your relationship to the children in your household under age 18. Please upload one of the following documents for every child in the household under age 18, regardless of whether child care is needed for them or not. If you are a legal guardian with financial responsibility, you must upload a Court order OR a letter of guardianship.",
+            "fields": [
+              {
+                "id": "relationship_doc_type",
+                "label": "Select one of the following:",
+                "type": "radio",
+                "required": true,
+                "ui": {
+                  "options": [
+                    "Birth Certificate",
+                    "Adoption record",
+                    "Baptismal record",
+                    "Passport with parent's signature",
+                    "Court order for legal guardian with financial responsibility",
+                    "Letter of Guardianship",
+                    "Other - CFWB-058 Caretaker Attestation"
+                  ]
+                }
+              },
+              {
+                "id": "relationship_doc_file",
+                "label": "Upload Relationship Document",
+                "description": "To add a document to your application, you can upload an image or scanned file from your phone or device. Accepted formats include .pdf, .gif, .jpeg, .jpg and .png up to 25 MB. Learn how to upload your files with this Tutorial Video.",
+                "type": "file",
+                "required": true,
+                "constraints": {
+                  "maxFileSizeMB": 25,
+                  "allowedTypes": [
+                    "application/pdf",
+                    "image/jpeg",
+                    "image/jpg",
+                    "image/png",
+                    "image/gif"
+                  ]
+                },
+                "metadata": {
+                  "proofCategory": "Child Relationship",
+                  "multiple": false
+                }
+              }
+            ]
+          },
+          {
+            "id": "age_proof",
+            "title": "Age",
+            "description": "These documents confirm the age of the children in your household. Please upload one of the following documents for every child in the household under age 18, regardless of whether child care is needed for them:",
+            "fields": [
+              {
+                "id": "age_doc_type",
+                "label": "Select one of the following:",
+                "type": "radio",
+                "required": true,
+                "ui": {
+                  "options": [
+                    "Birth Certificate",
+                    "Adoption record",
+                    "Baptismal record",
+                    "Alien Registration Card",
+                    "Passport",
+                    "Official hospital documentation of the child’s birth"
+                  ]
+                }
+              },
+              {
+                "id": "age_doc_file",
+                "label": "Upload Age Proof Document",
+                "description": "To add a document to your application, you can upload an image or scanned file from your phone or device. Accepted formats include .pdf, .gif, .jpeg, .jpg and .png up to 25 MB. Learn how to upload your files with this Tutorial Video.",
+                "type": "file",
+                "required": true,
+                "constraints": {
+                  "maxFileSizeMB": 25,
+                  "allowedTypes": [
+                    "application/pdf",
+                    "image/jpeg",
+                    "image/jpg",
+                    "image/png",
+                    "image/gif"
+                  ]
+                },
+                "metadata": {
+                  "proofCategory": "Child Age",
+                  "multiple": false
+                }
+              }
+            ]
+          }
+        ]
+      },
+      {
+        "id": "review",
+        "title": "Review & Submit",
+        "type": "review",
+        "sections": []
+      }
+    ]
+  }
+}

--- a/test-form/public/data/childcare_form.zh.json
+++ b/test-form/public/data/childcare_form.zh.json
@@ -1,0 +1,2287 @@
+{
+  "form": {
+    "title": "Childcare Voucher Application",
+    "description": "Step-by-step form for applying for Childcare Assistance",
+    "layout": {
+      "stepperPosition": "left"
+    },
+    "steps": [
+      {
+        "id": "consent_step",
+        "title": "Consent",
+        "sections": [
+          {
+            "id": "mycity_consent_info",
+            "title": "ModelCity Consent",
+            "type": "info",
+            "ui": {
+              "markdown": true,
+              "collapsible": false,
+              "defaultCollapsed": false
+            },
+            "content": "In connection with this application for child care services, **ModelCity**:\\n\\n- Collects, processes, stores, and shares the information you submit to screen you when you apply for child care services;\\n- Receives, processes, and stores the information the City already knows about you to screen you when you apply for child care services;\\n- Uses your information to improve ModelCity; and\\n- Communicates with you about your ModelCity account.\\n\\n---\\n\\nIf you consent, the following information may be shared between child care services agencies:\\n\\n- Demographic and background information, including address, phone number, household composition.\\n- Housing information, including benefits awarded/received, current housing/shelter status.\\n- Benefits information, including public assistance awarded/received, child care program participation.\\n\\n---\\n\\nIf you choose not to consent, **you will not be denied** any benefits or services you are receiving or any benefits for which you are eligible.\\n\\nThe [ModelCity Privacy Policy](https://www.nyc.gov/privacy) details how ModelCity handles the information you submit through ModelCity."
+          }
+        ]
+      },
+      {
+        "id": "instructions_step",
+        "title": "Instructions",
+        "sections": [
+          {
+            "id": "application_instructions",
+            "title": "Application Instructions",
+            "type": "info",
+            "ui": {
+              "markdown": true,
+              "collapsible": false,
+              "defaultCollapsed": false
+            },
+            "content": "**Let’s get started on your application!**\\n\\nTo complete this application, you will be asked for information about:\\n\\n- Yourself\\n- Your household\\n- Your employment or reason for care\\n- Your income\\n\\nAll required fields are marked and must be filled out to move forward with the application. The pages of the application are shown on the right-hand side of the screen and will be highlighted as you move through the application.\\n\\nYour application will be saved automatically as you progress to each page.  \\nIf you need to pause at any time, click the **“Save for later”** button at the bottom of each page to save your application.  \\nYou can log back in to resume your application.\\n\\nWhen you’re ready to begin, click **“Next”** below.\\n\\n---\\n\\n⚠️ **Important:**  \\nTo keep your information current and safe, applications in draft status that you have not edited for **30 days** will be deleted.  \\nIf your draft application is deleted, you can still create and submit a new application when you're ready to apply."
+          },
+          {
+            "id": "new_york_city_residency",
+            "title": "New York City Residency",
+            "type": "info",
+            "ui": {
+              "markdown": true,
+              "collapsible": true,
+              "defaultCollapsed": true
+            },
+            "content": "You will need to upload **ONE** of the following documents to confirm your NYC residency:\\n\\n- IDNYC\\n- Driver’s License\\n- Utility Bill (dated within the last 60 days, with your address)\\n- Current lease, rent, or mortgage statement (dated within the last 60 days, with your address)\\n- Section 8 Award Letter\\n- NYCHA Certificate\\n- CFWB-027 Housing Attestation with address listed\\n- Shelter Residency Letter with address listed\\n\\nIf you do not have any of those documents, you must submit a **CFWB-067 Residency Attestation**."
+          },
+          {
+            "id": "children_documents",
+            "title": "Children Documents",
+            "type": "info",
+            "ui": {
+              "markdown": true,
+              "collapsible": true,
+              "defaultCollapsed": true
+            },
+            "content": "### Citizenship or Immigration Status\\nThese documents confirm the citizenship or immigration status of the children in your family for whom you’re applying for child care assistance. Please upload one of the following documents for each child needing care. *Do not upload these documents for children who do not need care.*\\n\\n- Birth Certificate from US state or territory\\n- Alien Registration Card including Permanent Resident or Green Card\\n- Passport\\n- FS-240 (Consular Report of Birth Abroad)\\n- Naturalization Certificate\\n- Other documentation that proves child’s immigration status\\n\\n### Child's Relationship to Applicant\\nThese documents confirm your relationship to the children in your household under age 18. Please upload one of the following documents for every child in the household under age 18, regardless of whether they need child care.\\n\\n- Birth certificate\\n- Adoption record\\n- Baptismal record\\n- Passport with parent's signature\\n- Court order for legal guardian with financial responsibility\\n- Letter of guardianship\\n- Other - CFWB-058 Caretaker Attestation\\n\\nIf you are not the child's parent or stepparent, you must submit a **CFWB-058 Caretaker Attestation Form**.\\n\\n### Age of Children\\nYou will need to upload **ONE** of the following documents for every child in the household under age 18, regardless of whether child care is needed for them:\\n\\n- Birth certificate\\n- Adoption record\\n- Baptismal record\\n- Alien Registration Card\\n- Passport\\n- Official hospital documentation of the child’s birth"
+          },
+          {
+            "id": "employment_income",
+            "title": "Employment & Income",
+            "type": "info",
+            "ui": {
+              "markdown": true,
+              "collapsible": true,
+              "defaultCollapsed": true
+            },
+            "content": "### Income\\nThese documents confirm your family’s income.\\n\\n---\\n\\n### If You Are Employed\\nIf you are employed and receive paystubs, you must submit them to confirm your income. The number of paystubs you must submit varies by how often you get paid and whether your payment amount is the same or different each time you are paid – see the table below for details. Submit the most recent paystub you have received, followed by others in consecutive order.\\n\\n**Income Information**\\n\\n| How Often Do You Get Paid? | Always the SAME Amount | DIFFERENT Amounts Each Time |\\n|----------------------------|-------------------------|------------------------------|\\n| Weekly (Every Week) | 4 most recent, consecutive pay stubs | 12 most recent, consecutive pay stubs |\\n| Bi-Weekly (Every Two Weeks) | 2 most recent, consecutive pay stubs | 6 most recent, consecutive pay stubs |\\n| Semi-Monthly (Two Times Per Month) | 2 most recent, consecutive pay stubs | 6 most recent, consecutive pay stubs |\\n| Monthly (One Time Per Month) | 3 most recent, consecutive pay stubs | 3 most recent, consecutive pay stubs |\\n\\nIf you do not have any paystubs, you must submit a **CFWB-015 Referral to Employer for Employee Income Information Form**.\\n\\n---\\n\\n### If You Are Self-Employed\\nIf you have been self-employed for **one year or more**, you must submit a current, complete and signed income tax package (e.g., 1040, 1065, Schedule C, SE for partnership, K-1, etc.).\\n\\nIf you have been self-employed for **less than one year**, you must submit a **CFWB-031 Self-Employment Income Information Attestation Form**.\\n\\n---\\n\\n### Other Income\\nIf you receive other types of income outside or instead of employment income, you must submit your most recent check, pay stub, or current award letter that indicates the amount you receive. If your other income fluctuates, **3 months of documentation is required**.\\n\\nThis includes, but is not limited to:\\n- Income from SSI, SSD\\n- Unemployment benefits\\n- Rental income\\n- Pensions\\n- Annuities\\n- Worker’s compensation\\n- Alimony\\n- Child support"
+          },
+          {
+            "id": "reason_for_care",
+            "title": "Reason for Care",
+            "type": "info",
+            "ui": {
+              "markdown": true,
+              "collapsible": true,
+              "defaultCollapsed": true
+            },
+            "content": "### Reason for Care\\nThese documents confirm your reason for care. Every applicant must have a qualified reason for care; in a two-parent household, parents or caretakers can have the same or different reasons for care. Only the documents related to your stated reasons for care need to be uploaded, and documentation must be uploaded for all parent or caretakers in the household.\\n\\n---\\n\\n### Working 10+ Hours Per Week\\nYour employment or self-employment income documents will cover this reason for care. You do not need to submit additional documentation.\\n\\n---\\n\\n### Participating in an Educational or Vocational Training Program\\nYou will need to upload **ONE** of the following documents to confirm your participation in vocational school, two-year college, or four-year college.\\n\\n- CFWB-005 Vocational, Education and Training Verification Form\\n- A letter from the educational or vocational training program on their official letterhead; this letter must contain all the information required in the CFWB-005 Vocational, Education and Training Verification Form.\\n\\n---\\n\\n### Looking for Work\\nYou will need to upload **ONE** of the following documents to confirm that you are looking for work.\\n\\n- CFWB-026 Work Search Record Form\\n- Approved work search plan from the NYS Dept. of Labor\\n- Proof of receipt of unemployment insurance\\n\\n---\\n\\n### Experiencing Homelessness\\nYou will need to upload **ONE** of the following documents to confirm that you are experiencing homelessness. This includes families who may be living in shelter or sharing the housing of others due to loss of housing, economic hardship, or similar reason.\\n\\n- Shelter Residency Letter (If living in Shelter, including Humanitarian Emergency Relief Centers)\\n- CFWB-027 Housing Attestation (If living doubled-up, in a place not meant for human habitation, in a hotel/motel, or in another living situation)\\n\\n---\\n\\n### Attending Services for Domestic Violence\\nYou will need to upload a referral for services from a domestic violence service provider to confirm that you are attending services for domestic violence.\\n\\n---\\n\\n### Attending Services for Substance Abuse Treatment\\nYou will need to upload a referral for a substance abuse treatment service provider to confirm that you are attending services for substance abuse treatment."
+          },
+          {
+            "id": "additional_details",
+            "title": "Additional Details",
+            "type": "info",
+            "ui": {
+              "markdown": true,
+              "collapsible": true,
+              "defaultCollapsed": true
+            },
+            "content": "### Application Scope\\nThis application is used to apply **only** for **Category 2 or 3 child care assistance** (for families not in receipt of cash assistance). To apply for **Cash Assistance** or other benefits, including **Category 1 Child Care Assistance** (for families in receipt of cash assistance), you must use the **New York State Application for Certain Benefits and Services (LDSS-2921)**.\\n\\n---\\n\\n### Exempt Applicants\\nThe following applicants may be eligible for child care assistance **without regard to income** and do not need to complete this application:\\n\\n- Foster parents who need child care assistance to allow them to work and are only applying for assistance for the foster children;\\n- Families in receipt of protective or preventive services.\\n\\n---\\n\\n### Application Completion\\nAll sections of this form must be filled out to be considered complete **unless the section is identified as optional**. If you do not complete all required sections of this form, you may not be considered for Child Care Assistance.\\n\\n---\\n\\n### Rights and Responsibilities\\nYou may obtain information about your rights and responsibilities [here](https://otda.ny.gov/programs/applications/). If you do not have access to the internet, you can call the **Administration for Children’s Services at 212-835-7610** to request that physical copies of the booklets which highlight your rights and responsibilities be mailed to you, including:\\n\\n- **LDSS-4148A**: What You Should Know About Your Rights and Responsibilities\\n- **LDSS-4148B**: What You Should Know About Social Services Programs\\n- **LDSS-4148C**: What You Should Know If You Have an Emergency"
+          }
+        ]
+      },
+      {
+        "id": "applicant",
+        "title": "Applicant",
+        "sections": [
+          {
+            "id": "personal_info",
+            "title": "Personal Information",
+            "fields": [
+              {
+                "id": "first_name",
+                "label": "First Name",
+                "type": "text",
+                "required": true
+              },
+              {
+                "id": "last_name",
+                "label": "Last Name",
+                "type": "text",
+                "required": true
+              },
+              {
+                "id": "mi",
+                "label": "Middle Initial",
+                "type": "text",
+                "required": false
+              },
+              {
+                "id": "date_of_birth",
+                "label": "Date of Birth",
+                "type": "date",
+                "required": true,
+                "tooltip": "To edit Date of Birth click on NYC ModelCity in the top-left corner then click on Account Settings."
+              },
+              {
+                "id": "sex",
+                "label": "Sex",
+                "type": "radio",
+                "required": true,
+                "ui": {
+                  "options": [
+                    "Male",
+                    "Female"
+                  ]
+                }
+              },
+              {
+                "id": "marital_status",
+                "label": "Marital Status",
+                "type": "select",
+                "required": true,
+                "tooltip": "Indicate your marital status (single, married, divorced, separated or widowed).",
+                "ui": {
+                  "options": [
+                    "",
+                    "Single",
+                    "Married",
+                    "Divorced",
+                    "Widowed",
+                    "Separated"
+                  ]
+                }
+              }
+            ]
+          },
+          {
+            "id": "contact_info",
+            "title": "Contact Information",
+            "fields": [
+              {
+                "id": "telephone_home",
+                "label": "Home Phone",
+                "type": "tel",
+                "required": false,
+                "constraints": {
+                  "pattern": "^\\\\(?[0-9]{3}\\\\)?[-. ]?[0-9]{3}[-. ]?[0-9]{4}$"
+                },
+                "ui": {
+                  "placeholder": "(123) 456-7890"
+                }
+              },
+              {
+                "id": "telephone_work",
+                "label": "Work Phone",
+                "type": "tel",
+                "required": false,
+                "constraints": {
+                  "pattern": "^\\\\(?[0-9]{3}\\\\)?[-. ]?[0-9]{3}[-. ]?[0-9]{4}$"
+                },
+                "ui": {
+                  "placeholder": "(123) 456-7890"
+                }
+              },
+              {
+                "id": "telephone_mobile_or_other",
+                "label": "Mobile or Other Phone",
+                "type": "tel",
+                "required": false,
+                "tooltip": "To edit Telephone (Cell or Other) click on NYC ModelCity in the top-left corner then click on Account Settings and then click on Contact.",
+                "constraints": {
+                  "pattern": "^\\\\(?[0-9]{3}\\\\)?[-. ]?[0-9]{3}[-. ]?[0-9]{4}$"
+                },
+                "ui": {
+                  "placeholder": "(123) 456-7890"
+                }
+              },
+              {
+                "id": "email",
+                "label": "Email",
+                "type": "email",
+                "required": true,
+                "tooltip": "To edit email, go to NYC ID Profile tab by clicking your name at the top right corner"
+              }
+            ]
+          },
+          {
+            "id": "address_info",
+            "title": "Address",
+            "tooltip": "To edit home address click on NYC ModelCity in the top-left corner then click on Account Settings.",
+            "ui": {
+              "autocomplete": "street",
+              "placeholder": "Start typing your street address",
+              "overrideComponent": "AddressAutocomplete"
+            },
+            "metadata": {
+              "integration": {
+                "provider": "Google",
+                "feature": "AddressAutocomplete"
+              },
+              "autofillTargets": [
+                {
+                  "fieldId": "city",
+                  "source": "locality",
+                  "fallbackSources": [
+                    "postal_town",
+                    "sublocality_level_1",
+                    "administrative_area_level_2"
+                  ]
+                },
+                {
+                  "fieldId": "borough",
+                  "source": "sublocality_level_1",
+                  "fallbackSources": [
+                    "administrative_area_level_2"
+                  ],
+                  "mapping": "boroughMap"
+                },
+                { "fieldId": "state", "source": "administrative_area_level_1" },
+                { "fieldId": "zip_code", "source": "postal_code" },
+                { "fieldId": "latitude", "source": "location.latitude" },
+                { "fieldId": "longitude", "source": "location.longitude" }
+              ]
+            },
+            "fields": [
+              {
+                "id": "street",
+                "label": "Street Address",
+                "type": "text",
+                "required": true,
+                "tooltip": "To edit home address click on NYC ModelCity in the top-left corner then click on Account Settings."
+              },
+              {
+                "id": "apt",
+                "label": "Apt #",
+                "type": "text",
+                "required": false
+              },
+              {
+                "id": "city",
+                "label": "City",
+                "type": "text",
+                "required": true
+              },
+              {
+                "id": "borough",
+                "label": "Borough",
+                "type": "select",
+                "required": true,
+                "ui": {
+                  "options": [
+                    "",
+                    "Bronx",
+                    "Brooklyn",
+                    "Manhattan",
+                    "Queens",
+                    "Staten Island"
+                  ]
+                }
+              },
+              {
+                "id": "state",
+                "label": "State",
+                "type": "text",
+                "required": true
+              },
+              {
+                "id": "zip_code",
+                "label": "Zip Code",
+                "type": "text",
+                "required": true
+              },
+              {
+                "id": "latitude",
+                "label": "Latitude",
+                "type": "number",
+                "required": false
+              },
+              {
+                "id": "longitude",
+                "label": "Longitude",
+                "type": "number",
+                "required": false
+              },
+              {
+                "id": "is_temporary_address",
+                "label": "Is Temporary Address",
+                "type": "radio",
+                "required": true,
+                "tooltip": "Check YES if you are currently living in a homeless shelter, doubled-up with another family, in a hotel/motel, in a car/ bus/ train, in a park/campsite, or other temporary accomodation.",
+                "ui": {
+                  "options": [
+                    "Yes",
+                    "No"
+                  ]
+                }
+              },
+              {
+                "id": "currently_living_in",
+                "label": "Currently Living In",
+                "type": "select",
+                "required": false,
+                "requiredCondition": {
+                  "field": "is_temporary_address",
+                  "operator": "equals",
+                  "value": "Yes"
+                },
+                "ui": {
+                  "options": [
+                    "",
+                    "Homeless Shelter",
+                    "Doubled-up with another Family",
+                    "Hotel/Motel",
+                    "Car, Bus, Train",
+                    "Park",
+                    "Campsite",
+                    "Other"
+                  ]
+                }
+              }
+            ]
+          },
+          {
+            "id": "demographics",
+            "title": "Demographics",
+            "fields": [
+              {
+                "id": "ethnicity",
+                "label": "Ethnicity",
+                "type": "select",
+                "required": false,
+                "ui": {
+                  "options": [
+                    "",
+                    "Hispanic",
+                    "Latino",
+                    "No",
+                    "Prefer not to answer"
+                  ]
+                }
+              },
+              {
+                "id": "race",
+                "label": "Race",
+                "type": "checkbox",
+                "required": false,
+                "tooltip": "You may choose multiple race categories. Providing race information is voluntary and will not affect your eligibility for Child Care Assistance or the amount of assistance that you will be given by this agency.",
+                "ui": {
+                  "options": [
+                    {
+                      "value": "AI",
+                      "label": "American Indian or Alaska Native"
+                    },
+                    {
+                      "value": "AS",
+                      "label": "Asian"
+                    },
+                    {
+                      "value": "BL",
+                      "label": "Black or African American"
+                    },
+                    {
+                      "value": "HP",
+                      "label": "Native Hawaiian or Pacific Islander"
+                    },
+                    {
+                      "value": "WH",
+                      "label": "White"
+                    }
+                  ]
+                },
+                "metadata": {
+                  "multiple": true
+                }
+              },
+              {
+                "id": "ssn",
+                "label": "Social Security Number",
+                "type": "text",
+                "tooltip": "To edit social security number click on NYC ModelCity in the top-left corner then click on Account Settings.",
+                "required": false,
+                "constraints": {
+                  "pattern": "^\\\\d{3}-\\\\d{2}-\\\\d{4}$"
+                },
+                "ui": {
+                  "placeholder": "123-45-6789"
+                }
+              }
+            ]
+          },
+          {
+            "id": "language_info",
+            "title": "Language Preferences",
+            "fields": [
+              {
+                "id": "primary_language",
+                "label": "Primary Language",
+                "type": "radio",
+                "required": true,
+                "tooltip": "Select the language that is spoken most often in your household. If “other”, provide the name of the language.",
+                "ui": {
+                  "options": [
+                    "English",
+                    "Spanish",
+                    "Other"
+                  ]
+                }
+              },
+              {
+                "id": "preferred_language",
+                "label": "Preferred Language",
+                "type": "radio",
+                "required": true,
+                "tooltip": "Select the language you prefer to communicate in. If “other”, provide the name of the language.",
+                "ui": {
+                  "options": [
+                    "English",
+                    "Spanish",
+                    "Other"
+                  ]
+                }
+              },
+              {
+                "id": "other_primary_language",
+                "label": "Other Primary Language",
+                "type": "text",
+                "required": false,
+                "requiredCondition": {
+                  "field": "primary_language",
+                  "operator": "equals",
+                  "value": "Other"
+                }
+              },
+              {
+                "id": "other_preferred_language",
+                "label": "Other Preferred Language",
+                "type": "text",
+                "required": false,
+                "requiredCondition": {
+                  "field": "preferred_language",
+                  "operator": "equals",
+                  "value": "Other"
+                }
+              }
+            ]
+          },
+          {
+            "id": "cash_assistance",
+            "title": "Cash Assistance",
+            "fields": [
+              {
+                "id": "has_cash_assistance",
+                "label": "Do you receive Cash Assistance?",
+                "type": "radio",
+                "required": false,
+                "ui": {
+                  "options": [
+                    "Yes",
+                    "No"
+                  ]
+                }
+              },
+              {
+                "id": "ca_number",
+                "label": "Cash Assistance Number",
+                "type": "text",
+                "required": false,
+                "requiredCondition": {
+                  "condition": {
+                    "field": "has_cash_assistance",
+                    "operator": "equals",
+                    "value": "Yes"
+                  }
+                }
+              }
+            ]
+          }
+        ]
+      },
+      {
+        "id": "children_needing_care",
+        "title": "Children Needing Care",
+        "sections": [
+          {
+            "id": "child_details",
+            "title": "Child Details",
+            "required": true,
+            "fields": [
+              {
+                "id": "children",
+                "label": "Children Needing Care",
+                "type": "group",
+                "metadata": {
+                  "multiple": true,
+                  "tableColumns": [
+                  "first_name",
+                  "last_name",
+                  "date_of_birth",
+                  "relationship_to_applicant"
+                  ]
+                },
+                "fields": [
+                  {
+                    "id": "first_name",
+                    "label": "First Name",
+                    "type": "text",
+                    "required": true,
+                    "tooltip": "Provide the first name, last name, and middle initial of each child you are applying for child care assistance for."
+                  },
+                  {
+                    "id": "last_name",
+                    "label": "Last Name",
+                    "type": "text",
+                    "required": true
+                  },
+                  {
+                    "id": "mi",
+                    "label": "Middle Initial",
+                    "type": "text",
+                    "required": false
+                  },
+                  {
+                    "id": "relationship_to_applicant",
+                    "label": "Relationship to Applicant",
+                    "type": "select",
+                    "required": true,
+                    "ui": {
+                      "options": [
+                        "",
+                        "Child",
+                        "Grandchild",
+                        "Foster Child",
+                        "Other"
+                      ]
+                    }
+                  },
+                  {
+                    "id": "date_of_birth",
+                    "label": "Date of Birth",
+                    "type": "date",
+                    "required": true,
+                    "tooltip": "Provide the date of birth."
+                  },
+                  {
+                    "id": "sex",
+                    "label": "Sex",
+                    "type": "radio",
+                    "required": true,
+                    "tooltip": "Select to indicate the sex.",
+                    "ui": {
+                      "options": [
+                        "Male",
+                        "Female"
+                      ]
+                    }
+                  },
+                  {
+                    "id": "ethnicity",
+                    "label": "Ethnicity Hispanic or Latino",
+                    "type": "select",
+                    "required": false,
+                    "tooltip": "Check “YES” or “NO” to indicate if each child in need of child care is Hispanic or Latino or not. Providing ethnicity information is voluntary and will not affect your eligibility for child care assistance or the amount of assistance that you will be given by this agency.",
+                    "ui": {
+                      "options": [
+                        "",
+                        "Yes",
+                        "No",
+                        "Prefer not to answer"
+                      ]
+                    }
+                  },
+                  {
+                    "id": "race",
+                    "label": "Race",
+                    "type": "checkbox",
+                    "required": false,
+                    "tooltip": "You may choose multiple race categories for a single child. Providing race information is voluntary and will not affect your eligibility for Child Care Assistance or the amount of assistance that you will be given by this agency.",
+                    "ui": {
+                      "options": [
+                        {
+                          "value": "AI",
+                          "label": "American Indian or Alaska Native"
+                        },
+                        {
+                          "value": "AS",
+                          "label": "Asian"
+                        },
+                        {
+                          "value": "BL",
+                          "label": "Black or African American"
+                        },
+                        {
+                          "value": "HP",
+                          "label": "Native Hawaiian or Pacific Islander"
+                        },
+                        {
+                          "value": "WH",
+                          "label": "White"
+                        }
+                      ]
+                    },
+                    "metadata": {
+                      "multiple": true
+                    }
+                  },
+                  {
+                    "id": "ssn",
+                    "label": "Social Security Number",
+                    "type": "text",
+                    "required": false,
+                    "tooltip": "Provide each child’s Social Security Number (SSN). You are not required to provide SSNs. They may be used by federal, state, and local agencies to prevent duplication of services and fraud, and for Federal Reporting.",
+                    "constraints": {
+                      "pattern": "^\\\\d{3}-\\\\d{2}-\\\\d{4}$"
+                    },
+                    "ui": {
+                      "placeholder": "123-45-6789"
+                    }
+                  },
+                  {
+                    "id": "do_both_parents_reside_in_home",
+                    "label": "Do both parents reside in the home?",
+                    "type": "radio",
+                    "required": true,
+                    "tooltip": "Check “YES” or “NO” to indicate whether both of the child’s parents live in the home.",
+                    "ui": {
+                      "options": [
+                        "Yes",
+                        "No"
+                      ]
+                    }
+                  },
+                  {
+                    "id": "has_disability",
+                    "label": "Does the child have a disability?",
+                    "type": "radio",
+                    "required": true,
+                    "tooltip": "Check “YES” or “NO” to indicate whether the child needing child care has a disability.",
+                    "ui": {
+                      "options": [
+                        "Yes",
+                        "No"
+                      ]
+                    }
+                  },
+                  {
+                    "id": "is_immigration_status_satisfactory",
+                    "label": "Is child U.S. Citizen, U.S. National, or person with satisfactory immigration status?",
+                    "type": "radio",
+                    "required": true,
+                    "tooltip": "You will only be asked about the immigration status of the children in need of care. Other members of the family will not need to state or prove their immigration status. Your child will be eligible for care if they are a U.S. citizen, a legal permanent resident (green card holder), a refugee, or an asylee; have a T-visa; or hold another qualified immigration status. Please select “Yes” if your child holds one of these statuses.",
+                    "ui": {
+                      "options": [
+                        "Yes",
+                        "No"
+                      ]
+                    }
+                  }
+                ]
+              }
+            ]
+          }
+        ]
+      },
+      {
+        "id": "family_members",
+        "title": "Family Members",
+        "sections": [
+          {
+            "id": "household_members_info",
+            "title": "Household Members Information",
+            "type": "info",
+            "ui": {
+              "markdown": true,
+              "collapsible": false,
+              "defaultCollapsed": false
+            },
+            "content": "**List the household members who do _not_ need child care.**\\n\\nIf applicable, list:\\n\\n- Your **spouse**, your child’s **second parent**, **caretaker**, or **step-parent**\\n- Any other **adult with whom you share a child**, if they live in your home\\n\\nThen, if applicable, list:\\n\\n- Any **siblings under the age of 18** who live in your home\\n\\n> **Only list other household members** — such as **aunts, uncles, cousins, grandparents, or friends** — _if they have financial responsibility_ for the child.\\n\\nA household member with financial responsibility, other than a parent or step-parent, is one who has a **letter or order of guardianship**.\\n\\n**Otherwise, do not include them.**"
+          },
+          {
+            "id": "family_member_details",
+            "title": "Household Member Details",
+            "description": "Include household members who do not need child care assistance (e.g., spouse, partner, other children).",
+            "fields": [
+              {
+                "id": "familymember",
+                "label": "Family Members",
+                "type": "group",
+                "requiredCondition": {
+                  "repeatingGroup": "children",
+                  "operator": "ANY",
+                  "condition": { "field": "do_both_parents_reside_in_home", "operator": "equals", "value": "Yes" }
+                },  
+                "metadata": {
+                  "multiple": true,
+                  "tableColumns": [
+                    "first_name",
+                    "last_name",
+                    "relationship_to_applicant",
+                    "date_of_birth"
+                  ]
+                },
+                "fields": [
+                  {
+                    "id": "first_name",
+                    "label": "First Name",
+                    "type": "text",
+                    "required": true,
+                    "tooltip": "Provide last and first name, and middle initial if applicable."
+                  },
+                  {
+                    "id": "last_name",
+                    "label": "Last Name",
+                    "type": "text",
+                    "required": true
+                  },
+                  {
+                    "id": "mi",
+                    "label": "Middle Initial",
+                    "type": "text",
+                    "required": false
+                  },
+                  {
+                    "id": "relationship_to_applicant",
+                    "label": "Relationship to Applicant",
+                    "type": "select",
+                    "required": true,
+                    "tooltip": "Provide each person’s relationship to you (e.g. spouse, partner, child, foster parent, other).",
+                    "ui": {
+                      "options": [
+                        "",
+                        "Spouse",
+                        "Partner",
+                        "Foster Parent",
+                        "Child",
+                        "Other"
+                      ]
+                    }
+                  },
+                  {
+                    "id": "date_of_birth",
+                    "label": "Date of Birth",
+                    "type": "date",
+                    "required": true,
+                    "tooltip": "Provide the family member's date of birth."
+                  },
+                  {
+                    "id": "sex",
+                    "label": "Sex",
+                    "type": "radio",
+                    "required": true,
+                    "tooltip": "Indicate the sex for each family member listed.",
+                    "ui": {
+                      "options": [
+                        "Male",
+                        "Female"
+                      ]
+                    }
+                  },
+                  {
+                    "id": "ethnicity",
+                    "label": "Ethnicity Hispanic or Latino",
+                    "type": "select",
+                    "required": false,
+                    "tooltip": "Check “YES” or “NO” to indicate if each member in the household is Hispanic or Latino or not. Providing ethnicity information is voluntary and will not affect your eligibility for Child Care Assistance or the amount of assistance that you will be given by this agency.",
+                    "ui": {
+                      "options": [
+                        "",
+                        "Yes",
+                        "No",
+                        "Prefer not to answer"
+                      ]
+                    }
+                  },
+                  {
+                    "id": "race",
+                    "label": "Race",
+                    "type": "checkbox",
+                    "required": false,
+                    "tooltip": "You may choose multiple race categories for a single person. Providing race information is voluntary and will not affect your eligibility for Child Care Assistance or the amount of assistance that you will be given by this agency.",
+                    "ui": {
+                      "options": [
+                        {
+                          "value": "AI",
+                          "label": "American Indian or Alaska Native"
+                        },
+                        {
+                          "value": "AS",
+                          "label": "Asian"
+                        },
+                        {
+                          "value": "BL",
+                          "label": "Black or African American"
+                        },
+                        {
+                          "value": "HP",
+                          "label": "Native Hawaiian or Pacific Islander"
+                        },
+                        {
+                          "value": "WH",
+                          "label": "White"
+                        }
+                      ]
+                    },
+                    "metadata": {
+                      "multiple": true
+                    }
+                  },
+                  {
+                    "id": "ssn",
+                    "label": "Social Security Number",
+                    "type": "text",
+                    "required": false,
+                    "tooltip": "Fill in the Social Security Number (SSN) for your family members. SSN is optional. SSN may be used by federal, state, and local agencies to prevent duplication of services and fraud, and for Federal Reporting.",
+                    "constraints": {
+                      "pattern": "^\\\\d{3}-\\\\d{2}-\\\\d{4}$"
+                    },
+                    "ui": {
+                      "placeholder": "123-45-6789"
+                    }
+                  }
+                ]
+              }
+            ]
+          }
+        ]
+      },
+      {
+        "id": "child_family_needs",
+        "title": "Child / Family Needs",
+        "sections": [
+          {
+            "id": "assistance_reason",
+            "title": "Reason for Child Care Assistance",
+            "description": "Select one or two reasons you are requesting Child Care Assistance.",
+            "tooltip": "Select one reason. In a two-parent household, parents/caretakers can have the same or different reasons for needing child care. Both parents/caretakers will be required to submit documentation in support of their own reason. If you are living in temporary housing, please select Homelessness even if you have another reason that applies to you.",
+            "fields": [
+              {
+                "id": "assistance_reason",
+                "label": "Reason(s) for Assistance",
+                "type": "select",
+                "required": true,
+                "ui": {
+                  "options": [
+                    "",
+                    "Employment",
+                    "Looking for Work",
+                    "Vocational Training/Educational Activities",
+                    "Receiving Domestic Violence Services",
+                    "Homelessness"
+                  ]
+                },
+                "constraints": {
+                  "minSelections": 1,
+                  "maxSelections": 2
+                },
+                "metadata": {
+                  "multiple": true
+                }
+              }
+            ]
+          },
+          {
+            "id": "military_status",
+            "title": "Military and Parental Availability",
+            "description": "Provide information about parental military status and availability for child care.",
+            "fields": [
+              {
+                "id": "is_parent_currently_active_in_military",
+                "label": "Is a Parent Currently Active Full-Time in the U.S. Military?",
+                "tooltip": "Check “YES” or “NO” to indicate whether a parent is currently active full-time in the U.S. Military.",
+                "type": "radio",
+                "required": true,
+                "ui": {
+                  "options": [
+                    "Yes",
+                    "No"
+                  ]
+                }
+              },
+              {
+                "id": "is_parent_mem_of_guard_or_mru",
+                "label": "Is a Parent a Member of National Guard or Military Reserve Unit?",
+                "tooltip": "Check “YES” or “NO” to indicate whether a parent is currently a member of a National Guard or Military Reserve Unit.",
+                "type": "radio",
+                "required": true,
+                "ui": {
+                  "options": [
+                    "Yes",
+                    "No"
+                  ]
+                }
+              },
+              {
+                "id": "is_non_custodial_parent_available",
+                "label": "Is the Non-Custodial Parent Available to Provide Care?",
+                "tooltip": "Check “YES” or “NO” to indicate whether there is a non-custodial parent available to provide child care.",
+                "type": "radio",
+                "required": true,
+                "ui": {
+                  "options": [
+                    "Yes",
+                    "No"
+                  ]
+                }
+              }
+            ]
+          },
+          {
+            "id": "duplicate_application",
+            "title": "Other Applications",
+            "description": "Indicate if you are also applying for or receiving child care from other agencies.",
+            "tooltip": "Indicate whether you are currently receiving or have applied for child care assistance with one of the agencies or organizations listed below. Note: If you are receiving Cash Assistance and are interested in child care assistance, you must apply through the Human Resources Administration. Reach out to your Benefits Access Center or visit the Human Resources Administration webpage.",
+            "fields": [
+              {
+                "id": "duplicate_app",
+                "label": "Are You Receiving or Applying for Child Care Through Another Agency?",
+                "type": "select",
+                "required": false,
+                "ui": {
+                  "options": [
+                    "",
+                    "Not Applicable",
+                    "Department of Education (DOE)",
+                    "Human Resources Administration (HRA)",
+                    "Department of Youth and Community Development (DYCD)",
+                    "Department of Homeless Services (DHS)",
+                    "Consortium for Worker Education (CWE)",
+                    "Administration for Children's Services (ACS)"
+                  ]
+                }
+              }
+            ]
+          }
+        ]
+      },
+      {
+        "id": "employment",
+        "title": "Employment",
+        "sections": [
+          {
+            "id": "employment_precheck",
+            "title": "Tell us about your employment",
+            "description": "Tell us about your employment",
+            "fields": [
+              {
+                "id": "applicant_emp_income_indicator",
+                "label": "Does applicant earn any income/ wages from employment? ",
+                "type": "radio",
+                "required": false,
+                "ui": {
+                  "options": [
+                    "Yes",
+                    "No"
+                  ]
+                }
+              },
+              {
+                "id": "coparent_emp_income_indicator",
+                "label": "Does Coparent/2nd Guardian earn any income/ wages from employment? ",
+                "type": "radio",
+                "required": false,
+                "ui": {
+                  "options": [
+                    "Yes",
+                    "No"
+                  ]
+                }
+              }
+            ]
+          },
+          {
+            "id": "applicant_jobs",
+            "title": "Applicant Employment Information",
+            "description": "Enter details for up to two jobs held by the applicant.",
+            "visibilityCondition": {
+              "field": "applicant_emp_income_indicator",
+              "operator": "equals",
+              "value": "Yes"
+            },
+            "fields": [
+              {
+                "id": "applicant_1st_job_start_date",
+                "label": "1st Job - Start Date",
+                "type": "date",
+                "required": false,
+                "ui": {
+                  "group": "1st Job"
+                }
+              },
+              {
+                "id": "applicant_1st_job_rotating_shift",
+                "label": "1st Job - Has Rotating Shift?",
+                "type": "radio",
+                "required": false,
+                "ui": {
+                  "options": [
+                    "Yes",
+                    "No"
+                  ],
+                  "group": "1st Job"
+                }
+              },
+              {
+                "id": "applicant_1st_job_requires_overtime",
+                "label": "1st Job - Requires Overtime?",
+                "type": "radio",
+                "required": false,
+                "ui": {
+                  "options": [
+                    "Yes",
+                    "No"
+                  ],
+                  "group": "1st Job"
+                }
+              },
+              {
+                "id": "applicant_1st_job_employer_name",
+                "label": "1st Job - Employer Name",
+                "type": "text",
+                "required": false,
+                "ui": {
+                  "group": "1st Job"
+                }
+              },
+              {
+                "id": "applicant_1st_job_employer_phone",
+                "label": "1st Job - Employer Phone",
+                "type": "tel",
+                "required": false,
+                "ui": {
+                  "group": "1st Job"
+                }
+              },
+              {
+                "id": "applicant_1st_job_employer_street",
+                "label": "1st Job - Employer Street Address",
+                "type": "text",
+                "required": false,
+                "ui": {
+                  "group": "1st Job"
+                }
+              },
+              {
+                "id": "applicant_1st_job_employer_city",
+                "label": "1st Job - Employer City",
+                "type": "text",
+                "required": false,
+                "ui": {
+                  "group": "1st Job"
+                }
+              },
+              {
+                "id": "applicant_1st_job_employer_state",
+                "label": "1st Job - Employer State",
+                "type": "text",
+                "required": false,
+                "ui": {
+                  "group": "1st Job"
+                }
+              },
+              {
+                "id": "applicant_1st_job_employer_zipcode",
+                "label": "1st Job - Employer ZIP Code",
+                "type": "text",
+                "required": false,
+                "ui": {
+                  "group": "1st Job"
+                }
+              },
+              {
+                "id": "applicant_2nd_job_start_date",
+                "label": "2nd Job - Start Date",
+                "type": "date",
+                "required": false,
+                "ui": {
+                  "group": "2nd Job"
+                }
+              },
+              {
+                "id": "applicant_2nd_job_rotating_shift",
+                "label": "2nd Job - Has Rotating Shift?",
+                "type": "radio",
+                "required": false,
+                "ui": {
+                  "options": [
+                    "Yes",
+                    "No"
+                  ],
+                  "group": "2nd Job"
+                }
+              },
+              {
+                "id": "applicant_2nd_job_requires_overtime",
+                "label": "2nd Job - Requires Overtime?",
+                "type": "radio",
+                "required": false,
+                "ui": {
+                  "options": [
+                    "Yes",
+                    "No"
+                  ],
+                  "group": "2nd Job"
+                }
+              },
+              {
+                "id": "applicant_2nd_job_employer_name",
+                "label": "2nd Job - Employer Name",
+                "type": "text",
+                "required": false,
+                "ui": {
+                  "group": "2nd Job"
+                }
+              },
+              {
+                "id": "applicant_2nd_job_employer_phone",
+                "label": "2nd Job - Employer Phone",
+                "type": "tel",
+                "required": false,
+                "ui": {
+                  "group": "2nd Job"
+                }
+              },
+              {
+                "id": "applicant_2nd_job_employer_street",
+                "label": "2nd Job - Employer Street Address",
+                "type": "text",
+                "required": false,
+                "ui": {
+                  "group": "2nd Job"
+                }
+              },
+              {
+                "id": "applicant_2nd_job_employer_city",
+                "label": "2nd Job - Employer City",
+                "type": "text",
+                "required": false,
+                "ui": {
+                  "group": "2nd Job"
+                }
+              },
+              {
+                "id": "applicant_2nd_job_employer_state",
+                "label": "2nd Job - Employer State",
+                "type": "text",
+                "required": false,
+                "ui": {
+                  "group": "2nd Job"
+                }
+              },
+              {
+                "id": "applicant_2nd_job_employer_zipcode",
+                "label": "2nd Job - Employer ZIP Code",
+                "type": "text",
+                "required": false,
+                "ui": {
+                  "group": "2nd Job"
+                }
+              }
+            ]
+          },
+          {
+            "id": "second_parent_jobs",
+            "title": "Second Parent Employment Information",
+            "description": "Enter details for up to two jobs held by the second parent (if applicable).",
+            "visibilityCondition": {
+              "field": "coparent_emp_income_indicator",
+              "operator": "equals",
+              "value": "Yes"
+            },
+            "fields": [
+              {
+                "id": "second_parent_1st_job_start_date",
+                "label": "1st Job - Start Date",
+                "type": "date",
+                "required": false
+              },
+              {
+                "id": "second_parent_1st_job_rotating_shift",
+                "label": "1st Job - Has Rotating Shift?",
+                "type": "radio",
+                "required": false,
+                "ui": {
+                  "options": [
+                    "Yes",
+                    "No"
+                  ]
+                }
+              },
+              {
+                "id": "second_parent_1st_job_requires_overtime",
+                "label": "1st Job - Requires Overtime?",
+                "type": "radio",
+                "required": false,
+                "ui": {
+                  "options": [
+                    "Yes",
+                    "No"
+                  ]
+                }
+              },
+              {
+                "id": "second_parent_1st_job_employer_name",
+                "label": "1st Job - Employer Name",
+                "type": "text",
+                "required": false
+              },
+              {
+                "id": "second_parent_1st_job_employer_phone",
+                "label": "1st Job - Employer Phone",
+                "type": "tel",
+                "required": false
+              },
+              {
+                "id": "second_parent_1st_job_employer_street",
+                "label": "1st Job - Employer Street Address",
+                "type": "text",
+                "required": false
+              },
+              {
+                "id": "second_parent_1st_job_employer_city",
+                "label": "1st Job - Employer City",
+                "type": "text",
+                "required": false
+              },
+              {
+                "id": "second_parent_1st_job_employer_state",
+                "label": "1st Job - Employer State",
+                "type": "text",
+                "required": false
+              },
+              {
+                "id": "second_parent_1st_job_employer_zipcode",
+                "label": "1st Job - Employer ZIP Code",
+                "type": "text",
+                "required": false
+              },
+              {
+                "id": "second_parent_2nd_job_start_date",
+                "label": "2nd Job - Start Date",
+                "type": "date",
+                "required": false
+              },
+              {
+                "id": "second_parent_2nd_job_rotating_shift",
+                "label": "2nd Job - Has Rotating Shift?",
+                "type": "radio",
+                "required": false,
+                "ui": {
+                  "options": [
+                    "Yes",
+                    "No"
+                  ]
+                }
+              },
+              {
+                "id": "second_parent_2nd_job_requires_overtime",
+                "label": "2nd Job - Requires Overtime?",
+                "type": "radio",
+                "required": false,
+                "ui": {
+                  "options": [
+                    "Yes",
+                    "No"
+                  ]
+                }
+              },
+              {
+                "id": "second_parent_2nd_job_employer_name",
+                "label": "2nd Job - Employer Name",
+                "type": "text",
+                "required": false
+              },
+              {
+                "id": "second_parent_2nd_job_employer_phone",
+                "label": "2nd Job - Employer Phone",
+                "type": "tel",
+                "required": false
+              },
+              {
+                "id": "second_parent_2nd_job_employer_street",
+                "label": "2nd Job - Employer Street Address",
+                "type": "text",
+                "required": false
+              },
+              {
+                "id": "second_parent_2nd_job_employer_city",
+                "label": "2nd Job - Employer City",
+                "type": "text",
+                "required": false
+              },
+              {
+                "id": "second_parent_2nd_job_employer_state",
+                "label": "2nd Job - Employer State",
+                "type": "text",
+                "required": false
+              },
+              {
+                "id": "second_parent_2nd_job_employer_zipcode",
+                "label": "2nd Job - Employer ZIP Code",
+                "type": "text",
+                "required": false
+              }
+            ]
+          }
+        ]
+      },
+      {
+        "id": "schedule",
+        "title": "Work/Activity/Travel Time Schedule",
+        "sections": [
+          {
+            "id": "schedule_section_info",
+            "title": "Schedule Information",
+            "type": "info",
+            "ui": {
+              "markdown": true,
+              "collapsible": false,
+              "defaultCollapsed": false
+            },
+            "content": "Please indicate what days and hours you will need child care for based on your reason for care.\\n\\n- **Employed**: Indicate the hours you attend work\\n- **Educational or Vocational Program**: Indicate the hours you attend school or your program\\n- **Looking for Work**: Indicate the hours you spend looking for work\\n- **Homeless**: Indicate the hours you spend looking for housing\\n- **Attending Services for Domestic Violence**: Indicate the hours you attend services.\\n- **Attending Services for Substance Abuse Treatment**: Indicate the hours you attend services."
+          },
+          {
+            "id": "first_parent_activity_schedule",
+            "title": "First Parent Activity Schedule",
+            "description": "Enter the start and end times for each day of the week for the first parent's activities.",
+            "ui": {
+              "layout": "table",
+              "columns": [
+                "Start Time",
+                "End Time"
+              ],
+              "rowCopy": {
+                "enableUserPickSource": true,
+                "rowIdentifier": "ui.rowGroup",
+                "fieldsToCopy": [
+                  1,
+                  2
+                ],
+                "targetRowValues": [
+                  "Monday",
+                  "Tuesday",
+                  "Wednesday",
+                  "Thursday",
+                  "Friday"
+                ],
+                "copyControlLabel": "Apply selected schedule to other weekdays",
+                "sourceOptions": [
+                  "Monday",
+                  "Tuesday",
+                  "Wednesday",
+                  "Thursday",
+                  "Friday",
+                  "Saturday",
+                  "Sunday"
+                ]
+              }
+            },
+            "fields": [
+              {
+                "id": "fp_monday_from",
+                "label": "Monday From",
+                "type": "time",
+                "ui": {
+                  "rowGroup": "Monday",
+                  "column": 1
+                }
+              },
+              {
+                "id": "fp_monday_to",
+                "label": "Monday To",
+                "type": "time",
+                "ui": {
+                  "rowGroup": "Monday",
+                  "column": 2
+                }
+              },
+              {
+                "id": "fp_tuesday_from",
+                "label": "Tuesday From",
+                "type": "time",
+                "ui": {
+                  "rowGroup": "Tuesday",
+                  "column": 1
+                }
+              },
+              {
+                "id": "fp_tuesday_to",
+                "label": "Tuesday To",
+                "type": "time",
+                "ui": {
+                  "rowGroup": "Tuesday",
+                  "column": 2
+                }
+              },
+              {
+                "id": "fp_wednesday_from",
+                "label": "Wednesday From",
+                "type": "time",
+                "ui": {
+                  "rowGroup": "Wednesday",
+                  "column": 1
+                }
+              },
+              {
+                "id": "fp_wednesday_to",
+                "label": "Wednesday To",
+                "type": "time",
+                "ui": {
+                  "rowGroup": "Wednesday",
+                  "column": 2
+                }
+              },
+              {
+                "id": "fp_thursday_from",
+                "label": "Thursday From",
+                "type": "time",
+                "ui": {
+                  "rowGroup": "Thursday",
+                  "column": 1
+                }
+              },
+              {
+                "id": "fp_thursday_to",
+                "label": "Thursday To",
+                "type": "time",
+                "ui": {
+                  "rowGroup": "Thursday",
+                  "column": 2
+                }
+              },
+              {
+                "id": "fp_friday_from",
+                "label": "Friday From",
+                "type": "time",
+                "ui": {
+                  "rowGroup": "Friday",
+                  "column": 1
+                }
+              },
+              {
+                "id": "fp_friday_to",
+                "label": "Friday To",
+                "type": "time",
+                "ui": {
+                  "rowGroup": "Friday",
+                  "column": 2
+                }
+              },
+              {
+                "id": "fp_saturday_from",
+                "label": "Saturday From",
+                "type": "time",
+                "ui": {
+                  "rowGroup": "Saturday",
+                  "column": 1
+                }
+              },
+              {
+                "id": "fp_saturday_to",
+                "label": "Saturday To",
+                "type": "time",
+                "ui": {
+                  "rowGroup": "Saturday",
+                  "column": 2
+                }
+              },
+              {
+                "id": "fp_sunday_from",
+                "label": "Sunday From",
+                "type": "time",
+                "ui": {
+                  "rowGroup": "Sunday",
+                  "column": 1
+                }
+              },
+              {
+                "id": "fp_sunday_to",
+                "label": "Sunday To",
+                "type": "time",
+                "ui": {
+                  "rowGroup": "Sunday",
+                  "column": 2
+                }
+              }
+            ]
+          },
+          {
+            "id": "second_parent_activity_schedule",
+            "title": "Second Parent Activity Schedule",
+            "description": "Enter the start and end times for each day of the week for the second parent's activities.",
+            "ui": {
+              "layout": "table",
+              "columns": [
+                "Start Time",
+                "End Time"
+              ],
+              "rowCopy": {
+                "enableUserPickSource": true,
+                "rowIdentifier": "ui.rowGroup",
+                "fieldsToCopy": [
+                  1,
+                  2
+                ],
+                "targetRowValues": [
+                  "Monday",
+                  "Tuesday",
+                  "Wednesday",
+                  "Thursday",
+                  "Friday"
+                ],
+                "copyControlLabel": "Apply selected schedule to other weekdays",
+                "sourceOptions": [
+                  "Monday",
+                  "Tuesday",
+                  "Wednesday",
+                  "Thursday",
+                  "Friday",
+                  "Saturday",
+                  "Sunday"
+                ]
+              }
+            },
+            "fields": [
+              {
+                "id": "sp_monday_from",
+                "label": "Monday From",
+                "type": "time",
+                "ui": {
+                  "rowGroup": "Monday",
+                  "column": 1
+                }
+              },
+              {
+                "id": "sp_monday_to",
+                "label": "Monday To",
+                "type": "time",
+                "ui": {
+                  "rowGroup": "Monday",
+                  "column": 2
+                }
+              },
+              {
+                "id": "sp_tuesday_from",
+                "label": "Tuesday From",
+                "type": "time",
+                "ui": {
+                  "rowGroup": "Tuesday",
+                  "column": 1
+                }
+              },
+              {
+                "id": "sp_tuesday_to",
+                "label": "Tuesday To",
+                "type": "time",
+                "ui": {
+                  "rowGroup": "Tuesday",
+                  "column": 2
+                }
+              },
+              {
+                "id": "sp_wednesday_from",
+                "label": "Wednesday From",
+                "type": "time",
+                "ui": {
+                  "rowGroup": "Wednesday",
+                  "column": 1
+                }
+              },
+              {
+                "id": "sp_wednesday_to",
+                "label": "Wednesday To",
+                "type": "time",
+                "ui": {
+                  "rowGroup": "Wednesday",
+                  "column": 2
+                }
+              },
+              {
+                "id": "sp_thursday_from",
+                "label": "Thursday From",
+                "type": "time",
+                "ui": {
+                  "rowGroup": "Thursday",
+                  "column": 1
+                }
+              },
+              {
+                "id": "sp_thursday_to",
+                "label": "Thursday To",
+                "type": "time",
+                "ui": {
+                  "rowGroup": "Thursday",
+                  "column": 2
+                }
+              },
+              {
+                "id": "sp_friday_from",
+                "label": "Friday From",
+                "type": "time",
+                "ui": {
+                  "rowGroup": "Friday",
+                  "column": 1
+                }
+              },
+              {
+                "id": "sp_friday_to",
+                "label": "Friday To",
+                "type": "time",
+                "ui": {
+                  "rowGroup": "Friday",
+                  "column": 2
+                }
+              },
+              {
+                "id": "sp_saturday_from",
+                "label": "Saturday From",
+                "type": "time",
+                "ui": {
+                  "rowGroup": "Saturday",
+                  "column": 1
+                }
+              },
+              {
+                "id": "sp_saturday_to",
+                "label": "Saturday To",
+                "type": "time",
+                "ui": {
+                  "rowGroup": "Saturday",
+                  "column": 2
+                }
+              },
+              {
+                "id": "sp_sunday_from",
+                "label": "Sunday From",
+                "type": "time",
+                "ui": {
+                  "rowGroup": "Sunday",
+                  "column": 1
+                }
+              },
+              {
+                "id": "sp_sunday_to",
+                "label": "Sunday To",
+                "type": "time",
+                "ui": {
+                  "rowGroup": "Sunday",
+                  "column": 2
+                }
+              }
+            ]
+          },
+          {
+            "id": "first_parent_travel_time",
+            "title": "First Parent Travel Time",
+            "description": "Enter the travel times and method of transport for the first parent.",
+            "fields": [
+              {
+                "id": "fp_dropoff_travel_time",
+                "label": "Drop-off Travel Time",
+                "type": "select",
+                "tooltip": "Select your typical travel time from work/activity to your child care provider",
+                "ui": {
+                  "options": [
+                    "",
+                    "15 min",
+                    "30 min",
+                    "45 min",
+                    "1 hour",
+                    "More than 1 hour"
+                  ]
+                }
+              },
+              {
+                "id": "fp_dropoff_time_gt_1hr",
+                "label": "Drop-off Time (if > 1 hour)",
+                "type": "text",
+                "requiredCondition": {
+                  "field": "fp_dropoff_travel_time",
+                  "operator": "equals",
+                  "value": "More than 1 hour"
+                }
+              },
+              {
+                "id": "fp_pickup_travel_time",
+                "label": "Pick-up Travel Time",
+                "type": "select",
+                "tooltip": "Select your typical travel time from work/activity to your child care provider",
+                "ui": {
+                  "options": [
+                    "",
+                    "15 min",
+                    "30 min",
+                    "45 min",
+                    "1 hour",
+                    "More than 1 hour"
+                  ]
+                }
+              },
+              {
+                "id": "fp_pickup_time_gt_1hr",
+                "label": "Pick-up Time (if > 1 hour)",
+                "type": "text",
+                "requiredCondition": {
+                  "field": "fp_pickup_travel_time",
+                  "operator": "equals",
+                  "value": "More than 1 hour"
+                }
+              },
+              {
+                "id": "fp_public_transport_dropoff",
+                "label": "Public Transport for Drop-off?",
+                "type": "radio",
+                "tooltip": "Indicate if the applicant uses public transportation to travel to and from work/activity to provider.",
+                "ui": {
+                  "options": [
+                    "Yes",
+                    "No"
+                  ]
+                }
+              },
+              {
+                "id": "fp_public_transport_pickup",
+                "label": "Public Transport for Pick-up?",
+                "tooltip": "Indicate if the applicant uses public transportation to travel to and from work/activity to provider.",
+                "type": "radio",
+                "ui": {
+                  "options": [
+                    "Yes",
+                    "No"
+                  ]
+                }
+              }
+            ]
+          },
+          {
+            "id": "second_parent_travel_time",
+            "title": "Second Parent Travel Time",
+            "description": "Enter the travel times and method of transport for the second parent.",
+            "fields": [
+              {
+                "id": "sp_dropoff_travel_time",
+                "label": "Drop-off Travel Time",
+                "type": "select",
+                "ui": {
+                  "options": [
+                    "",
+                    "15 min",
+                    "30 min",
+                    "45 min",
+                    "1 hour",
+                    "More than 1 hour"
+                  ]
+                }
+              },
+              {
+                "id": "sp_pickup_travel_time",
+                "label": "Pick-up Travel Time",
+                "type": "select",
+                "ui": {
+                  "options": [
+                    "",
+                    "15 min",
+                    "30 min",
+                    "45 min",
+                    "1 hour",
+                    "More than 1 hour"
+                  ]
+                }
+              },
+              {
+                "id": "sp_dropoff_time_gt_1hr",
+                "label": "Drop-off Time (if > 1 hour)",
+                "type": "text",
+                "requiredCondition": {
+                  "field": "sp_dropoff_travel_time",
+                  "operator": "equals",
+                  "value": "More than 1 hour"
+                }
+              },
+              {
+                "id": "sp_pickup_time_gt_1hr",
+                "label": "Pick-up Time (if > 1 hour)",
+                "type": "text",
+                "requiredCondition": {
+                  "field": "sp_pickup_travel_time",
+                  "operator": "equals",
+                  "value": "More than 1 hour"
+                }
+              },
+              {
+                "id": "sp_public_transport_dropoff",
+                "label": "Public Transport for Drop-off?",
+                "type": "radio",
+                "ui": {
+                  "options": [
+                    "Yes",
+                    "No"
+                  ]
+                }
+              },
+              {
+                "id": "sp_public_transport_pickup",
+                "label": "Public Transport for Pick-up?",
+                "type": "radio",
+                "ui": {
+                  "options": [
+                    "Yes",
+                    "No"
+                  ]
+                }
+              }
+            ]
+          }
+        ]
+      },
+      {
+        "id": "income",
+        "title": "Income Information",
+        "sections": [
+          {
+            "id": "income_step_info",
+            "title": "Instructions",
+            "type": "info",
+            "ui": {
+              "markdown": true,
+              "collapsible": false,
+              "defaultCollapsed": false
+            },
+            "content": "Please include income/benefits information for yourself and, if applicable, your spouse, your child’s second caretaker, and/or any other adult with whom you share a child, if they live in your home.\\n\\nIndicate if you receive money from the following sources by selecting “Yes” or “No.” If you select “Yes,” you will be asked for additional information.\\n\\nIf the second caretaker in the household also receives the same income source, add a separate line for their income."
+          },
+          {
+            "id": "income_sources",
+            "title": "Income Sources",
+            "description": "Provide details about all income sources applicable to the applicant or household.",
+            "fields": [
+              {
+                "id": "income_sources",
+                "label": "List of Income Sources",
+                "type": "group",
+                "metadata": {
+                  "multiple": true,
+                  "tableColumns": [
+                    "name_ref",
+                    "how_often",
+                    "recipient",
+                    "monthly_amount"
+                  ]
+                },
+                "fields": [
+                  {
+                    "id": "name_ref",
+                    "label": "Income Source Type",
+                    "type": "select",
+                    "required": true,
+                    "ui": {
+                      "options": [
+                        "",
+                        "ApplicantWages",
+                        "SecondParentWages",
+                        "SelfEmployment",
+                        "ChildSupport",
+                        "Alimony",
+                        "Unemployment",
+                        "SocialSecurity",
+                        "Disability",
+                        "Rental",
+                        "Dividends",
+                        "Retirement",
+                        "CashAssistance",
+                        "Other"
+                      ]
+                    }
+                  },
+                  {
+                    "id": "other_source_text",
+                    "label": "Other Source (If applicable)",
+                    "type": "text",
+                    "visibilityCondition": {
+                      "field": "name_ref",
+                      "operator": "equals",
+                      "value": "Other"
+                    },
+                    "requiredCondition": {
+                      "condition": {
+                        "field": "name_ref",
+                        "operator": "equals",
+                        "value": "Other"
+                      }
+                    }
+                  },
+                  {
+                    "id": "is_source_applicable",
+                    "label": "Is this Source Applicable?",
+                    "type": "radio",
+                    "required": true,
+                    "ui": {
+                      "options": [
+                        "Yes",
+                        "No"
+                      ]
+                    }
+                  },
+                  {
+                    "id": "gross_amount",
+                    "label": "Gross Amount ($)",
+                    "type": "number",
+                    "required": true
+                  },
+                  {
+                    "id": "how_often",
+                    "label": "Frequency of Income",
+                    "type": "radio",
+                    "required": true,
+                    "ui": {
+                      "options": [
+                        "Weekly",
+                        "Bi-weekly",
+                        "Monthly",
+                        "Other"
+                      ]
+                    }
+                  },
+                  {
+                    "id": "recipient",
+                    "label": "Recipient of Income",
+                    "type": "text",
+                    "required": true
+                  },
+                  {
+                    "id": "monthly_amount",
+                    "label": "Monthly Amount ($)",
+                    "type": "number",
+                    "required": true
+                  }
+                ]
+              }
+            ]
+          },
+          {
+            "id": "total_income",
+            "title": "Total Household Income",
+            "description": "Sum of all monthly income across sources.",
+            "fields": [
+              {
+                "id": "total_income",
+                "label": "Total Monthly Income ($)",
+                "type": "number",
+                "required": true
+              }
+            ]
+          },
+          {
+            "id": "income_proof_section",
+            "title": "Income Proof",
+            "fields": [
+              {
+                "id": "income_proof",
+                "label": "Upload Income Proof",
+                "type": "file",
+                "requiredCondition": {
+                  "condition": {
+                    "field": "assistance_reason",
+                    "operator": "includes",
+                    "value": "Employment"
+                  }
+                },
+                "constraints": {
+                  "maxFileSizeMB": 5,
+                  "allowedTypes": [
+                    "application/pdf",
+                    "image/jpeg"
+                  ],
+                  "imageResolution": {
+                    "minWidth": 800,
+                    "minHeight": 600
+                  }
+                },
+                "metadata": {
+                  "proofCategory": "Income Verification",
+                  "examples": [
+                    "Pay Stub",
+                    "W-2"
+                  ],
+                  "multiple": true
+                }
+              }
+            ]
+          }
+        ]
+      },
+      {
+        "id": "provider",
+        "title": "Provider",
+        "sections": [
+          {
+            "id": "provider_step_info",
+            "title": "Instructions",
+            "type": "info",
+            "ui": {
+              "markdown": true,
+              "collapsible": false,
+              "defaultCollapsed": false
+            },
+            "content": "If you are found eligible for child care assistance, you can choose center-based or home-based care from a licensed, registered, or legally exempt provider. If you choose a provider that is not licensed or registered, the provider must be enrolled as a legally exempt provider.\\n\\nIf you know which child care providers you would like your child to attend, provide the names and addresses of your choice of providers. You can leave this section blank if you do not know (it will not impact your eligibility and you will have an opportunity to select a provider if determined eligible)."
+          },
+          {
+            "id": "provider_choices",
+            "title": "Provider Choices",
+            "description": "Specify details of the provider where you intend to enroll the child(ren).",
+            "fields": [
+              {
+                "id": "provider_choices",
+                "label": "List of Providers",
+                "type": "group",
+                "metadata": {
+                  "multiple": true,
+                  "tableColumns": [
+                    "provider_name",
+                    "program_number",
+                    "provider_zip_code"
+                  ]
+                },
+                "fields": [
+                  {
+                    "id": "provider_name",
+                    "label": "Provider Name",
+                    "type": "text",
+                    "required": true
+                  },
+                  {
+                    "id": "program_number",
+                    "label": "Program Number (If Applicable)",
+                    "type": "text",
+                    "required": false
+                  },
+                  {
+                    "id": "provider_street",
+                    "label": "Street Address",
+                    "type": "text",
+                    "required": true
+                  },
+                  {
+                    "id": "provider_city",
+                    "label": "City",
+                    "type": "text",
+                    "required": true
+                  },
+                  {
+                    "id": "provider_state",
+                    "label": "State",
+                    "type": "text",
+                    "required": true
+                  },
+                  {
+                    "id": "provider_zip_code",
+                    "label": "Zip Code",
+                    "type": "text",
+                    "required": true
+                  }
+                ]
+              }
+            ]
+          }
+        ]
+      },
+      {
+        "id": "document_upload_step",
+        "title": "Document Upload",
+        "description": "The Application for Child Care Assistance (CFWB-012) must include supporting documentation. Check to ensure that documentation is provided for each requirement of subsidy eligibility.",
+        "sections": [
+          {
+            "id": "nyc_residency",
+            "title": "New York City Residency",
+            "description": "These documents confirm that you live in New York City. Please upload one of the following documents.",
+            "fields": [
+              {
+                "id": "nyc_residency_type",
+                "label": "Select one of the following:",
+                "type": "radio",
+                "required": true,
+                "ui": {
+                  "options": [
+                    "IDNYC",
+                    "Utility Bill",
+                    "Section 8 Award Letter",
+                    "Driver’s License",
+                    "Rent Receipt",
+                    "NYCHA Certificate",
+                    "CFWB-067 Residency Attestation",
+                    "CFWB-027 Housing Attestation with address listed",
+                    "Shelter Residency Letter with address listed",
+                    "Other"
+                  ]
+                }
+              },
+              {
+                "id": "nyc_residency_file",
+                "label": "Upload Residency Proof Document",
+                "description": "To add a document to your application, you can upload an image or scanned file from your phone or device. Accepted formats include .pdf, .gif, .jpeg, .jpg and .png up to 25 MB. Learn how to upload your files with this Tutorial Video.",
+                "type": "file",
+                "required": true, 
+                "constraints": {
+                  "maxFileSizeMB": 25,
+                  "allowedTypes": [
+                    "application/pdf",
+                    "image/jpeg",
+                    "image/jpg",
+                    "image/png",
+                    "image/gif"
+                  ]
+                },
+                "metadata": {
+                  "proofCategory": "NYC Residency",
+                  "multiple": false
+                }
+              }
+            ]
+          },
+          {
+            "id": "citizenship_status",
+            "title": "Citizenship or Immigration Status",
+            "description": "These documents confirm the citizenship/immigration status of the children in your family for whom you’re applying for child care assistance. Please upload one of the following documents for ONLY each child needing care.",
+            "fields": [
+              {
+                "id": "citizenship_doc_type",
+                "label": "Select one of the following:",
+                "type": "radio",
+                "required": true,
+                "ui": {
+                  "options": [
+                    "US Birth Certificate",
+                    "Alien Registration Card including Permanent Resident or Green Card",
+                    "Passport",
+                    "FS-240 (Report of Birth Abroad of a U.S. Citizen)",
+                    "Naturalization Certificate",
+                    "Other"
+                  ]
+                }
+              },
+              {
+                "id": "citizenship_doc_file",
+                "label": "Upload Citizenship/Immigration Document",
+                "description": "To add a document to your application, you can upload an image or scanned file from your phone or device. Accepted formats include .pdf, .gif, .jpeg, .jpg and .png up to 25 MB. Learn how to upload your files with this Tutorial Video.",
+                "type": "file",
+                "required": true,
+                "constraints": {
+                  "maxFileSizeMB": 25,
+                  "allowedTypes": [
+                    "application/pdf",
+                    "image/jpeg",
+                    "image/jpg",
+                    "image/png",
+                    "image/gif"
+                  ]
+                },
+                "metadata": {
+                  "proofCategory": "Citizenship/Immigration Status",
+                  "multiple": false
+                }
+              }
+            ]
+          },
+          {
+            "id": "child_relationship",
+            "title": "Child’s Relationship to Parent/Applicant",
+            "description": "These documents confirm your relationship to the children in your household under age 18. Please upload one of the following documents for every child in the household under age 18, regardless of whether child care is needed for them or not. If you are a legal guardian with financial responsibility, you must upload a Court order OR a letter of guardianship.",
+            "fields": [
+              {
+                "id": "relationship_doc_type",
+                "label": "Select one of the following:",
+                "type": "radio",
+                "required": true,
+                "ui": {
+                  "options": [
+                    "Birth Certificate",
+                    "Adoption record",
+                    "Baptismal record",
+                    "Passport with parent's signature",
+                    "Court order for legal guardian with financial responsibility",
+                    "Letter of Guardianship",
+                    "Other - CFWB-058 Caretaker Attestation"
+                  ]
+                }
+              },
+              {
+                "id": "relationship_doc_file",
+                "label": "Upload Relationship Document",
+                "description": "To add a document to your application, you can upload an image or scanned file from your phone or device. Accepted formats include .pdf, .gif, .jpeg, .jpg and .png up to 25 MB. Learn how to upload your files with this Tutorial Video.",
+                "type": "file",
+                "required": true,
+                "constraints": {
+                  "maxFileSizeMB": 25,
+                  "allowedTypes": [
+                    "application/pdf",
+                    "image/jpeg",
+                    "image/jpg",
+                    "image/png",
+                    "image/gif"
+                  ]
+                },
+                "metadata": {
+                  "proofCategory": "Child Relationship",
+                  "multiple": false
+                }
+              }
+            ]
+          },
+          {
+            "id": "age_proof",
+            "title": "Age",
+            "description": "These documents confirm the age of the children in your household. Please upload one of the following documents for every child in the household under age 18, regardless of whether child care is needed for them:",
+            "fields": [
+              {
+                "id": "age_doc_type",
+                "label": "Select one of the following:",
+                "type": "radio",
+                "required": true,
+                "ui": {
+                  "options": [
+                    "Birth Certificate",
+                    "Adoption record",
+                    "Baptismal record",
+                    "Alien Registration Card",
+                    "Passport",
+                    "Official hospital documentation of the child’s birth"
+                  ]
+                }
+              },
+              {
+                "id": "age_doc_file",
+                "label": "Upload Age Proof Document",
+                "description": "To add a document to your application, you can upload an image or scanned file from your phone or device. Accepted formats include .pdf, .gif, .jpeg, .jpg and .png up to 25 MB. Learn how to upload your files with this Tutorial Video.",
+                "type": "file",
+                "required": true,
+                "constraints": {
+                  "maxFileSizeMB": 25,
+                  "allowedTypes": [
+                    "application/pdf",
+                    "image/jpeg",
+                    "image/jpg",
+                    "image/png",
+                    "image/gif"
+                  ]
+                },
+                "metadata": {
+                  "proofCategory": "Child Age",
+                  "multiple": false
+                }
+              }
+            ]
+          }
+        ]
+      },
+      {
+        "id": "review",
+        "title": "Review & Submit",
+        "type": "review",
+        "sections": []
+      }
+    ]
+  }
+}

--- a/test-form/public/data/dycd_form.ar.json
+++ b/test-form/public/data/dycd_form.ar.json
@@ -1,0 +1,574 @@
+{
+  "form": {
+    "title": "DYCD Youth Services Intake – Ages 13 and Younger",
+    "description": "Form to collect youth and guardian information for DYCD programs",
+    "steps": [
+      {
+        "id": "demographics",
+        "title": "Youth Information",
+        "sections": [
+          {
+            "id": "youth_info",
+            "title": "Basic Information",
+            "fields": [
+              {
+                "id": "first_name",
+                "label": "First Name",
+                "type": "text",
+                "required": true
+              },
+              {
+                "id": "last_name",
+                "label": "Last Name",
+                "type": "text",
+                "required": true
+              },
+              {
+                "id": "dob",
+                "label": "Date of Birth",
+                "type": "date",
+                "required": true
+              },
+              {
+                "id": "gender",
+                "label": "Gender",
+                "type": "select",
+                "ui": {
+                  "options": [
+                    "Male",
+                    "Female",
+                    "Non-binary",
+                    "Other"
+                  ]
+                },
+                "required": true
+              },
+              {
+                "id": "ethnicity",
+                "label": "Ethnicity",
+                "type": "text"
+              }
+            ]
+          }
+        ]
+      },
+      {
+        "id": "guardian_info",
+        "title": "Parent/Guardian Info",
+        "sections": [
+          {
+            "id": "guardian_contact",
+            "title": "Contact Details",
+            "fields": [
+              {
+                "id": "guardian_name",
+                "label": "Name of Parent/Guardian",
+                "type": "text",
+                "required": true
+              },
+              {
+                "id": "phone",
+                "label": "Phone Number",
+                "type": "tel",
+                "required": true
+              },
+              {
+                "id": "email",
+                "label": "Email Address",
+                "type": "email"
+              },
+              {
+                "id": "relationship",
+                "label": "Relationship to Youth",
+                "type": "text",
+                "required": true
+              }
+            ]
+          }
+        ]
+      },
+      {
+        "id": "school_info",
+        "title": "School Information",
+        "sections": [
+          {
+            "id": "school",
+            "title": "Current School Details",
+            "fields": [
+              {
+                "id": "school_name",
+                "label": "School Name",
+                "type": "text"
+              },
+              {
+                "id": "grade",
+                "label": "Current Grade",
+                "type": "text"
+              },
+              {
+                "id": "school_type",
+                "label": "School Type",
+                "type": "select",
+                "ui": {
+                  "options": [
+                    "Public",
+                    "Private",
+                    "Charter",
+                    "Home School"
+                  ]
+                }
+              }
+            ]
+          }
+        ]
+      },
+      {
+        "id": "education_work_status",
+        "title": "Part III: Applicant’s Education/Work Status",
+        "sections": [
+          {
+            "id": "education_status",
+            "title": "Education Status",
+            "fields": [
+              {
+                "id": "education_status",
+                "label": "Applicant’s Education Status",
+                "type": "select",
+                "required": true,
+                "ui": {
+                  "options": [
+                    "Full-Time Student",
+                    "Part-Time Student",
+                    "Not in School"
+                  ]
+                }
+              },
+              {
+                "id": "grade_level_category",
+                "label": "Select Grade Level Category",
+                "type": "radio",
+                "required": true,
+                "ui": {
+                  "options": [
+                    "Elementary School",
+                    "Middle School",
+                    "High School",
+                    "Community College",
+                    "College/University",
+                    "Other"
+                  ]
+                }
+              },
+              {
+                "id": "grade_elem",
+                "label": "Select Specific Grade (Elementary School)",
+                "type": "select",
+                "requiredCondition": {
+                  "field": "grade_level_category",
+                  "operator": "equals",
+                  "value": "Elementary School"
+                },
+                "ui": {
+                  "options": [
+                    "Pre-K",
+                    "K",
+                    "1st",
+                    "2nd",
+                    "3rd",
+                    "4th",
+                    "5th"
+                  ]
+                }
+              },
+              {
+                "id": "grade_middle",
+                "label": "Select Specific Grade (Middle School)",
+                "type": "select",
+                "requiredCondition": {
+                  "field": "grade_level_category",
+                  "operator": "equals",
+                  "value": "Middle School"
+                },
+                "ui": {
+                  "options": [
+                    "6th",
+                    "7th",
+                    "8th"
+                  ]
+                }
+              },
+              {
+                "id": "grade_high",
+                "label": "Select Specific Grade (High School)",
+                "type": "select",
+                "requiredCondition": {
+                  "field": "grade_level_category",
+                  "operator": "equals",
+                  "value": "High School"
+                },
+                "ui": {
+                  "options": [
+                    "9th",
+                    "10th",
+                    "11th",
+                    "12th",
+                    "High School Diploma",
+                    "High School Equivalency"
+                  ]
+                }
+              },
+              {
+                "id": "grade_cc",
+                "label": "Select Specific Grade (Community College)",
+                "type": "select",
+                "requiredCondition": {
+                  "field": "grade_level_category",
+                  "operator": "equals",
+                  "value": "Community College"
+                },
+                "ui": {
+                  "options": [
+                    "1st Year",
+                    "2nd Year",
+                    "3rd Year",
+                    "Associate’s Degree"
+                  ]
+                }
+              },
+              {
+                "id": "grade_university",
+                "label": "Select Specific Grade (College/University)",
+                "type": "select",
+                "requiredCondition": {
+                  "field": "grade_level_category",
+                  "operator": "equals",
+                  "value": "College/University"
+                },
+                "ui": {
+                  "options": [
+                    "Freshman",
+                    "Sophomore",
+                    "Junior",
+                    "Senior",
+                    "Bachelor’s Degree",
+                    "Some Master’s",
+                    "Master’s Degree",
+                    "Some Doctorate",
+                    "Doctorate Degree"
+                  ]
+                }
+              },
+              {
+                "id": "grade_other",
+                "label": "Select Specific Grade (Other)",
+                "type": "select",
+                "requiredCondition": {
+                  "field": "grade_level_category",
+                  "operator": "equals",
+                  "value": "Other"
+                },
+                "ui": {
+                  "options": [
+                    "Foreign Degree",
+                    "No Formal Schooling"
+                  ]
+                }
+              }
+            ]
+          },
+          {
+            "id": "work_status",
+            "title": "Work Status",
+            "fields": [
+              {
+                "id": "work_status",
+                "label": "Applicant’s Current Work Status",
+                "type": "select",
+                "required": true,
+                "ui": {
+                  "options": [
+                    "Employed Full-Time",
+                    "Employed Part-Time",
+                    "Retired",
+                    "Unemployed (Short-Term ≤ 6 mo)",
+                    "Unemployed (Long-Term > 6 mo)",
+                    "Unemployed (Not in labor force)",
+                    "Migrant Seasonal Farm Worker",
+                    "Not applicable (under 14)"
+                  ]
+                }
+              }
+            ]
+          },
+          {
+            "id": "ft_student_info",
+            "title": "Full-Time Student Info",
+            "fields": [
+              {
+                "id": "student_id",
+                "label": "Student ID / OSIS",
+                "type": "text",
+                "requiredCondition": {
+                  "field": "education_status",
+                  "operator": "equals",
+                  "value": "Full-Time Student"
+                }
+              },
+              {
+                "id": "student_school_type",
+                "label": "School Type",
+                "type": "select",
+                "requiredCondition": {
+                  "field": "education_status",
+                  "operator": "equals",
+                  "value": "Full-Time Student"
+                },
+                "ui": {
+                  "options": [
+                    "Public",
+                    "Charter",
+                    "Private",
+                    "Other"
+                  ]
+                }
+              },
+              {
+                "id": "student_school_type_other",
+                "label": "If Other, please specify school type",
+                "type": "text",
+                "requiredCondition": {
+                  "field": "student_school_type",
+                  "operator": "equals",
+                  "value": "Other"
+                }
+              },
+              {
+                "id": "student_school_name",
+                "label": "School Name",
+                "type": "text",
+                "requiredCondition": {
+                  "field": "education_status",
+                  "operator": "equals",
+                  "value": "Full-Time Student"
+                }
+              },
+              {
+                "id": "student_school_address",
+                "label": "School Address",
+                "type": "text",
+                "requiredCondition": {
+                  "field": "education_status",
+                  "operator": "equals",
+                  "value": "Full-Time Student"
+                }
+              },
+              {
+                "id": "student_school_city",
+                "label": "School City",
+                "type": "text",
+                "requiredCondition": {
+                  "field": "education_status",
+                  "operator": "equals",
+                  "value": "Full-Time Student"
+                }
+              },
+              {
+                "id": "student_school_state",
+                "label": "School State",
+                "type": "text",
+                "requiredCondition": {
+                  "field": "education_status",
+                  "operator": "equals",
+                  "value": "Full-Time Student"
+                }
+              },
+              {
+                "id": "student_school_zip",
+                "label": "School Zip Code",
+                "type": "text",
+                "requiredCondition": {
+                  "field": "education_status",
+                  "operator": "equals",
+                  "value": "Full-Time Student"
+                }
+              }
+            ]
+          }
+        ]
+      },
+      {
+        "id": "household_info",
+        "title": "Part VI: Household Information",
+        "sections": [
+          {
+            "id": "household_composition",
+            "title": "Household Composition",
+            "fields": [
+              {
+                "id": "head_of_household",
+                "label": "Is the parent/guardian the head of household?",
+                "type": "radio",
+                "required": true,
+                "ui": {
+                  "options": [
+                    "Yes",
+                    "No"
+                  ]
+                }
+              },
+              {
+                "id": "household_income_source",
+                "label": "Primary Source of Household Income",
+                "type": "radio",
+                "required": true,
+                "ui": {
+                  "options": [
+                    "Employment",
+                    "Public Assistance",
+                    "Social Security",
+                    "Pension",
+                    "No Income",
+                    "Other"
+                  ]
+                }
+              },
+              {
+                "id": "household_income_source_other",
+                "label": "Specify Other Income Source",
+                "type": "text",
+                "requiredCondition": {
+                  "field": "household_income_source",
+                  "operator": "equals",
+                  "value": "Other"
+                },
+                "visibleCondition": {
+                  "field": "household_income_source",
+                  "operator": "equals",
+                  "value": "Other"
+                }
+              },
+              {
+                "id": "housing_type",
+                "label": "Type of Housing",
+                "type": "radio",
+                "required": true,
+                "ui": {
+                  "options": [
+                    "NYCHA",
+                    "Shelter",
+                    "Own Home",
+                    "Rental",
+                    "Supportive Housing",
+                    "Other"
+                  ]
+                }
+              },
+              {
+                "id": "housing_type_other",
+                "label": "Specify Other Housing Type",
+                "type": "text",
+                "requiredCondition": {
+                  "field": "housing_type",
+                  "operator": "equals",
+                  "value": "Other"
+                },
+                "visibleCondition": {
+                  "field": "housing_type",
+                  "operator": "equals",
+                  "value": "Other"
+                }
+              },
+              {
+                "id": "household_size",
+                "label": "Number of People in Household",
+                "type": "number",
+                "required": true,
+                "ui": {
+                  "min": 1
+                }
+              }
+            ]
+          }
+        ]
+      },
+      {
+        "id": "medical_info",
+        "title": "Medical & Emergency",
+        "sections": [
+          {
+            "id": "emergency",
+            "title": "Emergency Contact",
+            "fields": [
+              {
+                "id": "emergency_name",
+                "label": "Emergency Contact Name",
+                "type": "text"
+              },
+              {
+                "id": "emergency_phone",
+                "label": "Emergency Contact Phone",
+                "type": "tel"
+              }
+            ]
+          },
+          {
+            "id": "medical",
+            "title": "Medical Info",
+            "fields": [
+              {
+                "id": "medical_conditions",
+                "label": "Medical Conditions",
+                "type": "text"
+              },
+              {
+                "id": "medications",
+                "label": "Medications",
+                "type": "text"
+              },
+              {
+                "id": "allergies",
+                "label": "Allergies",
+                "type": "text"
+              }
+            ]
+          }
+        ]
+      },
+      {
+        "id": "consent",
+        "title": "Consent & Signature",
+        "sections": [
+          {
+            "id": "consent_info",
+            "title": "Authorization",
+            "fields": [
+              {
+                "id": "media_consent",
+                "label": "Media Release Consent",
+                "type": "checkbox"
+              },
+              {
+                "id": "signature",
+                "label": "Parent/Guardian Signature",
+                "type": "text",
+                "required": true
+              },
+              {
+                "id": "date_signed",
+                "label": "Date Signed",
+                "type": "date",
+                "required": true
+              }
+            ]
+          }
+        ]
+      },
+      {
+        "id": "review",
+        "title": "Review & Submit",
+        "type": "review",
+        "sections": []
+      }
+    ]
+  }
+}

--- a/test-form/public/data/dycd_form.bn.json
+++ b/test-form/public/data/dycd_form.bn.json
@@ -1,0 +1,574 @@
+{
+  "form": {
+    "title": "DYCD Youth Services Intake – Ages 13 and Younger",
+    "description": "Form to collect youth and guardian information for DYCD programs",
+    "steps": [
+      {
+        "id": "demographics",
+        "title": "Youth Information",
+        "sections": [
+          {
+            "id": "youth_info",
+            "title": "Basic Information",
+            "fields": [
+              {
+                "id": "first_name",
+                "label": "First Name",
+                "type": "text",
+                "required": true
+              },
+              {
+                "id": "last_name",
+                "label": "Last Name",
+                "type": "text",
+                "required": true
+              },
+              {
+                "id": "dob",
+                "label": "Date of Birth",
+                "type": "date",
+                "required": true
+              },
+              {
+                "id": "gender",
+                "label": "Gender",
+                "type": "select",
+                "ui": {
+                  "options": [
+                    "Male",
+                    "Female",
+                    "Non-binary",
+                    "Other"
+                  ]
+                },
+                "required": true
+              },
+              {
+                "id": "ethnicity",
+                "label": "Ethnicity",
+                "type": "text"
+              }
+            ]
+          }
+        ]
+      },
+      {
+        "id": "guardian_info",
+        "title": "Parent/Guardian Info",
+        "sections": [
+          {
+            "id": "guardian_contact",
+            "title": "Contact Details",
+            "fields": [
+              {
+                "id": "guardian_name",
+                "label": "Name of Parent/Guardian",
+                "type": "text",
+                "required": true
+              },
+              {
+                "id": "phone",
+                "label": "Phone Number",
+                "type": "tel",
+                "required": true
+              },
+              {
+                "id": "email",
+                "label": "Email Address",
+                "type": "email"
+              },
+              {
+                "id": "relationship",
+                "label": "Relationship to Youth",
+                "type": "text",
+                "required": true
+              }
+            ]
+          }
+        ]
+      },
+      {
+        "id": "school_info",
+        "title": "School Information",
+        "sections": [
+          {
+            "id": "school",
+            "title": "Current School Details",
+            "fields": [
+              {
+                "id": "school_name",
+                "label": "School Name",
+                "type": "text"
+              },
+              {
+                "id": "grade",
+                "label": "Current Grade",
+                "type": "text"
+              },
+              {
+                "id": "school_type",
+                "label": "School Type",
+                "type": "select",
+                "ui": {
+                  "options": [
+                    "Public",
+                    "Private",
+                    "Charter",
+                    "Home School"
+                  ]
+                }
+              }
+            ]
+          }
+        ]
+      },
+      {
+        "id": "education_work_status",
+        "title": "Part III: Applicant’s Education/Work Status",
+        "sections": [
+          {
+            "id": "education_status",
+            "title": "Education Status",
+            "fields": [
+              {
+                "id": "education_status",
+                "label": "Applicant’s Education Status",
+                "type": "select",
+                "required": true,
+                "ui": {
+                  "options": [
+                    "Full-Time Student",
+                    "Part-Time Student",
+                    "Not in School"
+                  ]
+                }
+              },
+              {
+                "id": "grade_level_category",
+                "label": "Select Grade Level Category",
+                "type": "radio",
+                "required": true,
+                "ui": {
+                  "options": [
+                    "Elementary School",
+                    "Middle School",
+                    "High School",
+                    "Community College",
+                    "College/University",
+                    "Other"
+                  ]
+                }
+              },
+              {
+                "id": "grade_elem",
+                "label": "Select Specific Grade (Elementary School)",
+                "type": "select",
+                "requiredCondition": {
+                  "field": "grade_level_category",
+                  "operator": "equals",
+                  "value": "Elementary School"
+                },
+                "ui": {
+                  "options": [
+                    "Pre-K",
+                    "K",
+                    "1st",
+                    "2nd",
+                    "3rd",
+                    "4th",
+                    "5th"
+                  ]
+                }
+              },
+              {
+                "id": "grade_middle",
+                "label": "Select Specific Grade (Middle School)",
+                "type": "select",
+                "requiredCondition": {
+                  "field": "grade_level_category",
+                  "operator": "equals",
+                  "value": "Middle School"
+                },
+                "ui": {
+                  "options": [
+                    "6th",
+                    "7th",
+                    "8th"
+                  ]
+                }
+              },
+              {
+                "id": "grade_high",
+                "label": "Select Specific Grade (High School)",
+                "type": "select",
+                "requiredCondition": {
+                  "field": "grade_level_category",
+                  "operator": "equals",
+                  "value": "High School"
+                },
+                "ui": {
+                  "options": [
+                    "9th",
+                    "10th",
+                    "11th",
+                    "12th",
+                    "High School Diploma",
+                    "High School Equivalency"
+                  ]
+                }
+              },
+              {
+                "id": "grade_cc",
+                "label": "Select Specific Grade (Community College)",
+                "type": "select",
+                "requiredCondition": {
+                  "field": "grade_level_category",
+                  "operator": "equals",
+                  "value": "Community College"
+                },
+                "ui": {
+                  "options": [
+                    "1st Year",
+                    "2nd Year",
+                    "3rd Year",
+                    "Associate’s Degree"
+                  ]
+                }
+              },
+              {
+                "id": "grade_university",
+                "label": "Select Specific Grade (College/University)",
+                "type": "select",
+                "requiredCondition": {
+                  "field": "grade_level_category",
+                  "operator": "equals",
+                  "value": "College/University"
+                },
+                "ui": {
+                  "options": [
+                    "Freshman",
+                    "Sophomore",
+                    "Junior",
+                    "Senior",
+                    "Bachelor’s Degree",
+                    "Some Master’s",
+                    "Master’s Degree",
+                    "Some Doctorate",
+                    "Doctorate Degree"
+                  ]
+                }
+              },
+              {
+                "id": "grade_other",
+                "label": "Select Specific Grade (Other)",
+                "type": "select",
+                "requiredCondition": {
+                  "field": "grade_level_category",
+                  "operator": "equals",
+                  "value": "Other"
+                },
+                "ui": {
+                  "options": [
+                    "Foreign Degree",
+                    "No Formal Schooling"
+                  ]
+                }
+              }
+            ]
+          },
+          {
+            "id": "work_status",
+            "title": "Work Status",
+            "fields": [
+              {
+                "id": "work_status",
+                "label": "Applicant’s Current Work Status",
+                "type": "select",
+                "required": true,
+                "ui": {
+                  "options": [
+                    "Employed Full-Time",
+                    "Employed Part-Time",
+                    "Retired",
+                    "Unemployed (Short-Term ≤ 6 mo)",
+                    "Unemployed (Long-Term > 6 mo)",
+                    "Unemployed (Not in labor force)",
+                    "Migrant Seasonal Farm Worker",
+                    "Not applicable (under 14)"
+                  ]
+                }
+              }
+            ]
+          },
+          {
+            "id": "ft_student_info",
+            "title": "Full-Time Student Info",
+            "fields": [
+              {
+                "id": "student_id",
+                "label": "Student ID / OSIS",
+                "type": "text",
+                "requiredCondition": {
+                  "field": "education_status",
+                  "operator": "equals",
+                  "value": "Full-Time Student"
+                }
+              },
+              {
+                "id": "student_school_type",
+                "label": "School Type",
+                "type": "select",
+                "requiredCondition": {
+                  "field": "education_status",
+                  "operator": "equals",
+                  "value": "Full-Time Student"
+                },
+                "ui": {
+                  "options": [
+                    "Public",
+                    "Charter",
+                    "Private",
+                    "Other"
+                  ]
+                }
+              },
+              {
+                "id": "student_school_type_other",
+                "label": "If Other, please specify school type",
+                "type": "text",
+                "requiredCondition": {
+                  "field": "student_school_type",
+                  "operator": "equals",
+                  "value": "Other"
+                }
+              },
+              {
+                "id": "student_school_name",
+                "label": "School Name",
+                "type": "text",
+                "requiredCondition": {
+                  "field": "education_status",
+                  "operator": "equals",
+                  "value": "Full-Time Student"
+                }
+              },
+              {
+                "id": "student_school_address",
+                "label": "School Address",
+                "type": "text",
+                "requiredCondition": {
+                  "field": "education_status",
+                  "operator": "equals",
+                  "value": "Full-Time Student"
+                }
+              },
+              {
+                "id": "student_school_city",
+                "label": "School City",
+                "type": "text",
+                "requiredCondition": {
+                  "field": "education_status",
+                  "operator": "equals",
+                  "value": "Full-Time Student"
+                }
+              },
+              {
+                "id": "student_school_state",
+                "label": "School State",
+                "type": "text",
+                "requiredCondition": {
+                  "field": "education_status",
+                  "operator": "equals",
+                  "value": "Full-Time Student"
+                }
+              },
+              {
+                "id": "student_school_zip",
+                "label": "School Zip Code",
+                "type": "text",
+                "requiredCondition": {
+                  "field": "education_status",
+                  "operator": "equals",
+                  "value": "Full-Time Student"
+                }
+              }
+            ]
+          }
+        ]
+      },
+      {
+        "id": "household_info",
+        "title": "Part VI: Household Information",
+        "sections": [
+          {
+            "id": "household_composition",
+            "title": "Household Composition",
+            "fields": [
+              {
+                "id": "head_of_household",
+                "label": "Is the parent/guardian the head of household?",
+                "type": "radio",
+                "required": true,
+                "ui": {
+                  "options": [
+                    "Yes",
+                    "No"
+                  ]
+                }
+              },
+              {
+                "id": "household_income_source",
+                "label": "Primary Source of Household Income",
+                "type": "radio",
+                "required": true,
+                "ui": {
+                  "options": [
+                    "Employment",
+                    "Public Assistance",
+                    "Social Security",
+                    "Pension",
+                    "No Income",
+                    "Other"
+                  ]
+                }
+              },
+              {
+                "id": "household_income_source_other",
+                "label": "Specify Other Income Source",
+                "type": "text",
+                "requiredCondition": {
+                  "field": "household_income_source",
+                  "operator": "equals",
+                  "value": "Other"
+                },
+                "visibleCondition": {
+                  "field": "household_income_source",
+                  "operator": "equals",
+                  "value": "Other"
+                }
+              },
+              {
+                "id": "housing_type",
+                "label": "Type of Housing",
+                "type": "radio",
+                "required": true,
+                "ui": {
+                  "options": [
+                    "NYCHA",
+                    "Shelter",
+                    "Own Home",
+                    "Rental",
+                    "Supportive Housing",
+                    "Other"
+                  ]
+                }
+              },
+              {
+                "id": "housing_type_other",
+                "label": "Specify Other Housing Type",
+                "type": "text",
+                "requiredCondition": {
+                  "field": "housing_type",
+                  "operator": "equals",
+                  "value": "Other"
+                },
+                "visibleCondition": {
+                  "field": "housing_type",
+                  "operator": "equals",
+                  "value": "Other"
+                }
+              },
+              {
+                "id": "household_size",
+                "label": "Number of People in Household",
+                "type": "number",
+                "required": true,
+                "ui": {
+                  "min": 1
+                }
+              }
+            ]
+          }
+        ]
+      },
+      {
+        "id": "medical_info",
+        "title": "Medical & Emergency",
+        "sections": [
+          {
+            "id": "emergency",
+            "title": "Emergency Contact",
+            "fields": [
+              {
+                "id": "emergency_name",
+                "label": "Emergency Contact Name",
+                "type": "text"
+              },
+              {
+                "id": "emergency_phone",
+                "label": "Emergency Contact Phone",
+                "type": "tel"
+              }
+            ]
+          },
+          {
+            "id": "medical",
+            "title": "Medical Info",
+            "fields": [
+              {
+                "id": "medical_conditions",
+                "label": "Medical Conditions",
+                "type": "text"
+              },
+              {
+                "id": "medications",
+                "label": "Medications",
+                "type": "text"
+              },
+              {
+                "id": "allergies",
+                "label": "Allergies",
+                "type": "text"
+              }
+            ]
+          }
+        ]
+      },
+      {
+        "id": "consent",
+        "title": "Consent & Signature",
+        "sections": [
+          {
+            "id": "consent_info",
+            "title": "Authorization",
+            "fields": [
+              {
+                "id": "media_consent",
+                "label": "Media Release Consent",
+                "type": "checkbox"
+              },
+              {
+                "id": "signature",
+                "label": "Parent/Guardian Signature",
+                "type": "text",
+                "required": true
+              },
+              {
+                "id": "date_signed",
+                "label": "Date Signed",
+                "type": "date",
+                "required": true
+              }
+            ]
+          }
+        ]
+      },
+      {
+        "id": "review",
+        "title": "Review & Submit",
+        "type": "review",
+        "sections": []
+      }
+    ]
+  }
+}

--- a/test-form/public/data/dycd_form.en.json
+++ b/test-form/public/data/dycd_form.en.json
@@ -1,0 +1,574 @@
+{
+  "form": {
+    "title": "DYCD Youth Services Intake – Ages 13 and Younger",
+    "description": "Form to collect youth and guardian information for DYCD programs",
+    "steps": [
+      {
+        "id": "demographics",
+        "title": "Youth Information",
+        "sections": [
+          {
+            "id": "youth_info",
+            "title": "Basic Information",
+            "fields": [
+              {
+                "id": "first_name",
+                "label": "First Name",
+                "type": "text",
+                "required": true
+              },
+              {
+                "id": "last_name",
+                "label": "Last Name",
+                "type": "text",
+                "required": true
+              },
+              {
+                "id": "dob",
+                "label": "Date of Birth",
+                "type": "date",
+                "required": true
+              },
+              {
+                "id": "gender",
+                "label": "Gender",
+                "type": "select",
+                "ui": {
+                  "options": [
+                    "Male",
+                    "Female",
+                    "Non-binary",
+                    "Other"
+                  ]
+                },
+                "required": true
+              },
+              {
+                "id": "ethnicity",
+                "label": "Ethnicity",
+                "type": "text"
+              }
+            ]
+          }
+        ]
+      },
+      {
+        "id": "guardian_info",
+        "title": "Parent/Guardian Info",
+        "sections": [
+          {
+            "id": "guardian_contact",
+            "title": "Contact Details",
+            "fields": [
+              {
+                "id": "guardian_name",
+                "label": "Name of Parent/Guardian",
+                "type": "text",
+                "required": true
+              },
+              {
+                "id": "phone",
+                "label": "Phone Number",
+                "type": "tel",
+                "required": true
+              },
+              {
+                "id": "email",
+                "label": "Email Address",
+                "type": "email"
+              },
+              {
+                "id": "relationship",
+                "label": "Relationship to Youth",
+                "type": "text",
+                "required": true
+              }
+            ]
+          }
+        ]
+      },
+      {
+        "id": "school_info",
+        "title": "School Information",
+        "sections": [
+          {
+            "id": "school",
+            "title": "Current School Details",
+            "fields": [
+              {
+                "id": "school_name",
+                "label": "School Name",
+                "type": "text"
+              },
+              {
+                "id": "grade",
+                "label": "Current Grade",
+                "type": "text"
+              },
+              {
+                "id": "school_type",
+                "label": "School Type",
+                "type": "select",
+                "ui": {
+                  "options": [
+                    "Public",
+                    "Private",
+                    "Charter",
+                    "Home School"
+                  ]
+                }
+              }
+            ]
+          }
+        ]
+      },
+      {
+        "id": "education_work_status",
+        "title": "Part III: Applicant’s Education/Work Status",
+        "sections": [
+          {
+            "id": "education_status",
+            "title": "Education Status",
+            "fields": [
+              {
+                "id": "education_status",
+                "label": "Applicant’s Education Status",
+                "type": "select",
+                "required": true,
+                "ui": {
+                  "options": [
+                    "Full-Time Student",
+                    "Part-Time Student",
+                    "Not in School"
+                  ]
+                }
+              },
+              {
+                "id": "grade_level_category",
+                "label": "Select Grade Level Category",
+                "type": "radio",
+                "required": true,
+                "ui": {
+                  "options": [
+                    "Elementary School",
+                    "Middle School",
+                    "High School",
+                    "Community College",
+                    "College/University",
+                    "Other"
+                  ]
+                }
+              },
+              {
+                "id": "grade_elem",
+                "label": "Select Specific Grade (Elementary School)",
+                "type": "select",
+                "requiredCondition": {
+                  "field": "grade_level_category",
+                  "operator": "equals",
+                  "value": "Elementary School"
+                },
+                "ui": {
+                  "options": [
+                    "Pre-K",
+                    "K",
+                    "1st",
+                    "2nd",
+                    "3rd",
+                    "4th",
+                    "5th"
+                  ]
+                }
+              },
+              {
+                "id": "grade_middle",
+                "label": "Select Specific Grade (Middle School)",
+                "type": "select",
+                "requiredCondition": {
+                  "field": "grade_level_category",
+                  "operator": "equals",
+                  "value": "Middle School"
+                },
+                "ui": {
+                  "options": [
+                    "6th",
+                    "7th",
+                    "8th"
+                  ]
+                }
+              },
+              {
+                "id": "grade_high",
+                "label": "Select Specific Grade (High School)",
+                "type": "select",
+                "requiredCondition": {
+                  "field": "grade_level_category",
+                  "operator": "equals",
+                  "value": "High School"
+                },
+                "ui": {
+                  "options": [
+                    "9th",
+                    "10th",
+                    "11th",
+                    "12th",
+                    "High School Diploma",
+                    "High School Equivalency"
+                  ]
+                }
+              },
+              {
+                "id": "grade_cc",
+                "label": "Select Specific Grade (Community College)",
+                "type": "select",
+                "requiredCondition": {
+                  "field": "grade_level_category",
+                  "operator": "equals",
+                  "value": "Community College"
+                },
+                "ui": {
+                  "options": [
+                    "1st Year",
+                    "2nd Year",
+                    "3rd Year",
+                    "Associate’s Degree"
+                  ]
+                }
+              },
+              {
+                "id": "grade_university",
+                "label": "Select Specific Grade (College/University)",
+                "type": "select",
+                "requiredCondition": {
+                  "field": "grade_level_category",
+                  "operator": "equals",
+                  "value": "College/University"
+                },
+                "ui": {
+                  "options": [
+                    "Freshman",
+                    "Sophomore",
+                    "Junior",
+                    "Senior",
+                    "Bachelor’s Degree",
+                    "Some Master’s",
+                    "Master’s Degree",
+                    "Some Doctorate",
+                    "Doctorate Degree"
+                  ]
+                }
+              },
+              {
+                "id": "grade_other",
+                "label": "Select Specific Grade (Other)",
+                "type": "select",
+                "requiredCondition": {
+                  "field": "grade_level_category",
+                  "operator": "equals",
+                  "value": "Other"
+                },
+                "ui": {
+                  "options": [
+                    "Foreign Degree",
+                    "No Formal Schooling"
+                  ]
+                }
+              }
+            ]
+          },
+          {
+            "id": "work_status",
+            "title": "Work Status",
+            "fields": [
+              {
+                "id": "work_status",
+                "label": "Applicant’s Current Work Status",
+                "type": "select",
+                "required": true,
+                "ui": {
+                  "options": [
+                    "Employed Full-Time",
+                    "Employed Part-Time",
+                    "Retired",
+                    "Unemployed (Short-Term ≤ 6 mo)",
+                    "Unemployed (Long-Term > 6 mo)",
+                    "Unemployed (Not in labor force)",
+                    "Migrant Seasonal Farm Worker",
+                    "Not applicable (under 14)"
+                  ]
+                }
+              }
+            ]
+          },
+          {
+            "id": "ft_student_info",
+            "title": "Full-Time Student Info",
+            "fields": [
+              {
+                "id": "student_id",
+                "label": "Student ID / OSIS",
+                "type": "text",
+                "requiredCondition": {
+                  "field": "education_status",
+                  "operator": "equals",
+                  "value": "Full-Time Student"
+                }
+              },
+              {
+                "id": "student_school_type",
+                "label": "School Type",
+                "type": "select",
+                "requiredCondition": {
+                  "field": "education_status",
+                  "operator": "equals",
+                  "value": "Full-Time Student"
+                },
+                "ui": {
+                  "options": [
+                    "Public",
+                    "Charter",
+                    "Private",
+                    "Other"
+                  ]
+                }
+              },
+              {
+                "id": "student_school_type_other",
+                "label": "If Other, please specify school type",
+                "type": "text",
+                "requiredCondition": {
+                  "field": "student_school_type",
+                  "operator": "equals",
+                  "value": "Other"
+                }
+              },
+              {
+                "id": "student_school_name",
+                "label": "School Name",
+                "type": "text",
+                "requiredCondition": {
+                  "field": "education_status",
+                  "operator": "equals",
+                  "value": "Full-Time Student"
+                }
+              },
+              {
+                "id": "student_school_address",
+                "label": "School Address",
+                "type": "text",
+                "requiredCondition": {
+                  "field": "education_status",
+                  "operator": "equals",
+                  "value": "Full-Time Student"
+                }
+              },
+              {
+                "id": "student_school_city",
+                "label": "School City",
+                "type": "text",
+                "requiredCondition": {
+                  "field": "education_status",
+                  "operator": "equals",
+                  "value": "Full-Time Student"
+                }
+              },
+              {
+                "id": "student_school_state",
+                "label": "School State",
+                "type": "text",
+                "requiredCondition": {
+                  "field": "education_status",
+                  "operator": "equals",
+                  "value": "Full-Time Student"
+                }
+              },
+              {
+                "id": "student_school_zip",
+                "label": "School Zip Code",
+                "type": "text",
+                "requiredCondition": {
+                  "field": "education_status",
+                  "operator": "equals",
+                  "value": "Full-Time Student"
+                }
+              }
+            ]
+          }
+        ]
+      },
+      {
+        "id": "household_info",
+        "title": "Part VI: Household Information",
+        "sections": [
+          {
+            "id": "household_composition",
+            "title": "Household Composition",
+            "fields": [
+              {
+                "id": "head_of_household",
+                "label": "Is the parent/guardian the head of household?",
+                "type": "radio",
+                "required": true,
+                "ui": {
+                  "options": [
+                    "Yes",
+                    "No"
+                  ]
+                }
+              },
+              {
+                "id": "household_income_source",
+                "label": "Primary Source of Household Income",
+                "type": "radio",
+                "required": true,
+                "ui": {
+                  "options": [
+                    "Employment",
+                    "Public Assistance",
+                    "Social Security",
+                    "Pension",
+                    "No Income",
+                    "Other"
+                  ]
+                }
+              },
+              {
+                "id": "household_income_source_other",
+                "label": "Specify Other Income Source",
+                "type": "text",
+                "requiredCondition": {
+                  "field": "household_income_source",
+                  "operator": "equals",
+                  "value": "Other"
+                },
+                "visibleCondition": {
+                  "field": "household_income_source",
+                  "operator": "equals",
+                  "value": "Other"
+                }
+              },
+              {
+                "id": "housing_type",
+                "label": "Type of Housing",
+                "type": "radio",
+                "required": true,
+                "ui": {
+                  "options": [
+                    "NYCHA",
+                    "Shelter",
+                    "Own Home",
+                    "Rental",
+                    "Supportive Housing",
+                    "Other"
+                  ]
+                }
+              },
+              {
+                "id": "housing_type_other",
+                "label": "Specify Other Housing Type",
+                "type": "text",
+                "requiredCondition": {
+                  "field": "housing_type",
+                  "operator": "equals",
+                  "value": "Other"
+                },
+                "visibleCondition": {
+                  "field": "housing_type",
+                  "operator": "equals",
+                  "value": "Other"
+                }
+              },
+              {
+                "id": "household_size",
+                "label": "Number of People in Household",
+                "type": "number",
+                "required": true,
+                "ui": {
+                  "min": 1
+                }
+              }
+            ]
+          }
+        ]
+      },
+      {
+        "id": "medical_info",
+        "title": "Medical & Emergency",
+        "sections": [
+          {
+            "id": "emergency",
+            "title": "Emergency Contact",
+            "fields": [
+              {
+                "id": "emergency_name",
+                "label": "Emergency Contact Name",
+                "type": "text"
+              },
+              {
+                "id": "emergency_phone",
+                "label": "Emergency Contact Phone",
+                "type": "tel"
+              }
+            ]
+          },
+          {
+            "id": "medical",
+            "title": "Medical Info",
+            "fields": [
+              {
+                "id": "medical_conditions",
+                "label": "Medical Conditions",
+                "type": "text"
+              },
+              {
+                "id": "medications",
+                "label": "Medications",
+                "type": "text"
+              },
+              {
+                "id": "allergies",
+                "label": "Allergies",
+                "type": "text"
+              }
+            ]
+          }
+        ]
+      },
+      {
+        "id": "consent",
+        "title": "Consent & Signature",
+        "sections": [
+          {
+            "id": "consent_info",
+            "title": "Authorization",
+            "fields": [
+              {
+                "id": "media_consent",
+                "label": "Media Release Consent",
+                "type": "checkbox"
+              },
+              {
+                "id": "signature",
+                "label": "Parent/Guardian Signature",
+                "type": "text",
+                "required": true
+              },
+              {
+                "id": "date_signed",
+                "label": "Date Signed",
+                "type": "date",
+                "required": true
+              }
+            ]
+          }
+        ]
+      },
+      {
+        "id": "review",
+        "title": "Review & Submit",
+        "type": "review",
+        "sections": []
+      }
+    ]
+  }
+}

--- a/test-form/public/data/dycd_form.es.json
+++ b/test-form/public/data/dycd_form.es.json
@@ -1,0 +1,574 @@
+{
+  "form": {
+    "title": "DYCD Youth Services Intake – Ages 13 and Younger",
+    "description": "Form to collect youth and guardian information for DYCD programs",
+    "steps": [
+      {
+        "id": "demographics",
+        "title": "Youth Information",
+        "sections": [
+          {
+            "id": "youth_info",
+            "title": "Basic Information",
+            "fields": [
+              {
+                "id": "first_name",
+                "label": "First Name",
+                "type": "text",
+                "required": true
+              },
+              {
+                "id": "last_name",
+                "label": "Last Name",
+                "type": "text",
+                "required": true
+              },
+              {
+                "id": "dob",
+                "label": "Date of Birth",
+                "type": "date",
+                "required": true
+              },
+              {
+                "id": "gender",
+                "label": "Gender",
+                "type": "select",
+                "ui": {
+                  "options": [
+                    "Male",
+                    "Female",
+                    "Non-binary",
+                    "Other"
+                  ]
+                },
+                "required": true
+              },
+              {
+                "id": "ethnicity",
+                "label": "Ethnicity",
+                "type": "text"
+              }
+            ]
+          }
+        ]
+      },
+      {
+        "id": "guardian_info",
+        "title": "Parent/Guardian Info",
+        "sections": [
+          {
+            "id": "guardian_contact",
+            "title": "Contact Details",
+            "fields": [
+              {
+                "id": "guardian_name",
+                "label": "Name of Parent/Guardian",
+                "type": "text",
+                "required": true
+              },
+              {
+                "id": "phone",
+                "label": "Phone Number",
+                "type": "tel",
+                "required": true
+              },
+              {
+                "id": "email",
+                "label": "Email Address",
+                "type": "email"
+              },
+              {
+                "id": "relationship",
+                "label": "Relationship to Youth",
+                "type": "text",
+                "required": true
+              }
+            ]
+          }
+        ]
+      },
+      {
+        "id": "school_info",
+        "title": "School Information",
+        "sections": [
+          {
+            "id": "school",
+            "title": "Current School Details",
+            "fields": [
+              {
+                "id": "school_name",
+                "label": "School Name",
+                "type": "text"
+              },
+              {
+                "id": "grade",
+                "label": "Current Grade",
+                "type": "text"
+              },
+              {
+                "id": "school_type",
+                "label": "School Type",
+                "type": "select",
+                "ui": {
+                  "options": [
+                    "Public",
+                    "Private",
+                    "Charter",
+                    "Home School"
+                  ]
+                }
+              }
+            ]
+          }
+        ]
+      },
+      {
+        "id": "education_work_status",
+        "title": "Part III: Applicant’s Education/Work Status",
+        "sections": [
+          {
+            "id": "education_status",
+            "title": "Education Status",
+            "fields": [
+              {
+                "id": "education_status",
+                "label": "Applicant’s Education Status",
+                "type": "select",
+                "required": true,
+                "ui": {
+                  "options": [
+                    "Full-Time Student",
+                    "Part-Time Student",
+                    "Not in School"
+                  ]
+                }
+              },
+              {
+                "id": "grade_level_category",
+                "label": "Select Grade Level Category",
+                "type": "radio",
+                "required": true,
+                "ui": {
+                  "options": [
+                    "Elementary School",
+                    "Middle School",
+                    "High School",
+                    "Community College",
+                    "College/University",
+                    "Other"
+                  ]
+                }
+              },
+              {
+                "id": "grade_elem",
+                "label": "Select Specific Grade (Elementary School)",
+                "type": "select",
+                "requiredCondition": {
+                  "field": "grade_level_category",
+                  "operator": "equals",
+                  "value": "Elementary School"
+                },
+                "ui": {
+                  "options": [
+                    "Pre-K",
+                    "K",
+                    "1st",
+                    "2nd",
+                    "3rd",
+                    "4th",
+                    "5th"
+                  ]
+                }
+              },
+              {
+                "id": "grade_middle",
+                "label": "Select Specific Grade (Middle School)",
+                "type": "select",
+                "requiredCondition": {
+                  "field": "grade_level_category",
+                  "operator": "equals",
+                  "value": "Middle School"
+                },
+                "ui": {
+                  "options": [
+                    "6th",
+                    "7th",
+                    "8th"
+                  ]
+                }
+              },
+              {
+                "id": "grade_high",
+                "label": "Select Specific Grade (High School)",
+                "type": "select",
+                "requiredCondition": {
+                  "field": "grade_level_category",
+                  "operator": "equals",
+                  "value": "High School"
+                },
+                "ui": {
+                  "options": [
+                    "9th",
+                    "10th",
+                    "11th",
+                    "12th",
+                    "High School Diploma",
+                    "High School Equivalency"
+                  ]
+                }
+              },
+              {
+                "id": "grade_cc",
+                "label": "Select Specific Grade (Community College)",
+                "type": "select",
+                "requiredCondition": {
+                  "field": "grade_level_category",
+                  "operator": "equals",
+                  "value": "Community College"
+                },
+                "ui": {
+                  "options": [
+                    "1st Year",
+                    "2nd Year",
+                    "3rd Year",
+                    "Associate’s Degree"
+                  ]
+                }
+              },
+              {
+                "id": "grade_university",
+                "label": "Select Specific Grade (College/University)",
+                "type": "select",
+                "requiredCondition": {
+                  "field": "grade_level_category",
+                  "operator": "equals",
+                  "value": "College/University"
+                },
+                "ui": {
+                  "options": [
+                    "Freshman",
+                    "Sophomore",
+                    "Junior",
+                    "Senior",
+                    "Bachelor’s Degree",
+                    "Some Master’s",
+                    "Master’s Degree",
+                    "Some Doctorate",
+                    "Doctorate Degree"
+                  ]
+                }
+              },
+              {
+                "id": "grade_other",
+                "label": "Select Specific Grade (Other)",
+                "type": "select",
+                "requiredCondition": {
+                  "field": "grade_level_category",
+                  "operator": "equals",
+                  "value": "Other"
+                },
+                "ui": {
+                  "options": [
+                    "Foreign Degree",
+                    "No Formal Schooling"
+                  ]
+                }
+              }
+            ]
+          },
+          {
+            "id": "work_status",
+            "title": "Work Status",
+            "fields": [
+              {
+                "id": "work_status",
+                "label": "Applicant’s Current Work Status",
+                "type": "select",
+                "required": true,
+                "ui": {
+                  "options": [
+                    "Employed Full-Time",
+                    "Employed Part-Time",
+                    "Retired",
+                    "Unemployed (Short-Term ≤ 6 mo)",
+                    "Unemployed (Long-Term > 6 mo)",
+                    "Unemployed (Not in labor force)",
+                    "Migrant Seasonal Farm Worker",
+                    "Not applicable (under 14)"
+                  ]
+                }
+              }
+            ]
+          },
+          {
+            "id": "ft_student_info",
+            "title": "Full-Time Student Info",
+            "fields": [
+              {
+                "id": "student_id",
+                "label": "Student ID / OSIS",
+                "type": "text",
+                "requiredCondition": {
+                  "field": "education_status",
+                  "operator": "equals",
+                  "value": "Full-Time Student"
+                }
+              },
+              {
+                "id": "student_school_type",
+                "label": "School Type",
+                "type": "select",
+                "requiredCondition": {
+                  "field": "education_status",
+                  "operator": "equals",
+                  "value": "Full-Time Student"
+                },
+                "ui": {
+                  "options": [
+                    "Public",
+                    "Charter",
+                    "Private",
+                    "Other"
+                  ]
+                }
+              },
+              {
+                "id": "student_school_type_other",
+                "label": "If Other, please specify school type",
+                "type": "text",
+                "requiredCondition": {
+                  "field": "student_school_type",
+                  "operator": "equals",
+                  "value": "Other"
+                }
+              },
+              {
+                "id": "student_school_name",
+                "label": "School Name",
+                "type": "text",
+                "requiredCondition": {
+                  "field": "education_status",
+                  "operator": "equals",
+                  "value": "Full-Time Student"
+                }
+              },
+              {
+                "id": "student_school_address",
+                "label": "School Address",
+                "type": "text",
+                "requiredCondition": {
+                  "field": "education_status",
+                  "operator": "equals",
+                  "value": "Full-Time Student"
+                }
+              },
+              {
+                "id": "student_school_city",
+                "label": "School City",
+                "type": "text",
+                "requiredCondition": {
+                  "field": "education_status",
+                  "operator": "equals",
+                  "value": "Full-Time Student"
+                }
+              },
+              {
+                "id": "student_school_state",
+                "label": "School State",
+                "type": "text",
+                "requiredCondition": {
+                  "field": "education_status",
+                  "operator": "equals",
+                  "value": "Full-Time Student"
+                }
+              },
+              {
+                "id": "student_school_zip",
+                "label": "School Zip Code",
+                "type": "text",
+                "requiredCondition": {
+                  "field": "education_status",
+                  "operator": "equals",
+                  "value": "Full-Time Student"
+                }
+              }
+            ]
+          }
+        ]
+      },
+      {
+        "id": "household_info",
+        "title": "Part VI: Household Information",
+        "sections": [
+          {
+            "id": "household_composition",
+            "title": "Household Composition",
+            "fields": [
+              {
+                "id": "head_of_household",
+                "label": "Is the parent/guardian the head of household?",
+                "type": "radio",
+                "required": true,
+                "ui": {
+                  "options": [
+                    "Yes",
+                    "No"
+                  ]
+                }
+              },
+              {
+                "id": "household_income_source",
+                "label": "Primary Source of Household Income",
+                "type": "radio",
+                "required": true,
+                "ui": {
+                  "options": [
+                    "Employment",
+                    "Public Assistance",
+                    "Social Security",
+                    "Pension",
+                    "No Income",
+                    "Other"
+                  ]
+                }
+              },
+              {
+                "id": "household_income_source_other",
+                "label": "Specify Other Income Source",
+                "type": "text",
+                "requiredCondition": {
+                  "field": "household_income_source",
+                  "operator": "equals",
+                  "value": "Other"
+                },
+                "visibleCondition": {
+                  "field": "household_income_source",
+                  "operator": "equals",
+                  "value": "Other"
+                }
+              },
+              {
+                "id": "housing_type",
+                "label": "Type of Housing",
+                "type": "radio",
+                "required": true,
+                "ui": {
+                  "options": [
+                    "NYCHA",
+                    "Shelter",
+                    "Own Home",
+                    "Rental",
+                    "Supportive Housing",
+                    "Other"
+                  ]
+                }
+              },
+              {
+                "id": "housing_type_other",
+                "label": "Specify Other Housing Type",
+                "type": "text",
+                "requiredCondition": {
+                  "field": "housing_type",
+                  "operator": "equals",
+                  "value": "Other"
+                },
+                "visibleCondition": {
+                  "field": "housing_type",
+                  "operator": "equals",
+                  "value": "Other"
+                }
+              },
+              {
+                "id": "household_size",
+                "label": "Number of People in Household",
+                "type": "number",
+                "required": true,
+                "ui": {
+                  "min": 1
+                }
+              }
+            ]
+          }
+        ]
+      },
+      {
+        "id": "medical_info",
+        "title": "Medical & Emergency",
+        "sections": [
+          {
+            "id": "emergency",
+            "title": "Emergency Contact",
+            "fields": [
+              {
+                "id": "emergency_name",
+                "label": "Emergency Contact Name",
+                "type": "text"
+              },
+              {
+                "id": "emergency_phone",
+                "label": "Emergency Contact Phone",
+                "type": "tel"
+              }
+            ]
+          },
+          {
+            "id": "medical",
+            "title": "Medical Info",
+            "fields": [
+              {
+                "id": "medical_conditions",
+                "label": "Medical Conditions",
+                "type": "text"
+              },
+              {
+                "id": "medications",
+                "label": "Medications",
+                "type": "text"
+              },
+              {
+                "id": "allergies",
+                "label": "Allergies",
+                "type": "text"
+              }
+            ]
+          }
+        ]
+      },
+      {
+        "id": "consent",
+        "title": "Consent & Signature",
+        "sections": [
+          {
+            "id": "consent_info",
+            "title": "Authorization",
+            "fields": [
+              {
+                "id": "media_consent",
+                "label": "Media Release Consent",
+                "type": "checkbox"
+              },
+              {
+                "id": "signature",
+                "label": "Parent/Guardian Signature",
+                "type": "text",
+                "required": true
+              },
+              {
+                "id": "date_signed",
+                "label": "Date Signed",
+                "type": "date",
+                "required": true
+              }
+            ]
+          }
+        ]
+      },
+      {
+        "id": "review",
+        "title": "Review & Submit",
+        "type": "review",
+        "sections": []
+      }
+    ]
+  }
+}

--- a/test-form/public/data/dycd_form.fr.json
+++ b/test-form/public/data/dycd_form.fr.json
@@ -1,0 +1,574 @@
+{
+  "form": {
+    "title": "DYCD Youth Services Intake – Ages 13 and Younger",
+    "description": "Form to collect youth and guardian information for DYCD programs",
+    "steps": [
+      {
+        "id": "demographics",
+        "title": "Youth Information",
+        "sections": [
+          {
+            "id": "youth_info",
+            "title": "Basic Information",
+            "fields": [
+              {
+                "id": "first_name",
+                "label": "First Name",
+                "type": "text",
+                "required": true
+              },
+              {
+                "id": "last_name",
+                "label": "Last Name",
+                "type": "text",
+                "required": true
+              },
+              {
+                "id": "dob",
+                "label": "Date of Birth",
+                "type": "date",
+                "required": true
+              },
+              {
+                "id": "gender",
+                "label": "Gender",
+                "type": "select",
+                "ui": {
+                  "options": [
+                    "Male",
+                    "Female",
+                    "Non-binary",
+                    "Other"
+                  ]
+                },
+                "required": true
+              },
+              {
+                "id": "ethnicity",
+                "label": "Ethnicity",
+                "type": "text"
+              }
+            ]
+          }
+        ]
+      },
+      {
+        "id": "guardian_info",
+        "title": "Parent/Guardian Info",
+        "sections": [
+          {
+            "id": "guardian_contact",
+            "title": "Contact Details",
+            "fields": [
+              {
+                "id": "guardian_name",
+                "label": "Name of Parent/Guardian",
+                "type": "text",
+                "required": true
+              },
+              {
+                "id": "phone",
+                "label": "Phone Number",
+                "type": "tel",
+                "required": true
+              },
+              {
+                "id": "email",
+                "label": "Email Address",
+                "type": "email"
+              },
+              {
+                "id": "relationship",
+                "label": "Relationship to Youth",
+                "type": "text",
+                "required": true
+              }
+            ]
+          }
+        ]
+      },
+      {
+        "id": "school_info",
+        "title": "School Information",
+        "sections": [
+          {
+            "id": "school",
+            "title": "Current School Details",
+            "fields": [
+              {
+                "id": "school_name",
+                "label": "School Name",
+                "type": "text"
+              },
+              {
+                "id": "grade",
+                "label": "Current Grade",
+                "type": "text"
+              },
+              {
+                "id": "school_type",
+                "label": "School Type",
+                "type": "select",
+                "ui": {
+                  "options": [
+                    "Public",
+                    "Private",
+                    "Charter",
+                    "Home School"
+                  ]
+                }
+              }
+            ]
+          }
+        ]
+      },
+      {
+        "id": "education_work_status",
+        "title": "Part III: Applicant’s Education/Work Status",
+        "sections": [
+          {
+            "id": "education_status",
+            "title": "Education Status",
+            "fields": [
+              {
+                "id": "education_status",
+                "label": "Applicant’s Education Status",
+                "type": "select",
+                "required": true,
+                "ui": {
+                  "options": [
+                    "Full-Time Student",
+                    "Part-Time Student",
+                    "Not in School"
+                  ]
+                }
+              },
+              {
+                "id": "grade_level_category",
+                "label": "Select Grade Level Category",
+                "type": "radio",
+                "required": true,
+                "ui": {
+                  "options": [
+                    "Elementary School",
+                    "Middle School",
+                    "High School",
+                    "Community College",
+                    "College/University",
+                    "Other"
+                  ]
+                }
+              },
+              {
+                "id": "grade_elem",
+                "label": "Select Specific Grade (Elementary School)",
+                "type": "select",
+                "requiredCondition": {
+                  "field": "grade_level_category",
+                  "operator": "equals",
+                  "value": "Elementary School"
+                },
+                "ui": {
+                  "options": [
+                    "Pre-K",
+                    "K",
+                    "1st",
+                    "2nd",
+                    "3rd",
+                    "4th",
+                    "5th"
+                  ]
+                }
+              },
+              {
+                "id": "grade_middle",
+                "label": "Select Specific Grade (Middle School)",
+                "type": "select",
+                "requiredCondition": {
+                  "field": "grade_level_category",
+                  "operator": "equals",
+                  "value": "Middle School"
+                },
+                "ui": {
+                  "options": [
+                    "6th",
+                    "7th",
+                    "8th"
+                  ]
+                }
+              },
+              {
+                "id": "grade_high",
+                "label": "Select Specific Grade (High School)",
+                "type": "select",
+                "requiredCondition": {
+                  "field": "grade_level_category",
+                  "operator": "equals",
+                  "value": "High School"
+                },
+                "ui": {
+                  "options": [
+                    "9th",
+                    "10th",
+                    "11th",
+                    "12th",
+                    "High School Diploma",
+                    "High School Equivalency"
+                  ]
+                }
+              },
+              {
+                "id": "grade_cc",
+                "label": "Select Specific Grade (Community College)",
+                "type": "select",
+                "requiredCondition": {
+                  "field": "grade_level_category",
+                  "operator": "equals",
+                  "value": "Community College"
+                },
+                "ui": {
+                  "options": [
+                    "1st Year",
+                    "2nd Year",
+                    "3rd Year",
+                    "Associate’s Degree"
+                  ]
+                }
+              },
+              {
+                "id": "grade_university",
+                "label": "Select Specific Grade (College/University)",
+                "type": "select",
+                "requiredCondition": {
+                  "field": "grade_level_category",
+                  "operator": "equals",
+                  "value": "College/University"
+                },
+                "ui": {
+                  "options": [
+                    "Freshman",
+                    "Sophomore",
+                    "Junior",
+                    "Senior",
+                    "Bachelor’s Degree",
+                    "Some Master’s",
+                    "Master’s Degree",
+                    "Some Doctorate",
+                    "Doctorate Degree"
+                  ]
+                }
+              },
+              {
+                "id": "grade_other",
+                "label": "Select Specific Grade (Other)",
+                "type": "select",
+                "requiredCondition": {
+                  "field": "grade_level_category",
+                  "operator": "equals",
+                  "value": "Other"
+                },
+                "ui": {
+                  "options": [
+                    "Foreign Degree",
+                    "No Formal Schooling"
+                  ]
+                }
+              }
+            ]
+          },
+          {
+            "id": "work_status",
+            "title": "Work Status",
+            "fields": [
+              {
+                "id": "work_status",
+                "label": "Applicant’s Current Work Status",
+                "type": "select",
+                "required": true,
+                "ui": {
+                  "options": [
+                    "Employed Full-Time",
+                    "Employed Part-Time",
+                    "Retired",
+                    "Unemployed (Short-Term ≤ 6 mo)",
+                    "Unemployed (Long-Term > 6 mo)",
+                    "Unemployed (Not in labor force)",
+                    "Migrant Seasonal Farm Worker",
+                    "Not applicable (under 14)"
+                  ]
+                }
+              }
+            ]
+          },
+          {
+            "id": "ft_student_info",
+            "title": "Full-Time Student Info",
+            "fields": [
+              {
+                "id": "student_id",
+                "label": "Student ID / OSIS",
+                "type": "text",
+                "requiredCondition": {
+                  "field": "education_status",
+                  "operator": "equals",
+                  "value": "Full-Time Student"
+                }
+              },
+              {
+                "id": "student_school_type",
+                "label": "School Type",
+                "type": "select",
+                "requiredCondition": {
+                  "field": "education_status",
+                  "operator": "equals",
+                  "value": "Full-Time Student"
+                },
+                "ui": {
+                  "options": [
+                    "Public",
+                    "Charter",
+                    "Private",
+                    "Other"
+                  ]
+                }
+              },
+              {
+                "id": "student_school_type_other",
+                "label": "If Other, please specify school type",
+                "type": "text",
+                "requiredCondition": {
+                  "field": "student_school_type",
+                  "operator": "equals",
+                  "value": "Other"
+                }
+              },
+              {
+                "id": "student_school_name",
+                "label": "School Name",
+                "type": "text",
+                "requiredCondition": {
+                  "field": "education_status",
+                  "operator": "equals",
+                  "value": "Full-Time Student"
+                }
+              },
+              {
+                "id": "student_school_address",
+                "label": "School Address",
+                "type": "text",
+                "requiredCondition": {
+                  "field": "education_status",
+                  "operator": "equals",
+                  "value": "Full-Time Student"
+                }
+              },
+              {
+                "id": "student_school_city",
+                "label": "School City",
+                "type": "text",
+                "requiredCondition": {
+                  "field": "education_status",
+                  "operator": "equals",
+                  "value": "Full-Time Student"
+                }
+              },
+              {
+                "id": "student_school_state",
+                "label": "School State",
+                "type": "text",
+                "requiredCondition": {
+                  "field": "education_status",
+                  "operator": "equals",
+                  "value": "Full-Time Student"
+                }
+              },
+              {
+                "id": "student_school_zip",
+                "label": "School Zip Code",
+                "type": "text",
+                "requiredCondition": {
+                  "field": "education_status",
+                  "operator": "equals",
+                  "value": "Full-Time Student"
+                }
+              }
+            ]
+          }
+        ]
+      },
+      {
+        "id": "household_info",
+        "title": "Part VI: Household Information",
+        "sections": [
+          {
+            "id": "household_composition",
+            "title": "Household Composition",
+            "fields": [
+              {
+                "id": "head_of_household",
+                "label": "Is the parent/guardian the head of household?",
+                "type": "radio",
+                "required": true,
+                "ui": {
+                  "options": [
+                    "Yes",
+                    "No"
+                  ]
+                }
+              },
+              {
+                "id": "household_income_source",
+                "label": "Primary Source of Household Income",
+                "type": "radio",
+                "required": true,
+                "ui": {
+                  "options": [
+                    "Employment",
+                    "Public Assistance",
+                    "Social Security",
+                    "Pension",
+                    "No Income",
+                    "Other"
+                  ]
+                }
+              },
+              {
+                "id": "household_income_source_other",
+                "label": "Specify Other Income Source",
+                "type": "text",
+                "requiredCondition": {
+                  "field": "household_income_source",
+                  "operator": "equals",
+                  "value": "Other"
+                },
+                "visibleCondition": {
+                  "field": "household_income_source",
+                  "operator": "equals",
+                  "value": "Other"
+                }
+              },
+              {
+                "id": "housing_type",
+                "label": "Type of Housing",
+                "type": "radio",
+                "required": true,
+                "ui": {
+                  "options": [
+                    "NYCHA",
+                    "Shelter",
+                    "Own Home",
+                    "Rental",
+                    "Supportive Housing",
+                    "Other"
+                  ]
+                }
+              },
+              {
+                "id": "housing_type_other",
+                "label": "Specify Other Housing Type",
+                "type": "text",
+                "requiredCondition": {
+                  "field": "housing_type",
+                  "operator": "equals",
+                  "value": "Other"
+                },
+                "visibleCondition": {
+                  "field": "housing_type",
+                  "operator": "equals",
+                  "value": "Other"
+                }
+              },
+              {
+                "id": "household_size",
+                "label": "Number of People in Household",
+                "type": "number",
+                "required": true,
+                "ui": {
+                  "min": 1
+                }
+              }
+            ]
+          }
+        ]
+      },
+      {
+        "id": "medical_info",
+        "title": "Medical & Emergency",
+        "sections": [
+          {
+            "id": "emergency",
+            "title": "Emergency Contact",
+            "fields": [
+              {
+                "id": "emergency_name",
+                "label": "Emergency Contact Name",
+                "type": "text"
+              },
+              {
+                "id": "emergency_phone",
+                "label": "Emergency Contact Phone",
+                "type": "tel"
+              }
+            ]
+          },
+          {
+            "id": "medical",
+            "title": "Medical Info",
+            "fields": [
+              {
+                "id": "medical_conditions",
+                "label": "Medical Conditions",
+                "type": "text"
+              },
+              {
+                "id": "medications",
+                "label": "Medications",
+                "type": "text"
+              },
+              {
+                "id": "allergies",
+                "label": "Allergies",
+                "type": "text"
+              }
+            ]
+          }
+        ]
+      },
+      {
+        "id": "consent",
+        "title": "Consent & Signature",
+        "sections": [
+          {
+            "id": "consent_info",
+            "title": "Authorization",
+            "fields": [
+              {
+                "id": "media_consent",
+                "label": "Media Release Consent",
+                "type": "checkbox"
+              },
+              {
+                "id": "signature",
+                "label": "Parent/Guardian Signature",
+                "type": "text",
+                "required": true
+              },
+              {
+                "id": "date_signed",
+                "label": "Date Signed",
+                "type": "date",
+                "required": true
+              }
+            ]
+          }
+        ]
+      },
+      {
+        "id": "review",
+        "title": "Review & Submit",
+        "type": "review",
+        "sections": []
+      }
+    ]
+  }
+}

--- a/test-form/public/data/dycd_form.ht.json
+++ b/test-form/public/data/dycd_form.ht.json
@@ -1,0 +1,574 @@
+{
+  "form": {
+    "title": "DYCD Youth Services Intake – Ages 13 and Younger",
+    "description": "Form to collect youth and guardian information for DYCD programs",
+    "steps": [
+      {
+        "id": "demographics",
+        "title": "Youth Information",
+        "sections": [
+          {
+            "id": "youth_info",
+            "title": "Basic Information",
+            "fields": [
+              {
+                "id": "first_name",
+                "label": "First Name",
+                "type": "text",
+                "required": true
+              },
+              {
+                "id": "last_name",
+                "label": "Last Name",
+                "type": "text",
+                "required": true
+              },
+              {
+                "id": "dob",
+                "label": "Date of Birth",
+                "type": "date",
+                "required": true
+              },
+              {
+                "id": "gender",
+                "label": "Gender",
+                "type": "select",
+                "ui": {
+                  "options": [
+                    "Male",
+                    "Female",
+                    "Non-binary",
+                    "Other"
+                  ]
+                },
+                "required": true
+              },
+              {
+                "id": "ethnicity",
+                "label": "Ethnicity",
+                "type": "text"
+              }
+            ]
+          }
+        ]
+      },
+      {
+        "id": "guardian_info",
+        "title": "Parent/Guardian Info",
+        "sections": [
+          {
+            "id": "guardian_contact",
+            "title": "Contact Details",
+            "fields": [
+              {
+                "id": "guardian_name",
+                "label": "Name of Parent/Guardian",
+                "type": "text",
+                "required": true
+              },
+              {
+                "id": "phone",
+                "label": "Phone Number",
+                "type": "tel",
+                "required": true
+              },
+              {
+                "id": "email",
+                "label": "Email Address",
+                "type": "email"
+              },
+              {
+                "id": "relationship",
+                "label": "Relationship to Youth",
+                "type": "text",
+                "required": true
+              }
+            ]
+          }
+        ]
+      },
+      {
+        "id": "school_info",
+        "title": "School Information",
+        "sections": [
+          {
+            "id": "school",
+            "title": "Current School Details",
+            "fields": [
+              {
+                "id": "school_name",
+                "label": "School Name",
+                "type": "text"
+              },
+              {
+                "id": "grade",
+                "label": "Current Grade",
+                "type": "text"
+              },
+              {
+                "id": "school_type",
+                "label": "School Type",
+                "type": "select",
+                "ui": {
+                  "options": [
+                    "Public",
+                    "Private",
+                    "Charter",
+                    "Home School"
+                  ]
+                }
+              }
+            ]
+          }
+        ]
+      },
+      {
+        "id": "education_work_status",
+        "title": "Part III: Applicant’s Education/Work Status",
+        "sections": [
+          {
+            "id": "education_status",
+            "title": "Education Status",
+            "fields": [
+              {
+                "id": "education_status",
+                "label": "Applicant’s Education Status",
+                "type": "select",
+                "required": true,
+                "ui": {
+                  "options": [
+                    "Full-Time Student",
+                    "Part-Time Student",
+                    "Not in School"
+                  ]
+                }
+              },
+              {
+                "id": "grade_level_category",
+                "label": "Select Grade Level Category",
+                "type": "radio",
+                "required": true,
+                "ui": {
+                  "options": [
+                    "Elementary School",
+                    "Middle School",
+                    "High School",
+                    "Community College",
+                    "College/University",
+                    "Other"
+                  ]
+                }
+              },
+              {
+                "id": "grade_elem",
+                "label": "Select Specific Grade (Elementary School)",
+                "type": "select",
+                "requiredCondition": {
+                  "field": "grade_level_category",
+                  "operator": "equals",
+                  "value": "Elementary School"
+                },
+                "ui": {
+                  "options": [
+                    "Pre-K",
+                    "K",
+                    "1st",
+                    "2nd",
+                    "3rd",
+                    "4th",
+                    "5th"
+                  ]
+                }
+              },
+              {
+                "id": "grade_middle",
+                "label": "Select Specific Grade (Middle School)",
+                "type": "select",
+                "requiredCondition": {
+                  "field": "grade_level_category",
+                  "operator": "equals",
+                  "value": "Middle School"
+                },
+                "ui": {
+                  "options": [
+                    "6th",
+                    "7th",
+                    "8th"
+                  ]
+                }
+              },
+              {
+                "id": "grade_high",
+                "label": "Select Specific Grade (High School)",
+                "type": "select",
+                "requiredCondition": {
+                  "field": "grade_level_category",
+                  "operator": "equals",
+                  "value": "High School"
+                },
+                "ui": {
+                  "options": [
+                    "9th",
+                    "10th",
+                    "11th",
+                    "12th",
+                    "High School Diploma",
+                    "High School Equivalency"
+                  ]
+                }
+              },
+              {
+                "id": "grade_cc",
+                "label": "Select Specific Grade (Community College)",
+                "type": "select",
+                "requiredCondition": {
+                  "field": "grade_level_category",
+                  "operator": "equals",
+                  "value": "Community College"
+                },
+                "ui": {
+                  "options": [
+                    "1st Year",
+                    "2nd Year",
+                    "3rd Year",
+                    "Associate’s Degree"
+                  ]
+                }
+              },
+              {
+                "id": "grade_university",
+                "label": "Select Specific Grade (College/University)",
+                "type": "select",
+                "requiredCondition": {
+                  "field": "grade_level_category",
+                  "operator": "equals",
+                  "value": "College/University"
+                },
+                "ui": {
+                  "options": [
+                    "Freshman",
+                    "Sophomore",
+                    "Junior",
+                    "Senior",
+                    "Bachelor’s Degree",
+                    "Some Master’s",
+                    "Master’s Degree",
+                    "Some Doctorate",
+                    "Doctorate Degree"
+                  ]
+                }
+              },
+              {
+                "id": "grade_other",
+                "label": "Select Specific Grade (Other)",
+                "type": "select",
+                "requiredCondition": {
+                  "field": "grade_level_category",
+                  "operator": "equals",
+                  "value": "Other"
+                },
+                "ui": {
+                  "options": [
+                    "Foreign Degree",
+                    "No Formal Schooling"
+                  ]
+                }
+              }
+            ]
+          },
+          {
+            "id": "work_status",
+            "title": "Work Status",
+            "fields": [
+              {
+                "id": "work_status",
+                "label": "Applicant’s Current Work Status",
+                "type": "select",
+                "required": true,
+                "ui": {
+                  "options": [
+                    "Employed Full-Time",
+                    "Employed Part-Time",
+                    "Retired",
+                    "Unemployed (Short-Term ≤ 6 mo)",
+                    "Unemployed (Long-Term > 6 mo)",
+                    "Unemployed (Not in labor force)",
+                    "Migrant Seasonal Farm Worker",
+                    "Not applicable (under 14)"
+                  ]
+                }
+              }
+            ]
+          },
+          {
+            "id": "ft_student_info",
+            "title": "Full-Time Student Info",
+            "fields": [
+              {
+                "id": "student_id",
+                "label": "Student ID / OSIS",
+                "type": "text",
+                "requiredCondition": {
+                  "field": "education_status",
+                  "operator": "equals",
+                  "value": "Full-Time Student"
+                }
+              },
+              {
+                "id": "student_school_type",
+                "label": "School Type",
+                "type": "select",
+                "requiredCondition": {
+                  "field": "education_status",
+                  "operator": "equals",
+                  "value": "Full-Time Student"
+                },
+                "ui": {
+                  "options": [
+                    "Public",
+                    "Charter",
+                    "Private",
+                    "Other"
+                  ]
+                }
+              },
+              {
+                "id": "student_school_type_other",
+                "label": "If Other, please specify school type",
+                "type": "text",
+                "requiredCondition": {
+                  "field": "student_school_type",
+                  "operator": "equals",
+                  "value": "Other"
+                }
+              },
+              {
+                "id": "student_school_name",
+                "label": "School Name",
+                "type": "text",
+                "requiredCondition": {
+                  "field": "education_status",
+                  "operator": "equals",
+                  "value": "Full-Time Student"
+                }
+              },
+              {
+                "id": "student_school_address",
+                "label": "School Address",
+                "type": "text",
+                "requiredCondition": {
+                  "field": "education_status",
+                  "operator": "equals",
+                  "value": "Full-Time Student"
+                }
+              },
+              {
+                "id": "student_school_city",
+                "label": "School City",
+                "type": "text",
+                "requiredCondition": {
+                  "field": "education_status",
+                  "operator": "equals",
+                  "value": "Full-Time Student"
+                }
+              },
+              {
+                "id": "student_school_state",
+                "label": "School State",
+                "type": "text",
+                "requiredCondition": {
+                  "field": "education_status",
+                  "operator": "equals",
+                  "value": "Full-Time Student"
+                }
+              },
+              {
+                "id": "student_school_zip",
+                "label": "School Zip Code",
+                "type": "text",
+                "requiredCondition": {
+                  "field": "education_status",
+                  "operator": "equals",
+                  "value": "Full-Time Student"
+                }
+              }
+            ]
+          }
+        ]
+      },
+      {
+        "id": "household_info",
+        "title": "Part VI: Household Information",
+        "sections": [
+          {
+            "id": "household_composition",
+            "title": "Household Composition",
+            "fields": [
+              {
+                "id": "head_of_household",
+                "label": "Is the parent/guardian the head of household?",
+                "type": "radio",
+                "required": true,
+                "ui": {
+                  "options": [
+                    "Yes",
+                    "No"
+                  ]
+                }
+              },
+              {
+                "id": "household_income_source",
+                "label": "Primary Source of Household Income",
+                "type": "radio",
+                "required": true,
+                "ui": {
+                  "options": [
+                    "Employment",
+                    "Public Assistance",
+                    "Social Security",
+                    "Pension",
+                    "No Income",
+                    "Other"
+                  ]
+                }
+              },
+              {
+                "id": "household_income_source_other",
+                "label": "Specify Other Income Source",
+                "type": "text",
+                "requiredCondition": {
+                  "field": "household_income_source",
+                  "operator": "equals",
+                  "value": "Other"
+                },
+                "visibleCondition": {
+                  "field": "household_income_source",
+                  "operator": "equals",
+                  "value": "Other"
+                }
+              },
+              {
+                "id": "housing_type",
+                "label": "Type of Housing",
+                "type": "radio",
+                "required": true,
+                "ui": {
+                  "options": [
+                    "NYCHA",
+                    "Shelter",
+                    "Own Home",
+                    "Rental",
+                    "Supportive Housing",
+                    "Other"
+                  ]
+                }
+              },
+              {
+                "id": "housing_type_other",
+                "label": "Specify Other Housing Type",
+                "type": "text",
+                "requiredCondition": {
+                  "field": "housing_type",
+                  "operator": "equals",
+                  "value": "Other"
+                },
+                "visibleCondition": {
+                  "field": "housing_type",
+                  "operator": "equals",
+                  "value": "Other"
+                }
+              },
+              {
+                "id": "household_size",
+                "label": "Number of People in Household",
+                "type": "number",
+                "required": true,
+                "ui": {
+                  "min": 1
+                }
+              }
+            ]
+          }
+        ]
+      },
+      {
+        "id": "medical_info",
+        "title": "Medical & Emergency",
+        "sections": [
+          {
+            "id": "emergency",
+            "title": "Emergency Contact",
+            "fields": [
+              {
+                "id": "emergency_name",
+                "label": "Emergency Contact Name",
+                "type": "text"
+              },
+              {
+                "id": "emergency_phone",
+                "label": "Emergency Contact Phone",
+                "type": "tel"
+              }
+            ]
+          },
+          {
+            "id": "medical",
+            "title": "Medical Info",
+            "fields": [
+              {
+                "id": "medical_conditions",
+                "label": "Medical Conditions",
+                "type": "text"
+              },
+              {
+                "id": "medications",
+                "label": "Medications",
+                "type": "text"
+              },
+              {
+                "id": "allergies",
+                "label": "Allergies",
+                "type": "text"
+              }
+            ]
+          }
+        ]
+      },
+      {
+        "id": "consent",
+        "title": "Consent & Signature",
+        "sections": [
+          {
+            "id": "consent_info",
+            "title": "Authorization",
+            "fields": [
+              {
+                "id": "media_consent",
+                "label": "Media Release Consent",
+                "type": "checkbox"
+              },
+              {
+                "id": "signature",
+                "label": "Parent/Guardian Signature",
+                "type": "text",
+                "required": true
+              },
+              {
+                "id": "date_signed",
+                "label": "Date Signed",
+                "type": "date",
+                "required": true
+              }
+            ]
+          }
+        ]
+      },
+      {
+        "id": "review",
+        "title": "Review & Submit",
+        "type": "review",
+        "sections": []
+      }
+    ]
+  }
+}

--- a/test-form/public/data/dycd_form.ko.json
+++ b/test-form/public/data/dycd_form.ko.json
@@ -1,0 +1,574 @@
+{
+  "form": {
+    "title": "DYCD Youth Services Intake – Ages 13 and Younger",
+    "description": "Form to collect youth and guardian information for DYCD programs",
+    "steps": [
+      {
+        "id": "demographics",
+        "title": "Youth Information",
+        "sections": [
+          {
+            "id": "youth_info",
+            "title": "Basic Information",
+            "fields": [
+              {
+                "id": "first_name",
+                "label": "First Name",
+                "type": "text",
+                "required": true
+              },
+              {
+                "id": "last_name",
+                "label": "Last Name",
+                "type": "text",
+                "required": true
+              },
+              {
+                "id": "dob",
+                "label": "Date of Birth",
+                "type": "date",
+                "required": true
+              },
+              {
+                "id": "gender",
+                "label": "Gender",
+                "type": "select",
+                "ui": {
+                  "options": [
+                    "Male",
+                    "Female",
+                    "Non-binary",
+                    "Other"
+                  ]
+                },
+                "required": true
+              },
+              {
+                "id": "ethnicity",
+                "label": "Ethnicity",
+                "type": "text"
+              }
+            ]
+          }
+        ]
+      },
+      {
+        "id": "guardian_info",
+        "title": "Parent/Guardian Info",
+        "sections": [
+          {
+            "id": "guardian_contact",
+            "title": "Contact Details",
+            "fields": [
+              {
+                "id": "guardian_name",
+                "label": "Name of Parent/Guardian",
+                "type": "text",
+                "required": true
+              },
+              {
+                "id": "phone",
+                "label": "Phone Number",
+                "type": "tel",
+                "required": true
+              },
+              {
+                "id": "email",
+                "label": "Email Address",
+                "type": "email"
+              },
+              {
+                "id": "relationship",
+                "label": "Relationship to Youth",
+                "type": "text",
+                "required": true
+              }
+            ]
+          }
+        ]
+      },
+      {
+        "id": "school_info",
+        "title": "School Information",
+        "sections": [
+          {
+            "id": "school",
+            "title": "Current School Details",
+            "fields": [
+              {
+                "id": "school_name",
+                "label": "School Name",
+                "type": "text"
+              },
+              {
+                "id": "grade",
+                "label": "Current Grade",
+                "type": "text"
+              },
+              {
+                "id": "school_type",
+                "label": "School Type",
+                "type": "select",
+                "ui": {
+                  "options": [
+                    "Public",
+                    "Private",
+                    "Charter",
+                    "Home School"
+                  ]
+                }
+              }
+            ]
+          }
+        ]
+      },
+      {
+        "id": "education_work_status",
+        "title": "Part III: Applicant’s Education/Work Status",
+        "sections": [
+          {
+            "id": "education_status",
+            "title": "Education Status",
+            "fields": [
+              {
+                "id": "education_status",
+                "label": "Applicant’s Education Status",
+                "type": "select",
+                "required": true,
+                "ui": {
+                  "options": [
+                    "Full-Time Student",
+                    "Part-Time Student",
+                    "Not in School"
+                  ]
+                }
+              },
+              {
+                "id": "grade_level_category",
+                "label": "Select Grade Level Category",
+                "type": "radio",
+                "required": true,
+                "ui": {
+                  "options": [
+                    "Elementary School",
+                    "Middle School",
+                    "High School",
+                    "Community College",
+                    "College/University",
+                    "Other"
+                  ]
+                }
+              },
+              {
+                "id": "grade_elem",
+                "label": "Select Specific Grade (Elementary School)",
+                "type": "select",
+                "requiredCondition": {
+                  "field": "grade_level_category",
+                  "operator": "equals",
+                  "value": "Elementary School"
+                },
+                "ui": {
+                  "options": [
+                    "Pre-K",
+                    "K",
+                    "1st",
+                    "2nd",
+                    "3rd",
+                    "4th",
+                    "5th"
+                  ]
+                }
+              },
+              {
+                "id": "grade_middle",
+                "label": "Select Specific Grade (Middle School)",
+                "type": "select",
+                "requiredCondition": {
+                  "field": "grade_level_category",
+                  "operator": "equals",
+                  "value": "Middle School"
+                },
+                "ui": {
+                  "options": [
+                    "6th",
+                    "7th",
+                    "8th"
+                  ]
+                }
+              },
+              {
+                "id": "grade_high",
+                "label": "Select Specific Grade (High School)",
+                "type": "select",
+                "requiredCondition": {
+                  "field": "grade_level_category",
+                  "operator": "equals",
+                  "value": "High School"
+                },
+                "ui": {
+                  "options": [
+                    "9th",
+                    "10th",
+                    "11th",
+                    "12th",
+                    "High School Diploma",
+                    "High School Equivalency"
+                  ]
+                }
+              },
+              {
+                "id": "grade_cc",
+                "label": "Select Specific Grade (Community College)",
+                "type": "select",
+                "requiredCondition": {
+                  "field": "grade_level_category",
+                  "operator": "equals",
+                  "value": "Community College"
+                },
+                "ui": {
+                  "options": [
+                    "1st Year",
+                    "2nd Year",
+                    "3rd Year",
+                    "Associate’s Degree"
+                  ]
+                }
+              },
+              {
+                "id": "grade_university",
+                "label": "Select Specific Grade (College/University)",
+                "type": "select",
+                "requiredCondition": {
+                  "field": "grade_level_category",
+                  "operator": "equals",
+                  "value": "College/University"
+                },
+                "ui": {
+                  "options": [
+                    "Freshman",
+                    "Sophomore",
+                    "Junior",
+                    "Senior",
+                    "Bachelor’s Degree",
+                    "Some Master’s",
+                    "Master’s Degree",
+                    "Some Doctorate",
+                    "Doctorate Degree"
+                  ]
+                }
+              },
+              {
+                "id": "grade_other",
+                "label": "Select Specific Grade (Other)",
+                "type": "select",
+                "requiredCondition": {
+                  "field": "grade_level_category",
+                  "operator": "equals",
+                  "value": "Other"
+                },
+                "ui": {
+                  "options": [
+                    "Foreign Degree",
+                    "No Formal Schooling"
+                  ]
+                }
+              }
+            ]
+          },
+          {
+            "id": "work_status",
+            "title": "Work Status",
+            "fields": [
+              {
+                "id": "work_status",
+                "label": "Applicant’s Current Work Status",
+                "type": "select",
+                "required": true,
+                "ui": {
+                  "options": [
+                    "Employed Full-Time",
+                    "Employed Part-Time",
+                    "Retired",
+                    "Unemployed (Short-Term ≤ 6 mo)",
+                    "Unemployed (Long-Term > 6 mo)",
+                    "Unemployed (Not in labor force)",
+                    "Migrant Seasonal Farm Worker",
+                    "Not applicable (under 14)"
+                  ]
+                }
+              }
+            ]
+          },
+          {
+            "id": "ft_student_info",
+            "title": "Full-Time Student Info",
+            "fields": [
+              {
+                "id": "student_id",
+                "label": "Student ID / OSIS",
+                "type": "text",
+                "requiredCondition": {
+                  "field": "education_status",
+                  "operator": "equals",
+                  "value": "Full-Time Student"
+                }
+              },
+              {
+                "id": "student_school_type",
+                "label": "School Type",
+                "type": "select",
+                "requiredCondition": {
+                  "field": "education_status",
+                  "operator": "equals",
+                  "value": "Full-Time Student"
+                },
+                "ui": {
+                  "options": [
+                    "Public",
+                    "Charter",
+                    "Private",
+                    "Other"
+                  ]
+                }
+              },
+              {
+                "id": "student_school_type_other",
+                "label": "If Other, please specify school type",
+                "type": "text",
+                "requiredCondition": {
+                  "field": "student_school_type",
+                  "operator": "equals",
+                  "value": "Other"
+                }
+              },
+              {
+                "id": "student_school_name",
+                "label": "School Name",
+                "type": "text",
+                "requiredCondition": {
+                  "field": "education_status",
+                  "operator": "equals",
+                  "value": "Full-Time Student"
+                }
+              },
+              {
+                "id": "student_school_address",
+                "label": "School Address",
+                "type": "text",
+                "requiredCondition": {
+                  "field": "education_status",
+                  "operator": "equals",
+                  "value": "Full-Time Student"
+                }
+              },
+              {
+                "id": "student_school_city",
+                "label": "School City",
+                "type": "text",
+                "requiredCondition": {
+                  "field": "education_status",
+                  "operator": "equals",
+                  "value": "Full-Time Student"
+                }
+              },
+              {
+                "id": "student_school_state",
+                "label": "School State",
+                "type": "text",
+                "requiredCondition": {
+                  "field": "education_status",
+                  "operator": "equals",
+                  "value": "Full-Time Student"
+                }
+              },
+              {
+                "id": "student_school_zip",
+                "label": "School Zip Code",
+                "type": "text",
+                "requiredCondition": {
+                  "field": "education_status",
+                  "operator": "equals",
+                  "value": "Full-Time Student"
+                }
+              }
+            ]
+          }
+        ]
+      },
+      {
+        "id": "household_info",
+        "title": "Part VI: Household Information",
+        "sections": [
+          {
+            "id": "household_composition",
+            "title": "Household Composition",
+            "fields": [
+              {
+                "id": "head_of_household",
+                "label": "Is the parent/guardian the head of household?",
+                "type": "radio",
+                "required": true,
+                "ui": {
+                  "options": [
+                    "Yes",
+                    "No"
+                  ]
+                }
+              },
+              {
+                "id": "household_income_source",
+                "label": "Primary Source of Household Income",
+                "type": "radio",
+                "required": true,
+                "ui": {
+                  "options": [
+                    "Employment",
+                    "Public Assistance",
+                    "Social Security",
+                    "Pension",
+                    "No Income",
+                    "Other"
+                  ]
+                }
+              },
+              {
+                "id": "household_income_source_other",
+                "label": "Specify Other Income Source",
+                "type": "text",
+                "requiredCondition": {
+                  "field": "household_income_source",
+                  "operator": "equals",
+                  "value": "Other"
+                },
+                "visibleCondition": {
+                  "field": "household_income_source",
+                  "operator": "equals",
+                  "value": "Other"
+                }
+              },
+              {
+                "id": "housing_type",
+                "label": "Type of Housing",
+                "type": "radio",
+                "required": true,
+                "ui": {
+                  "options": [
+                    "NYCHA",
+                    "Shelter",
+                    "Own Home",
+                    "Rental",
+                    "Supportive Housing",
+                    "Other"
+                  ]
+                }
+              },
+              {
+                "id": "housing_type_other",
+                "label": "Specify Other Housing Type",
+                "type": "text",
+                "requiredCondition": {
+                  "field": "housing_type",
+                  "operator": "equals",
+                  "value": "Other"
+                },
+                "visibleCondition": {
+                  "field": "housing_type",
+                  "operator": "equals",
+                  "value": "Other"
+                }
+              },
+              {
+                "id": "household_size",
+                "label": "Number of People in Household",
+                "type": "number",
+                "required": true,
+                "ui": {
+                  "min": 1
+                }
+              }
+            ]
+          }
+        ]
+      },
+      {
+        "id": "medical_info",
+        "title": "Medical & Emergency",
+        "sections": [
+          {
+            "id": "emergency",
+            "title": "Emergency Contact",
+            "fields": [
+              {
+                "id": "emergency_name",
+                "label": "Emergency Contact Name",
+                "type": "text"
+              },
+              {
+                "id": "emergency_phone",
+                "label": "Emergency Contact Phone",
+                "type": "tel"
+              }
+            ]
+          },
+          {
+            "id": "medical",
+            "title": "Medical Info",
+            "fields": [
+              {
+                "id": "medical_conditions",
+                "label": "Medical Conditions",
+                "type": "text"
+              },
+              {
+                "id": "medications",
+                "label": "Medications",
+                "type": "text"
+              },
+              {
+                "id": "allergies",
+                "label": "Allergies",
+                "type": "text"
+              }
+            ]
+          }
+        ]
+      },
+      {
+        "id": "consent",
+        "title": "Consent & Signature",
+        "sections": [
+          {
+            "id": "consent_info",
+            "title": "Authorization",
+            "fields": [
+              {
+                "id": "media_consent",
+                "label": "Media Release Consent",
+                "type": "checkbox"
+              },
+              {
+                "id": "signature",
+                "label": "Parent/Guardian Signature",
+                "type": "text",
+                "required": true
+              },
+              {
+                "id": "date_signed",
+                "label": "Date Signed",
+                "type": "date",
+                "required": true
+              }
+            ]
+          }
+        ]
+      },
+      {
+        "id": "review",
+        "title": "Review & Submit",
+        "type": "review",
+        "sections": []
+      }
+    ]
+  }
+}

--- a/test-form/public/data/dycd_form.pl.json
+++ b/test-form/public/data/dycd_form.pl.json
@@ -1,0 +1,574 @@
+{
+  "form": {
+    "title": "DYCD Youth Services Intake – Ages 13 and Younger",
+    "description": "Form to collect youth and guardian information for DYCD programs",
+    "steps": [
+      {
+        "id": "demographics",
+        "title": "Youth Information",
+        "sections": [
+          {
+            "id": "youth_info",
+            "title": "Basic Information",
+            "fields": [
+              {
+                "id": "first_name",
+                "label": "First Name",
+                "type": "text",
+                "required": true
+              },
+              {
+                "id": "last_name",
+                "label": "Last Name",
+                "type": "text",
+                "required": true
+              },
+              {
+                "id": "dob",
+                "label": "Date of Birth",
+                "type": "date",
+                "required": true
+              },
+              {
+                "id": "gender",
+                "label": "Gender",
+                "type": "select",
+                "ui": {
+                  "options": [
+                    "Male",
+                    "Female",
+                    "Non-binary",
+                    "Other"
+                  ]
+                },
+                "required": true
+              },
+              {
+                "id": "ethnicity",
+                "label": "Ethnicity",
+                "type": "text"
+              }
+            ]
+          }
+        ]
+      },
+      {
+        "id": "guardian_info",
+        "title": "Parent/Guardian Info",
+        "sections": [
+          {
+            "id": "guardian_contact",
+            "title": "Contact Details",
+            "fields": [
+              {
+                "id": "guardian_name",
+                "label": "Name of Parent/Guardian",
+                "type": "text",
+                "required": true
+              },
+              {
+                "id": "phone",
+                "label": "Phone Number",
+                "type": "tel",
+                "required": true
+              },
+              {
+                "id": "email",
+                "label": "Email Address",
+                "type": "email"
+              },
+              {
+                "id": "relationship",
+                "label": "Relationship to Youth",
+                "type": "text",
+                "required": true
+              }
+            ]
+          }
+        ]
+      },
+      {
+        "id": "school_info",
+        "title": "School Information",
+        "sections": [
+          {
+            "id": "school",
+            "title": "Current School Details",
+            "fields": [
+              {
+                "id": "school_name",
+                "label": "School Name",
+                "type": "text"
+              },
+              {
+                "id": "grade",
+                "label": "Current Grade",
+                "type": "text"
+              },
+              {
+                "id": "school_type",
+                "label": "School Type",
+                "type": "select",
+                "ui": {
+                  "options": [
+                    "Public",
+                    "Private",
+                    "Charter",
+                    "Home School"
+                  ]
+                }
+              }
+            ]
+          }
+        ]
+      },
+      {
+        "id": "education_work_status",
+        "title": "Part III: Applicant’s Education/Work Status",
+        "sections": [
+          {
+            "id": "education_status",
+            "title": "Education Status",
+            "fields": [
+              {
+                "id": "education_status",
+                "label": "Applicant’s Education Status",
+                "type": "select",
+                "required": true,
+                "ui": {
+                  "options": [
+                    "Full-Time Student",
+                    "Part-Time Student",
+                    "Not in School"
+                  ]
+                }
+              },
+              {
+                "id": "grade_level_category",
+                "label": "Select Grade Level Category",
+                "type": "radio",
+                "required": true,
+                "ui": {
+                  "options": [
+                    "Elementary School",
+                    "Middle School",
+                    "High School",
+                    "Community College",
+                    "College/University",
+                    "Other"
+                  ]
+                }
+              },
+              {
+                "id": "grade_elem",
+                "label": "Select Specific Grade (Elementary School)",
+                "type": "select",
+                "requiredCondition": {
+                  "field": "grade_level_category",
+                  "operator": "equals",
+                  "value": "Elementary School"
+                },
+                "ui": {
+                  "options": [
+                    "Pre-K",
+                    "K",
+                    "1st",
+                    "2nd",
+                    "3rd",
+                    "4th",
+                    "5th"
+                  ]
+                }
+              },
+              {
+                "id": "grade_middle",
+                "label": "Select Specific Grade (Middle School)",
+                "type": "select",
+                "requiredCondition": {
+                  "field": "grade_level_category",
+                  "operator": "equals",
+                  "value": "Middle School"
+                },
+                "ui": {
+                  "options": [
+                    "6th",
+                    "7th",
+                    "8th"
+                  ]
+                }
+              },
+              {
+                "id": "grade_high",
+                "label": "Select Specific Grade (High School)",
+                "type": "select",
+                "requiredCondition": {
+                  "field": "grade_level_category",
+                  "operator": "equals",
+                  "value": "High School"
+                },
+                "ui": {
+                  "options": [
+                    "9th",
+                    "10th",
+                    "11th",
+                    "12th",
+                    "High School Diploma",
+                    "High School Equivalency"
+                  ]
+                }
+              },
+              {
+                "id": "grade_cc",
+                "label": "Select Specific Grade (Community College)",
+                "type": "select",
+                "requiredCondition": {
+                  "field": "grade_level_category",
+                  "operator": "equals",
+                  "value": "Community College"
+                },
+                "ui": {
+                  "options": [
+                    "1st Year",
+                    "2nd Year",
+                    "3rd Year",
+                    "Associate’s Degree"
+                  ]
+                }
+              },
+              {
+                "id": "grade_university",
+                "label": "Select Specific Grade (College/University)",
+                "type": "select",
+                "requiredCondition": {
+                  "field": "grade_level_category",
+                  "operator": "equals",
+                  "value": "College/University"
+                },
+                "ui": {
+                  "options": [
+                    "Freshman",
+                    "Sophomore",
+                    "Junior",
+                    "Senior",
+                    "Bachelor’s Degree",
+                    "Some Master’s",
+                    "Master’s Degree",
+                    "Some Doctorate",
+                    "Doctorate Degree"
+                  ]
+                }
+              },
+              {
+                "id": "grade_other",
+                "label": "Select Specific Grade (Other)",
+                "type": "select",
+                "requiredCondition": {
+                  "field": "grade_level_category",
+                  "operator": "equals",
+                  "value": "Other"
+                },
+                "ui": {
+                  "options": [
+                    "Foreign Degree",
+                    "No Formal Schooling"
+                  ]
+                }
+              }
+            ]
+          },
+          {
+            "id": "work_status",
+            "title": "Work Status",
+            "fields": [
+              {
+                "id": "work_status",
+                "label": "Applicant’s Current Work Status",
+                "type": "select",
+                "required": true,
+                "ui": {
+                  "options": [
+                    "Employed Full-Time",
+                    "Employed Part-Time",
+                    "Retired",
+                    "Unemployed (Short-Term ≤ 6 mo)",
+                    "Unemployed (Long-Term > 6 mo)",
+                    "Unemployed (Not in labor force)",
+                    "Migrant Seasonal Farm Worker",
+                    "Not applicable (under 14)"
+                  ]
+                }
+              }
+            ]
+          },
+          {
+            "id": "ft_student_info",
+            "title": "Full-Time Student Info",
+            "fields": [
+              {
+                "id": "student_id",
+                "label": "Student ID / OSIS",
+                "type": "text",
+                "requiredCondition": {
+                  "field": "education_status",
+                  "operator": "equals",
+                  "value": "Full-Time Student"
+                }
+              },
+              {
+                "id": "student_school_type",
+                "label": "School Type",
+                "type": "select",
+                "requiredCondition": {
+                  "field": "education_status",
+                  "operator": "equals",
+                  "value": "Full-Time Student"
+                },
+                "ui": {
+                  "options": [
+                    "Public",
+                    "Charter",
+                    "Private",
+                    "Other"
+                  ]
+                }
+              },
+              {
+                "id": "student_school_type_other",
+                "label": "If Other, please specify school type",
+                "type": "text",
+                "requiredCondition": {
+                  "field": "student_school_type",
+                  "operator": "equals",
+                  "value": "Other"
+                }
+              },
+              {
+                "id": "student_school_name",
+                "label": "School Name",
+                "type": "text",
+                "requiredCondition": {
+                  "field": "education_status",
+                  "operator": "equals",
+                  "value": "Full-Time Student"
+                }
+              },
+              {
+                "id": "student_school_address",
+                "label": "School Address",
+                "type": "text",
+                "requiredCondition": {
+                  "field": "education_status",
+                  "operator": "equals",
+                  "value": "Full-Time Student"
+                }
+              },
+              {
+                "id": "student_school_city",
+                "label": "School City",
+                "type": "text",
+                "requiredCondition": {
+                  "field": "education_status",
+                  "operator": "equals",
+                  "value": "Full-Time Student"
+                }
+              },
+              {
+                "id": "student_school_state",
+                "label": "School State",
+                "type": "text",
+                "requiredCondition": {
+                  "field": "education_status",
+                  "operator": "equals",
+                  "value": "Full-Time Student"
+                }
+              },
+              {
+                "id": "student_school_zip",
+                "label": "School Zip Code",
+                "type": "text",
+                "requiredCondition": {
+                  "field": "education_status",
+                  "operator": "equals",
+                  "value": "Full-Time Student"
+                }
+              }
+            ]
+          }
+        ]
+      },
+      {
+        "id": "household_info",
+        "title": "Part VI: Household Information",
+        "sections": [
+          {
+            "id": "household_composition",
+            "title": "Household Composition",
+            "fields": [
+              {
+                "id": "head_of_household",
+                "label": "Is the parent/guardian the head of household?",
+                "type": "radio",
+                "required": true,
+                "ui": {
+                  "options": [
+                    "Yes",
+                    "No"
+                  ]
+                }
+              },
+              {
+                "id": "household_income_source",
+                "label": "Primary Source of Household Income",
+                "type": "radio",
+                "required": true,
+                "ui": {
+                  "options": [
+                    "Employment",
+                    "Public Assistance",
+                    "Social Security",
+                    "Pension",
+                    "No Income",
+                    "Other"
+                  ]
+                }
+              },
+              {
+                "id": "household_income_source_other",
+                "label": "Specify Other Income Source",
+                "type": "text",
+                "requiredCondition": {
+                  "field": "household_income_source",
+                  "operator": "equals",
+                  "value": "Other"
+                },
+                "visibleCondition": {
+                  "field": "household_income_source",
+                  "operator": "equals",
+                  "value": "Other"
+                }
+              },
+              {
+                "id": "housing_type",
+                "label": "Type of Housing",
+                "type": "radio",
+                "required": true,
+                "ui": {
+                  "options": [
+                    "NYCHA",
+                    "Shelter",
+                    "Own Home",
+                    "Rental",
+                    "Supportive Housing",
+                    "Other"
+                  ]
+                }
+              },
+              {
+                "id": "housing_type_other",
+                "label": "Specify Other Housing Type",
+                "type": "text",
+                "requiredCondition": {
+                  "field": "housing_type",
+                  "operator": "equals",
+                  "value": "Other"
+                },
+                "visibleCondition": {
+                  "field": "housing_type",
+                  "operator": "equals",
+                  "value": "Other"
+                }
+              },
+              {
+                "id": "household_size",
+                "label": "Number of People in Household",
+                "type": "number",
+                "required": true,
+                "ui": {
+                  "min": 1
+                }
+              }
+            ]
+          }
+        ]
+      },
+      {
+        "id": "medical_info",
+        "title": "Medical & Emergency",
+        "sections": [
+          {
+            "id": "emergency",
+            "title": "Emergency Contact",
+            "fields": [
+              {
+                "id": "emergency_name",
+                "label": "Emergency Contact Name",
+                "type": "text"
+              },
+              {
+                "id": "emergency_phone",
+                "label": "Emergency Contact Phone",
+                "type": "tel"
+              }
+            ]
+          },
+          {
+            "id": "medical",
+            "title": "Medical Info",
+            "fields": [
+              {
+                "id": "medical_conditions",
+                "label": "Medical Conditions",
+                "type": "text"
+              },
+              {
+                "id": "medications",
+                "label": "Medications",
+                "type": "text"
+              },
+              {
+                "id": "allergies",
+                "label": "Allergies",
+                "type": "text"
+              }
+            ]
+          }
+        ]
+      },
+      {
+        "id": "consent",
+        "title": "Consent & Signature",
+        "sections": [
+          {
+            "id": "consent_info",
+            "title": "Authorization",
+            "fields": [
+              {
+                "id": "media_consent",
+                "label": "Media Release Consent",
+                "type": "checkbox"
+              },
+              {
+                "id": "signature",
+                "label": "Parent/Guardian Signature",
+                "type": "text",
+                "required": true
+              },
+              {
+                "id": "date_signed",
+                "label": "Date Signed",
+                "type": "date",
+                "required": true
+              }
+            ]
+          }
+        ]
+      },
+      {
+        "id": "review",
+        "title": "Review & Submit",
+        "type": "review",
+        "sections": []
+      }
+    ]
+  }
+}

--- a/test-form/public/data/dycd_form.ru.json
+++ b/test-form/public/data/dycd_form.ru.json
@@ -1,0 +1,574 @@
+{
+  "form": {
+    "title": "DYCD Youth Services Intake – Ages 13 and Younger",
+    "description": "Form to collect youth and guardian information for DYCD programs",
+    "steps": [
+      {
+        "id": "demographics",
+        "title": "Youth Information",
+        "sections": [
+          {
+            "id": "youth_info",
+            "title": "Basic Information",
+            "fields": [
+              {
+                "id": "first_name",
+                "label": "First Name",
+                "type": "text",
+                "required": true
+              },
+              {
+                "id": "last_name",
+                "label": "Last Name",
+                "type": "text",
+                "required": true
+              },
+              {
+                "id": "dob",
+                "label": "Date of Birth",
+                "type": "date",
+                "required": true
+              },
+              {
+                "id": "gender",
+                "label": "Gender",
+                "type": "select",
+                "ui": {
+                  "options": [
+                    "Male",
+                    "Female",
+                    "Non-binary",
+                    "Other"
+                  ]
+                },
+                "required": true
+              },
+              {
+                "id": "ethnicity",
+                "label": "Ethnicity",
+                "type": "text"
+              }
+            ]
+          }
+        ]
+      },
+      {
+        "id": "guardian_info",
+        "title": "Parent/Guardian Info",
+        "sections": [
+          {
+            "id": "guardian_contact",
+            "title": "Contact Details",
+            "fields": [
+              {
+                "id": "guardian_name",
+                "label": "Name of Parent/Guardian",
+                "type": "text",
+                "required": true
+              },
+              {
+                "id": "phone",
+                "label": "Phone Number",
+                "type": "tel",
+                "required": true
+              },
+              {
+                "id": "email",
+                "label": "Email Address",
+                "type": "email"
+              },
+              {
+                "id": "relationship",
+                "label": "Relationship to Youth",
+                "type": "text",
+                "required": true
+              }
+            ]
+          }
+        ]
+      },
+      {
+        "id": "school_info",
+        "title": "School Information",
+        "sections": [
+          {
+            "id": "school",
+            "title": "Current School Details",
+            "fields": [
+              {
+                "id": "school_name",
+                "label": "School Name",
+                "type": "text"
+              },
+              {
+                "id": "grade",
+                "label": "Current Grade",
+                "type": "text"
+              },
+              {
+                "id": "school_type",
+                "label": "School Type",
+                "type": "select",
+                "ui": {
+                  "options": [
+                    "Public",
+                    "Private",
+                    "Charter",
+                    "Home School"
+                  ]
+                }
+              }
+            ]
+          }
+        ]
+      },
+      {
+        "id": "education_work_status",
+        "title": "Part III: Applicant’s Education/Work Status",
+        "sections": [
+          {
+            "id": "education_status",
+            "title": "Education Status",
+            "fields": [
+              {
+                "id": "education_status",
+                "label": "Applicant’s Education Status",
+                "type": "select",
+                "required": true,
+                "ui": {
+                  "options": [
+                    "Full-Time Student",
+                    "Part-Time Student",
+                    "Not in School"
+                  ]
+                }
+              },
+              {
+                "id": "grade_level_category",
+                "label": "Select Grade Level Category",
+                "type": "radio",
+                "required": true,
+                "ui": {
+                  "options": [
+                    "Elementary School",
+                    "Middle School",
+                    "High School",
+                    "Community College",
+                    "College/University",
+                    "Other"
+                  ]
+                }
+              },
+              {
+                "id": "grade_elem",
+                "label": "Select Specific Grade (Elementary School)",
+                "type": "select",
+                "requiredCondition": {
+                  "field": "grade_level_category",
+                  "operator": "equals",
+                  "value": "Elementary School"
+                },
+                "ui": {
+                  "options": [
+                    "Pre-K",
+                    "K",
+                    "1st",
+                    "2nd",
+                    "3rd",
+                    "4th",
+                    "5th"
+                  ]
+                }
+              },
+              {
+                "id": "grade_middle",
+                "label": "Select Specific Grade (Middle School)",
+                "type": "select",
+                "requiredCondition": {
+                  "field": "grade_level_category",
+                  "operator": "equals",
+                  "value": "Middle School"
+                },
+                "ui": {
+                  "options": [
+                    "6th",
+                    "7th",
+                    "8th"
+                  ]
+                }
+              },
+              {
+                "id": "grade_high",
+                "label": "Select Specific Grade (High School)",
+                "type": "select",
+                "requiredCondition": {
+                  "field": "grade_level_category",
+                  "operator": "equals",
+                  "value": "High School"
+                },
+                "ui": {
+                  "options": [
+                    "9th",
+                    "10th",
+                    "11th",
+                    "12th",
+                    "High School Diploma",
+                    "High School Equivalency"
+                  ]
+                }
+              },
+              {
+                "id": "grade_cc",
+                "label": "Select Specific Grade (Community College)",
+                "type": "select",
+                "requiredCondition": {
+                  "field": "grade_level_category",
+                  "operator": "equals",
+                  "value": "Community College"
+                },
+                "ui": {
+                  "options": [
+                    "1st Year",
+                    "2nd Year",
+                    "3rd Year",
+                    "Associate’s Degree"
+                  ]
+                }
+              },
+              {
+                "id": "grade_university",
+                "label": "Select Specific Grade (College/University)",
+                "type": "select",
+                "requiredCondition": {
+                  "field": "grade_level_category",
+                  "operator": "equals",
+                  "value": "College/University"
+                },
+                "ui": {
+                  "options": [
+                    "Freshman",
+                    "Sophomore",
+                    "Junior",
+                    "Senior",
+                    "Bachelor’s Degree",
+                    "Some Master’s",
+                    "Master’s Degree",
+                    "Some Doctorate",
+                    "Doctorate Degree"
+                  ]
+                }
+              },
+              {
+                "id": "grade_other",
+                "label": "Select Specific Grade (Other)",
+                "type": "select",
+                "requiredCondition": {
+                  "field": "grade_level_category",
+                  "operator": "equals",
+                  "value": "Other"
+                },
+                "ui": {
+                  "options": [
+                    "Foreign Degree",
+                    "No Formal Schooling"
+                  ]
+                }
+              }
+            ]
+          },
+          {
+            "id": "work_status",
+            "title": "Work Status",
+            "fields": [
+              {
+                "id": "work_status",
+                "label": "Applicant’s Current Work Status",
+                "type": "select",
+                "required": true,
+                "ui": {
+                  "options": [
+                    "Employed Full-Time",
+                    "Employed Part-Time",
+                    "Retired",
+                    "Unemployed (Short-Term ≤ 6 mo)",
+                    "Unemployed (Long-Term > 6 mo)",
+                    "Unemployed (Not in labor force)",
+                    "Migrant Seasonal Farm Worker",
+                    "Not applicable (under 14)"
+                  ]
+                }
+              }
+            ]
+          },
+          {
+            "id": "ft_student_info",
+            "title": "Full-Time Student Info",
+            "fields": [
+              {
+                "id": "student_id",
+                "label": "Student ID / OSIS",
+                "type": "text",
+                "requiredCondition": {
+                  "field": "education_status",
+                  "operator": "equals",
+                  "value": "Full-Time Student"
+                }
+              },
+              {
+                "id": "student_school_type",
+                "label": "School Type",
+                "type": "select",
+                "requiredCondition": {
+                  "field": "education_status",
+                  "operator": "equals",
+                  "value": "Full-Time Student"
+                },
+                "ui": {
+                  "options": [
+                    "Public",
+                    "Charter",
+                    "Private",
+                    "Other"
+                  ]
+                }
+              },
+              {
+                "id": "student_school_type_other",
+                "label": "If Other, please specify school type",
+                "type": "text",
+                "requiredCondition": {
+                  "field": "student_school_type",
+                  "operator": "equals",
+                  "value": "Other"
+                }
+              },
+              {
+                "id": "student_school_name",
+                "label": "School Name",
+                "type": "text",
+                "requiredCondition": {
+                  "field": "education_status",
+                  "operator": "equals",
+                  "value": "Full-Time Student"
+                }
+              },
+              {
+                "id": "student_school_address",
+                "label": "School Address",
+                "type": "text",
+                "requiredCondition": {
+                  "field": "education_status",
+                  "operator": "equals",
+                  "value": "Full-Time Student"
+                }
+              },
+              {
+                "id": "student_school_city",
+                "label": "School City",
+                "type": "text",
+                "requiredCondition": {
+                  "field": "education_status",
+                  "operator": "equals",
+                  "value": "Full-Time Student"
+                }
+              },
+              {
+                "id": "student_school_state",
+                "label": "School State",
+                "type": "text",
+                "requiredCondition": {
+                  "field": "education_status",
+                  "operator": "equals",
+                  "value": "Full-Time Student"
+                }
+              },
+              {
+                "id": "student_school_zip",
+                "label": "School Zip Code",
+                "type": "text",
+                "requiredCondition": {
+                  "field": "education_status",
+                  "operator": "equals",
+                  "value": "Full-Time Student"
+                }
+              }
+            ]
+          }
+        ]
+      },
+      {
+        "id": "household_info",
+        "title": "Part VI: Household Information",
+        "sections": [
+          {
+            "id": "household_composition",
+            "title": "Household Composition",
+            "fields": [
+              {
+                "id": "head_of_household",
+                "label": "Is the parent/guardian the head of household?",
+                "type": "radio",
+                "required": true,
+                "ui": {
+                  "options": [
+                    "Yes",
+                    "No"
+                  ]
+                }
+              },
+              {
+                "id": "household_income_source",
+                "label": "Primary Source of Household Income",
+                "type": "radio",
+                "required": true,
+                "ui": {
+                  "options": [
+                    "Employment",
+                    "Public Assistance",
+                    "Social Security",
+                    "Pension",
+                    "No Income",
+                    "Other"
+                  ]
+                }
+              },
+              {
+                "id": "household_income_source_other",
+                "label": "Specify Other Income Source",
+                "type": "text",
+                "requiredCondition": {
+                  "field": "household_income_source",
+                  "operator": "equals",
+                  "value": "Other"
+                },
+                "visibleCondition": {
+                  "field": "household_income_source",
+                  "operator": "equals",
+                  "value": "Other"
+                }
+              },
+              {
+                "id": "housing_type",
+                "label": "Type of Housing",
+                "type": "radio",
+                "required": true,
+                "ui": {
+                  "options": [
+                    "NYCHA",
+                    "Shelter",
+                    "Own Home",
+                    "Rental",
+                    "Supportive Housing",
+                    "Other"
+                  ]
+                }
+              },
+              {
+                "id": "housing_type_other",
+                "label": "Specify Other Housing Type",
+                "type": "text",
+                "requiredCondition": {
+                  "field": "housing_type",
+                  "operator": "equals",
+                  "value": "Other"
+                },
+                "visibleCondition": {
+                  "field": "housing_type",
+                  "operator": "equals",
+                  "value": "Other"
+                }
+              },
+              {
+                "id": "household_size",
+                "label": "Number of People in Household",
+                "type": "number",
+                "required": true,
+                "ui": {
+                  "min": 1
+                }
+              }
+            ]
+          }
+        ]
+      },
+      {
+        "id": "medical_info",
+        "title": "Medical & Emergency",
+        "sections": [
+          {
+            "id": "emergency",
+            "title": "Emergency Contact",
+            "fields": [
+              {
+                "id": "emergency_name",
+                "label": "Emergency Contact Name",
+                "type": "text"
+              },
+              {
+                "id": "emergency_phone",
+                "label": "Emergency Contact Phone",
+                "type": "tel"
+              }
+            ]
+          },
+          {
+            "id": "medical",
+            "title": "Medical Info",
+            "fields": [
+              {
+                "id": "medical_conditions",
+                "label": "Medical Conditions",
+                "type": "text"
+              },
+              {
+                "id": "medications",
+                "label": "Medications",
+                "type": "text"
+              },
+              {
+                "id": "allergies",
+                "label": "Allergies",
+                "type": "text"
+              }
+            ]
+          }
+        ]
+      },
+      {
+        "id": "consent",
+        "title": "Consent & Signature",
+        "sections": [
+          {
+            "id": "consent_info",
+            "title": "Authorization",
+            "fields": [
+              {
+                "id": "media_consent",
+                "label": "Media Release Consent",
+                "type": "checkbox"
+              },
+              {
+                "id": "signature",
+                "label": "Parent/Guardian Signature",
+                "type": "text",
+                "required": true
+              },
+              {
+                "id": "date_signed",
+                "label": "Date Signed",
+                "type": "date",
+                "required": true
+              }
+            ]
+          }
+        ]
+      },
+      {
+        "id": "review",
+        "title": "Review & Submit",
+        "type": "review",
+        "sections": []
+      }
+    ]
+  }
+}

--- a/test-form/public/data/dycd_form.ur.json
+++ b/test-form/public/data/dycd_form.ur.json
@@ -1,0 +1,574 @@
+{
+  "form": {
+    "title": "DYCD Youth Services Intake – Ages 13 and Younger",
+    "description": "Form to collect youth and guardian information for DYCD programs",
+    "steps": [
+      {
+        "id": "demographics",
+        "title": "Youth Information",
+        "sections": [
+          {
+            "id": "youth_info",
+            "title": "Basic Information",
+            "fields": [
+              {
+                "id": "first_name",
+                "label": "First Name",
+                "type": "text",
+                "required": true
+              },
+              {
+                "id": "last_name",
+                "label": "Last Name",
+                "type": "text",
+                "required": true
+              },
+              {
+                "id": "dob",
+                "label": "Date of Birth",
+                "type": "date",
+                "required": true
+              },
+              {
+                "id": "gender",
+                "label": "Gender",
+                "type": "select",
+                "ui": {
+                  "options": [
+                    "Male",
+                    "Female",
+                    "Non-binary",
+                    "Other"
+                  ]
+                },
+                "required": true
+              },
+              {
+                "id": "ethnicity",
+                "label": "Ethnicity",
+                "type": "text"
+              }
+            ]
+          }
+        ]
+      },
+      {
+        "id": "guardian_info",
+        "title": "Parent/Guardian Info",
+        "sections": [
+          {
+            "id": "guardian_contact",
+            "title": "Contact Details",
+            "fields": [
+              {
+                "id": "guardian_name",
+                "label": "Name of Parent/Guardian",
+                "type": "text",
+                "required": true
+              },
+              {
+                "id": "phone",
+                "label": "Phone Number",
+                "type": "tel",
+                "required": true
+              },
+              {
+                "id": "email",
+                "label": "Email Address",
+                "type": "email"
+              },
+              {
+                "id": "relationship",
+                "label": "Relationship to Youth",
+                "type": "text",
+                "required": true
+              }
+            ]
+          }
+        ]
+      },
+      {
+        "id": "school_info",
+        "title": "School Information",
+        "sections": [
+          {
+            "id": "school",
+            "title": "Current School Details",
+            "fields": [
+              {
+                "id": "school_name",
+                "label": "School Name",
+                "type": "text"
+              },
+              {
+                "id": "grade",
+                "label": "Current Grade",
+                "type": "text"
+              },
+              {
+                "id": "school_type",
+                "label": "School Type",
+                "type": "select",
+                "ui": {
+                  "options": [
+                    "Public",
+                    "Private",
+                    "Charter",
+                    "Home School"
+                  ]
+                }
+              }
+            ]
+          }
+        ]
+      },
+      {
+        "id": "education_work_status",
+        "title": "Part III: Applicant’s Education/Work Status",
+        "sections": [
+          {
+            "id": "education_status",
+            "title": "Education Status",
+            "fields": [
+              {
+                "id": "education_status",
+                "label": "Applicant’s Education Status",
+                "type": "select",
+                "required": true,
+                "ui": {
+                  "options": [
+                    "Full-Time Student",
+                    "Part-Time Student",
+                    "Not in School"
+                  ]
+                }
+              },
+              {
+                "id": "grade_level_category",
+                "label": "Select Grade Level Category",
+                "type": "radio",
+                "required": true,
+                "ui": {
+                  "options": [
+                    "Elementary School",
+                    "Middle School",
+                    "High School",
+                    "Community College",
+                    "College/University",
+                    "Other"
+                  ]
+                }
+              },
+              {
+                "id": "grade_elem",
+                "label": "Select Specific Grade (Elementary School)",
+                "type": "select",
+                "requiredCondition": {
+                  "field": "grade_level_category",
+                  "operator": "equals",
+                  "value": "Elementary School"
+                },
+                "ui": {
+                  "options": [
+                    "Pre-K",
+                    "K",
+                    "1st",
+                    "2nd",
+                    "3rd",
+                    "4th",
+                    "5th"
+                  ]
+                }
+              },
+              {
+                "id": "grade_middle",
+                "label": "Select Specific Grade (Middle School)",
+                "type": "select",
+                "requiredCondition": {
+                  "field": "grade_level_category",
+                  "operator": "equals",
+                  "value": "Middle School"
+                },
+                "ui": {
+                  "options": [
+                    "6th",
+                    "7th",
+                    "8th"
+                  ]
+                }
+              },
+              {
+                "id": "grade_high",
+                "label": "Select Specific Grade (High School)",
+                "type": "select",
+                "requiredCondition": {
+                  "field": "grade_level_category",
+                  "operator": "equals",
+                  "value": "High School"
+                },
+                "ui": {
+                  "options": [
+                    "9th",
+                    "10th",
+                    "11th",
+                    "12th",
+                    "High School Diploma",
+                    "High School Equivalency"
+                  ]
+                }
+              },
+              {
+                "id": "grade_cc",
+                "label": "Select Specific Grade (Community College)",
+                "type": "select",
+                "requiredCondition": {
+                  "field": "grade_level_category",
+                  "operator": "equals",
+                  "value": "Community College"
+                },
+                "ui": {
+                  "options": [
+                    "1st Year",
+                    "2nd Year",
+                    "3rd Year",
+                    "Associate’s Degree"
+                  ]
+                }
+              },
+              {
+                "id": "grade_university",
+                "label": "Select Specific Grade (College/University)",
+                "type": "select",
+                "requiredCondition": {
+                  "field": "grade_level_category",
+                  "operator": "equals",
+                  "value": "College/University"
+                },
+                "ui": {
+                  "options": [
+                    "Freshman",
+                    "Sophomore",
+                    "Junior",
+                    "Senior",
+                    "Bachelor’s Degree",
+                    "Some Master’s",
+                    "Master’s Degree",
+                    "Some Doctorate",
+                    "Doctorate Degree"
+                  ]
+                }
+              },
+              {
+                "id": "grade_other",
+                "label": "Select Specific Grade (Other)",
+                "type": "select",
+                "requiredCondition": {
+                  "field": "grade_level_category",
+                  "operator": "equals",
+                  "value": "Other"
+                },
+                "ui": {
+                  "options": [
+                    "Foreign Degree",
+                    "No Formal Schooling"
+                  ]
+                }
+              }
+            ]
+          },
+          {
+            "id": "work_status",
+            "title": "Work Status",
+            "fields": [
+              {
+                "id": "work_status",
+                "label": "Applicant’s Current Work Status",
+                "type": "select",
+                "required": true,
+                "ui": {
+                  "options": [
+                    "Employed Full-Time",
+                    "Employed Part-Time",
+                    "Retired",
+                    "Unemployed (Short-Term ≤ 6 mo)",
+                    "Unemployed (Long-Term > 6 mo)",
+                    "Unemployed (Not in labor force)",
+                    "Migrant Seasonal Farm Worker",
+                    "Not applicable (under 14)"
+                  ]
+                }
+              }
+            ]
+          },
+          {
+            "id": "ft_student_info",
+            "title": "Full-Time Student Info",
+            "fields": [
+              {
+                "id": "student_id",
+                "label": "Student ID / OSIS",
+                "type": "text",
+                "requiredCondition": {
+                  "field": "education_status",
+                  "operator": "equals",
+                  "value": "Full-Time Student"
+                }
+              },
+              {
+                "id": "student_school_type",
+                "label": "School Type",
+                "type": "select",
+                "requiredCondition": {
+                  "field": "education_status",
+                  "operator": "equals",
+                  "value": "Full-Time Student"
+                },
+                "ui": {
+                  "options": [
+                    "Public",
+                    "Charter",
+                    "Private",
+                    "Other"
+                  ]
+                }
+              },
+              {
+                "id": "student_school_type_other",
+                "label": "If Other, please specify school type",
+                "type": "text",
+                "requiredCondition": {
+                  "field": "student_school_type",
+                  "operator": "equals",
+                  "value": "Other"
+                }
+              },
+              {
+                "id": "student_school_name",
+                "label": "School Name",
+                "type": "text",
+                "requiredCondition": {
+                  "field": "education_status",
+                  "operator": "equals",
+                  "value": "Full-Time Student"
+                }
+              },
+              {
+                "id": "student_school_address",
+                "label": "School Address",
+                "type": "text",
+                "requiredCondition": {
+                  "field": "education_status",
+                  "operator": "equals",
+                  "value": "Full-Time Student"
+                }
+              },
+              {
+                "id": "student_school_city",
+                "label": "School City",
+                "type": "text",
+                "requiredCondition": {
+                  "field": "education_status",
+                  "operator": "equals",
+                  "value": "Full-Time Student"
+                }
+              },
+              {
+                "id": "student_school_state",
+                "label": "School State",
+                "type": "text",
+                "requiredCondition": {
+                  "field": "education_status",
+                  "operator": "equals",
+                  "value": "Full-Time Student"
+                }
+              },
+              {
+                "id": "student_school_zip",
+                "label": "School Zip Code",
+                "type": "text",
+                "requiredCondition": {
+                  "field": "education_status",
+                  "operator": "equals",
+                  "value": "Full-Time Student"
+                }
+              }
+            ]
+          }
+        ]
+      },
+      {
+        "id": "household_info",
+        "title": "Part VI: Household Information",
+        "sections": [
+          {
+            "id": "household_composition",
+            "title": "Household Composition",
+            "fields": [
+              {
+                "id": "head_of_household",
+                "label": "Is the parent/guardian the head of household?",
+                "type": "radio",
+                "required": true,
+                "ui": {
+                  "options": [
+                    "Yes",
+                    "No"
+                  ]
+                }
+              },
+              {
+                "id": "household_income_source",
+                "label": "Primary Source of Household Income",
+                "type": "radio",
+                "required": true,
+                "ui": {
+                  "options": [
+                    "Employment",
+                    "Public Assistance",
+                    "Social Security",
+                    "Pension",
+                    "No Income",
+                    "Other"
+                  ]
+                }
+              },
+              {
+                "id": "household_income_source_other",
+                "label": "Specify Other Income Source",
+                "type": "text",
+                "requiredCondition": {
+                  "field": "household_income_source",
+                  "operator": "equals",
+                  "value": "Other"
+                },
+                "visibleCondition": {
+                  "field": "household_income_source",
+                  "operator": "equals",
+                  "value": "Other"
+                }
+              },
+              {
+                "id": "housing_type",
+                "label": "Type of Housing",
+                "type": "radio",
+                "required": true,
+                "ui": {
+                  "options": [
+                    "NYCHA",
+                    "Shelter",
+                    "Own Home",
+                    "Rental",
+                    "Supportive Housing",
+                    "Other"
+                  ]
+                }
+              },
+              {
+                "id": "housing_type_other",
+                "label": "Specify Other Housing Type",
+                "type": "text",
+                "requiredCondition": {
+                  "field": "housing_type",
+                  "operator": "equals",
+                  "value": "Other"
+                },
+                "visibleCondition": {
+                  "field": "housing_type",
+                  "operator": "equals",
+                  "value": "Other"
+                }
+              },
+              {
+                "id": "household_size",
+                "label": "Number of People in Household",
+                "type": "number",
+                "required": true,
+                "ui": {
+                  "min": 1
+                }
+              }
+            ]
+          }
+        ]
+      },
+      {
+        "id": "medical_info",
+        "title": "Medical & Emergency",
+        "sections": [
+          {
+            "id": "emergency",
+            "title": "Emergency Contact",
+            "fields": [
+              {
+                "id": "emergency_name",
+                "label": "Emergency Contact Name",
+                "type": "text"
+              },
+              {
+                "id": "emergency_phone",
+                "label": "Emergency Contact Phone",
+                "type": "tel"
+              }
+            ]
+          },
+          {
+            "id": "medical",
+            "title": "Medical Info",
+            "fields": [
+              {
+                "id": "medical_conditions",
+                "label": "Medical Conditions",
+                "type": "text"
+              },
+              {
+                "id": "medications",
+                "label": "Medications",
+                "type": "text"
+              },
+              {
+                "id": "allergies",
+                "label": "Allergies",
+                "type": "text"
+              }
+            ]
+          }
+        ]
+      },
+      {
+        "id": "consent",
+        "title": "Consent & Signature",
+        "sections": [
+          {
+            "id": "consent_info",
+            "title": "Authorization",
+            "fields": [
+              {
+                "id": "media_consent",
+                "label": "Media Release Consent",
+                "type": "checkbox"
+              },
+              {
+                "id": "signature",
+                "label": "Parent/Guardian Signature",
+                "type": "text",
+                "required": true
+              },
+              {
+                "id": "date_signed",
+                "label": "Date Signed",
+                "type": "date",
+                "required": true
+              }
+            ]
+          }
+        ]
+      },
+      {
+        "id": "review",
+        "title": "Review & Submit",
+        "type": "review",
+        "sections": []
+      }
+    ]
+  }
+}

--- a/test-form/public/data/dycd_form.zh.json
+++ b/test-form/public/data/dycd_form.zh.json
@@ -1,0 +1,574 @@
+{
+  "form": {
+    "title": "DYCD Youth Services Intake – Ages 13 and Younger",
+    "description": "Form to collect youth and guardian information for DYCD programs",
+    "steps": [
+      {
+        "id": "demographics",
+        "title": "Youth Information",
+        "sections": [
+          {
+            "id": "youth_info",
+            "title": "Basic Information",
+            "fields": [
+              {
+                "id": "first_name",
+                "label": "First Name",
+                "type": "text",
+                "required": true
+              },
+              {
+                "id": "last_name",
+                "label": "Last Name",
+                "type": "text",
+                "required": true
+              },
+              {
+                "id": "dob",
+                "label": "Date of Birth",
+                "type": "date",
+                "required": true
+              },
+              {
+                "id": "gender",
+                "label": "Gender",
+                "type": "select",
+                "ui": {
+                  "options": [
+                    "Male",
+                    "Female",
+                    "Non-binary",
+                    "Other"
+                  ]
+                },
+                "required": true
+              },
+              {
+                "id": "ethnicity",
+                "label": "Ethnicity",
+                "type": "text"
+              }
+            ]
+          }
+        ]
+      },
+      {
+        "id": "guardian_info",
+        "title": "Parent/Guardian Info",
+        "sections": [
+          {
+            "id": "guardian_contact",
+            "title": "Contact Details",
+            "fields": [
+              {
+                "id": "guardian_name",
+                "label": "Name of Parent/Guardian",
+                "type": "text",
+                "required": true
+              },
+              {
+                "id": "phone",
+                "label": "Phone Number",
+                "type": "tel",
+                "required": true
+              },
+              {
+                "id": "email",
+                "label": "Email Address",
+                "type": "email"
+              },
+              {
+                "id": "relationship",
+                "label": "Relationship to Youth",
+                "type": "text",
+                "required": true
+              }
+            ]
+          }
+        ]
+      },
+      {
+        "id": "school_info",
+        "title": "School Information",
+        "sections": [
+          {
+            "id": "school",
+            "title": "Current School Details",
+            "fields": [
+              {
+                "id": "school_name",
+                "label": "School Name",
+                "type": "text"
+              },
+              {
+                "id": "grade",
+                "label": "Current Grade",
+                "type": "text"
+              },
+              {
+                "id": "school_type",
+                "label": "School Type",
+                "type": "select",
+                "ui": {
+                  "options": [
+                    "Public",
+                    "Private",
+                    "Charter",
+                    "Home School"
+                  ]
+                }
+              }
+            ]
+          }
+        ]
+      },
+      {
+        "id": "education_work_status",
+        "title": "Part III: Applicant’s Education/Work Status",
+        "sections": [
+          {
+            "id": "education_status",
+            "title": "Education Status",
+            "fields": [
+              {
+                "id": "education_status",
+                "label": "Applicant’s Education Status",
+                "type": "select",
+                "required": true,
+                "ui": {
+                  "options": [
+                    "Full-Time Student",
+                    "Part-Time Student",
+                    "Not in School"
+                  ]
+                }
+              },
+              {
+                "id": "grade_level_category",
+                "label": "Select Grade Level Category",
+                "type": "radio",
+                "required": true,
+                "ui": {
+                  "options": [
+                    "Elementary School",
+                    "Middle School",
+                    "High School",
+                    "Community College",
+                    "College/University",
+                    "Other"
+                  ]
+                }
+              },
+              {
+                "id": "grade_elem",
+                "label": "Select Specific Grade (Elementary School)",
+                "type": "select",
+                "requiredCondition": {
+                  "field": "grade_level_category",
+                  "operator": "equals",
+                  "value": "Elementary School"
+                },
+                "ui": {
+                  "options": [
+                    "Pre-K",
+                    "K",
+                    "1st",
+                    "2nd",
+                    "3rd",
+                    "4th",
+                    "5th"
+                  ]
+                }
+              },
+              {
+                "id": "grade_middle",
+                "label": "Select Specific Grade (Middle School)",
+                "type": "select",
+                "requiredCondition": {
+                  "field": "grade_level_category",
+                  "operator": "equals",
+                  "value": "Middle School"
+                },
+                "ui": {
+                  "options": [
+                    "6th",
+                    "7th",
+                    "8th"
+                  ]
+                }
+              },
+              {
+                "id": "grade_high",
+                "label": "Select Specific Grade (High School)",
+                "type": "select",
+                "requiredCondition": {
+                  "field": "grade_level_category",
+                  "operator": "equals",
+                  "value": "High School"
+                },
+                "ui": {
+                  "options": [
+                    "9th",
+                    "10th",
+                    "11th",
+                    "12th",
+                    "High School Diploma",
+                    "High School Equivalency"
+                  ]
+                }
+              },
+              {
+                "id": "grade_cc",
+                "label": "Select Specific Grade (Community College)",
+                "type": "select",
+                "requiredCondition": {
+                  "field": "grade_level_category",
+                  "operator": "equals",
+                  "value": "Community College"
+                },
+                "ui": {
+                  "options": [
+                    "1st Year",
+                    "2nd Year",
+                    "3rd Year",
+                    "Associate’s Degree"
+                  ]
+                }
+              },
+              {
+                "id": "grade_university",
+                "label": "Select Specific Grade (College/University)",
+                "type": "select",
+                "requiredCondition": {
+                  "field": "grade_level_category",
+                  "operator": "equals",
+                  "value": "College/University"
+                },
+                "ui": {
+                  "options": [
+                    "Freshman",
+                    "Sophomore",
+                    "Junior",
+                    "Senior",
+                    "Bachelor’s Degree",
+                    "Some Master’s",
+                    "Master’s Degree",
+                    "Some Doctorate",
+                    "Doctorate Degree"
+                  ]
+                }
+              },
+              {
+                "id": "grade_other",
+                "label": "Select Specific Grade (Other)",
+                "type": "select",
+                "requiredCondition": {
+                  "field": "grade_level_category",
+                  "operator": "equals",
+                  "value": "Other"
+                },
+                "ui": {
+                  "options": [
+                    "Foreign Degree",
+                    "No Formal Schooling"
+                  ]
+                }
+              }
+            ]
+          },
+          {
+            "id": "work_status",
+            "title": "Work Status",
+            "fields": [
+              {
+                "id": "work_status",
+                "label": "Applicant’s Current Work Status",
+                "type": "select",
+                "required": true,
+                "ui": {
+                  "options": [
+                    "Employed Full-Time",
+                    "Employed Part-Time",
+                    "Retired",
+                    "Unemployed (Short-Term ≤ 6 mo)",
+                    "Unemployed (Long-Term > 6 mo)",
+                    "Unemployed (Not in labor force)",
+                    "Migrant Seasonal Farm Worker",
+                    "Not applicable (under 14)"
+                  ]
+                }
+              }
+            ]
+          },
+          {
+            "id": "ft_student_info",
+            "title": "Full-Time Student Info",
+            "fields": [
+              {
+                "id": "student_id",
+                "label": "Student ID / OSIS",
+                "type": "text",
+                "requiredCondition": {
+                  "field": "education_status",
+                  "operator": "equals",
+                  "value": "Full-Time Student"
+                }
+              },
+              {
+                "id": "student_school_type",
+                "label": "School Type",
+                "type": "select",
+                "requiredCondition": {
+                  "field": "education_status",
+                  "operator": "equals",
+                  "value": "Full-Time Student"
+                },
+                "ui": {
+                  "options": [
+                    "Public",
+                    "Charter",
+                    "Private",
+                    "Other"
+                  ]
+                }
+              },
+              {
+                "id": "student_school_type_other",
+                "label": "If Other, please specify school type",
+                "type": "text",
+                "requiredCondition": {
+                  "field": "student_school_type",
+                  "operator": "equals",
+                  "value": "Other"
+                }
+              },
+              {
+                "id": "student_school_name",
+                "label": "School Name",
+                "type": "text",
+                "requiredCondition": {
+                  "field": "education_status",
+                  "operator": "equals",
+                  "value": "Full-Time Student"
+                }
+              },
+              {
+                "id": "student_school_address",
+                "label": "School Address",
+                "type": "text",
+                "requiredCondition": {
+                  "field": "education_status",
+                  "operator": "equals",
+                  "value": "Full-Time Student"
+                }
+              },
+              {
+                "id": "student_school_city",
+                "label": "School City",
+                "type": "text",
+                "requiredCondition": {
+                  "field": "education_status",
+                  "operator": "equals",
+                  "value": "Full-Time Student"
+                }
+              },
+              {
+                "id": "student_school_state",
+                "label": "School State",
+                "type": "text",
+                "requiredCondition": {
+                  "field": "education_status",
+                  "operator": "equals",
+                  "value": "Full-Time Student"
+                }
+              },
+              {
+                "id": "student_school_zip",
+                "label": "School Zip Code",
+                "type": "text",
+                "requiredCondition": {
+                  "field": "education_status",
+                  "operator": "equals",
+                  "value": "Full-Time Student"
+                }
+              }
+            ]
+          }
+        ]
+      },
+      {
+        "id": "household_info",
+        "title": "Part VI: Household Information",
+        "sections": [
+          {
+            "id": "household_composition",
+            "title": "Household Composition",
+            "fields": [
+              {
+                "id": "head_of_household",
+                "label": "Is the parent/guardian the head of household?",
+                "type": "radio",
+                "required": true,
+                "ui": {
+                  "options": [
+                    "Yes",
+                    "No"
+                  ]
+                }
+              },
+              {
+                "id": "household_income_source",
+                "label": "Primary Source of Household Income",
+                "type": "radio",
+                "required": true,
+                "ui": {
+                  "options": [
+                    "Employment",
+                    "Public Assistance",
+                    "Social Security",
+                    "Pension",
+                    "No Income",
+                    "Other"
+                  ]
+                }
+              },
+              {
+                "id": "household_income_source_other",
+                "label": "Specify Other Income Source",
+                "type": "text",
+                "requiredCondition": {
+                  "field": "household_income_source",
+                  "operator": "equals",
+                  "value": "Other"
+                },
+                "visibleCondition": {
+                  "field": "household_income_source",
+                  "operator": "equals",
+                  "value": "Other"
+                }
+              },
+              {
+                "id": "housing_type",
+                "label": "Type of Housing",
+                "type": "radio",
+                "required": true,
+                "ui": {
+                  "options": [
+                    "NYCHA",
+                    "Shelter",
+                    "Own Home",
+                    "Rental",
+                    "Supportive Housing",
+                    "Other"
+                  ]
+                }
+              },
+              {
+                "id": "housing_type_other",
+                "label": "Specify Other Housing Type",
+                "type": "text",
+                "requiredCondition": {
+                  "field": "housing_type",
+                  "operator": "equals",
+                  "value": "Other"
+                },
+                "visibleCondition": {
+                  "field": "housing_type",
+                  "operator": "equals",
+                  "value": "Other"
+                }
+              },
+              {
+                "id": "household_size",
+                "label": "Number of People in Household",
+                "type": "number",
+                "required": true,
+                "ui": {
+                  "min": 1
+                }
+              }
+            ]
+          }
+        ]
+      },
+      {
+        "id": "medical_info",
+        "title": "Medical & Emergency",
+        "sections": [
+          {
+            "id": "emergency",
+            "title": "Emergency Contact",
+            "fields": [
+              {
+                "id": "emergency_name",
+                "label": "Emergency Contact Name",
+                "type": "text"
+              },
+              {
+                "id": "emergency_phone",
+                "label": "Emergency Contact Phone",
+                "type": "tel"
+              }
+            ]
+          },
+          {
+            "id": "medical",
+            "title": "Medical Info",
+            "fields": [
+              {
+                "id": "medical_conditions",
+                "label": "Medical Conditions",
+                "type": "text"
+              },
+              {
+                "id": "medications",
+                "label": "Medications",
+                "type": "text"
+              },
+              {
+                "id": "allergies",
+                "label": "Allergies",
+                "type": "text"
+              }
+            ]
+          }
+        ]
+      },
+      {
+        "id": "consent",
+        "title": "Consent & Signature",
+        "sections": [
+          {
+            "id": "consent_info",
+            "title": "Authorization",
+            "fields": [
+              {
+                "id": "media_consent",
+                "label": "Media Release Consent",
+                "type": "checkbox"
+              },
+              {
+                "id": "signature",
+                "label": "Parent/Guardian Signature",
+                "type": "text",
+                "required": true
+              },
+              {
+                "id": "date_signed",
+                "label": "Date Signed",
+                "type": "date",
+                "required": true
+              }
+            ]
+          }
+        ]
+      },
+      {
+        "id": "review",
+        "title": "Review & Submit",
+        "type": "review",
+        "sections": []
+      }
+    ]
+  }
+}

--- a/test-form/public/data/group_cc_permit.ar.json
+++ b/test-form/public/data/group_cc_permit.ar.json
@@ -1,0 +1,788 @@
+{
+  "form": {
+    "title": "Group Child Care Permit Application",
+    "description": "Multi-step application for obtaining a permit to operate group child care programs.",
+    "layout": {
+      "stepperPosition": "left"
+    },
+    "steps": [
+      {
+        "id": "establishment_information",
+        "title": "Establishment Information",
+        "sections": [
+          {
+            "id": "establishment_address",
+            "title": "Establishment Address",
+            "description": "Enter the physical address where business will operate. If you are applying for a Tattoo License, enter your mailing or home address.",
+            "ui": {
+              "autocomplete": "street_1",
+              "placeholder": "Start typing your street address",
+              "overrideComponent": "AddressAutocomplete"
+            },
+            "metadata": {
+              "integration": {
+                "provider": "Google",
+                "feature": "AddressAutocomplete"
+              },
+              "autofillTargets": [
+                {
+                  "fieldId": "city",
+                  "source": "locality",
+                  "fallbackSources": [
+                    "postal_town",
+                    "sublocality_level_1",
+                    "administrative_area_level_2"
+                  ]
+                },
+                {
+                  "fieldId": "borough",
+                  "source": "sublocality_level_1",
+                  "fallbackSources": [
+                    "administrative_area_level_2"
+                  ],
+                  "mapping": "boroughMap"
+                },
+                { "fieldId": "state", "source": "administrative_area_level_1" },
+                { "fieldId": "building_number", "source": "street_number" },
+                { "fieldId": "house_number", "source": "street_number" }
+              ]
+            },
+            "fields": [
+              {
+                "id": "address_type",
+                "label": "Address Type",
+                "type": "select",
+                "required": true,
+                "ui": {
+                  "options": [
+                    "Select",
+                    "Complete Address",
+                    "Cross Street (Intersection)",
+                    "Place (Landmark)"
+                  ]
+                }
+              },
+              {
+                "id": "street_1",
+                "label": "Street 1",
+                "type": "text",
+                "required": true
+              },
+              {
+                "id": "building_number",
+                "label": "Building #",
+                "type": "text",
+                "required": true
+              },
+              {
+                "id": "street_2",
+                "label": "Street 2",
+                "type": "text",
+                "required": false
+              },
+              {
+                "id": "unit_type",
+                "label": "Unit Type",
+                "type": "select",
+                "required": false,
+                "ui": {
+                  "options": [
+                    "LBBY",
+                    "APT",
+                    "BLDG",
+                    "STE",
+                    "FL",
+                    "BSMT",
+                    "FRNT",
+                    "SIDE",
+                    "REAR",
+                    "UPPR",
+                    "LOWR",
+                    "PIER"
+                  ]
+                }
+              },
+              {
+                "id": "unit",
+                "label": "Unit",
+                "type": "text",
+                "required": false
+              },
+              {
+                "id": "city",
+                "label": "City",
+                "type": "text",
+                "required": true
+              },
+              {
+                "id": "state",
+                "label": "State",
+                "type": "text",
+                "required": true
+              },
+              {
+                "id": "borough",
+                "label": "Borough",
+                "type": "select",
+                "required": true,
+                "ui": {
+                  "options": [
+                    "Bronx",
+                    "Brooklyn",
+                    "Manhattan",
+                    "Queens",
+                    "Staten Island"
+                  ]
+                }
+              },
+              {
+                "id": "bin",
+                "label": "Bin",
+                "type": "text",
+                "required": false,
+                "metadata": {
+                  "source": "Geoclient API"
+                }
+              },
+              {
+                "id": "bbl",
+                "label": "Bbl",
+                "type": "text",
+                "required": false,
+                "metadata": {
+                  "source": "Geoclient API"
+                }
+              },
+              {
+                "id": "community_district",
+                "label": "Community District",
+                "type": "text",
+                "required": false,
+                "metadata": {
+                  "source": "Geoclient API"
+                }
+              },
+              {
+                "id": "council_district",
+                "label": "Council District",
+                "type": "text",
+                "required": false,
+                "metadata": {
+                  "source": "Geoclient API"
+                }
+              },
+              {
+                "id": "police_precinct",
+                "label": "Police Precinct",
+                "type": "text",
+                "required": false,
+                "metadata": {
+                  "source": "Geoclient API"
+                }
+              },
+              {
+                "id": "house_number",
+                "label": "House Number",
+                "type": "text",
+                "required": false,
+                "metadata": {
+                  "source": "Geoclient API"
+                }
+              }
+            ]
+          }
+        ]
+      },
+      {
+        "id": "contact_information",
+        "title": "Contact Information – Applicant and Other Contacts",
+        "sections": [
+          {
+            "id": "contact_info_guidance",
+            "title": "Contact Type Guidance",
+            "type": "info",
+            "ui": {
+              "markdown": true,
+              "collapsible": false,
+              "defaultCollapsed": false
+            },
+            "content": "### Applying as a Corporation, Partnership, or Not-for-Profit?\n\nSelect **\"Business Information\"** as your Type of Contact and complete the required fields.  \nBusinesses also have the opportunity to provide a complete list of the responsible individuals within their organization. To add each individual's information to your application, please select **\"Other Contact\"** as the Type of Contact and complete the required fields that appear.\n\n---\n\n### Applying as an Individual or Sole Proprietorship?\n\nSelect **\"Individual Owner\"** as your Type of Contact and complete the required fields that appear.\n\n---\n\n### Emergency Contact?\n\nUnless a **\"Designated Emergency Contact\"** is specified, the applicant will be assumed to be the Emergency Contact.  \nTo identify someone other than the applicant to be contacted in the event of an emergency, please select **\"Designated Emergency Contact\"** as the Type of Contact and complete the required fields that appear."
+          },
+          {
+            "id": "contact_list",
+            "title": "Contact List",
+            "fields": [
+              {
+                "id": "contacts",
+                "label": "Contacts",
+                "type": "group",
+                "metadata": {
+                  "multiple": true,
+                  "tableColumns": ["contact_type", "first_name", "last_name", "establishment_name", "email"]
+                },
+                "fields": [
+                  {
+                    "id": "contact_type",
+                    "label": "Type of Contact",
+                    "type": "select",
+                    "required": true,
+                    "ui": {
+                      "options": [
+                        "Business Information",
+                        "Individual Owner",
+                        "Other Contact",
+                        "Designated Emergency Contact"
+                      ]
+                    }
+                  },
+                  {
+                    "id": "establishment_name",
+                    "label": "Establishment Name",
+                    "type": "text",
+                    "requiredCondition": {
+                      "field": "contact_type",
+                      "operator": "equals",
+                      "value": "Business Information"
+                    }
+                  },
+                  {
+                    "id": "dba_name",
+                    "label": "DBA / Trade Name",
+                    "type": "text",
+                    "requiredCondition": {
+                      "field": "contact_type",
+                      "operator": "equals",
+                      "value": "Business Information"
+                    }
+                  },
+                  {
+                    "id": "legal_structure",
+                    "label": "Legal Structure",
+                    "type": "select",
+                    "requiredCondition": {
+                      "field": "contact_type",
+                      "operator": "equals",
+                      "value": "Business Information"
+                    },
+                    "ui": {
+                      "options": [
+                        "Corporation",
+                        "Partnership",
+                        "Limited Partnership",
+                        "Limited Liability",
+                        "Not-for-Profit"
+                      ]
+                    }
+                  },
+                  {
+                    "id": "nys_sales_tax_id",
+                    "label": "NYS Sales Tax ID #",
+                    "type": "text",
+                    "requiredCondition": {
+                      "field": "contact_type",
+                      "operator": "equals",
+                      "value": "Business Information"
+                    }
+                  },
+                  {
+                    "id": "is_out_of_state_corp",
+                    "label": "Are you a corporation formed outside of New York State?",
+                    "type": "radio",
+                    "requiredCondition": {
+                      "field": "contact_type",
+                      "operator": "equals",
+                      "value": "Business Information"
+                    },
+                    "ui": {
+                      "options": ["Yes", "No"]
+                    }
+                  },
+                  {
+                    "id": "first_name",
+                    "label": "First Name",
+                    "type": "text",
+                    "requiredCondition": {
+                      "anyOf": [
+                        { "field": "contact_type", "operator": "equals", "value": "Individual Owner" },
+                        { "field": "contact_type", "operator": "equals", "value": "Other Contact" },
+                        { "field": "contact_type", "operator": "equals", "value": "Designated Emergency Contact" }
+                      ]
+                    }
+                  },
+                  {
+                    "id": "last_name",
+                    "label": "Last Name",
+                    "type": "text",
+                    "requiredCondition": {
+                      "anyOf": [
+                        { "field": "contact_type", "operator": "equals", "value": "Individual Owner" },
+                        { "field": "contact_type", "operator": "equals", "value": "Other Contact" },
+                        { "field": "contact_type", "operator": "equals", "value": "Designated Emergency Contact" }
+                      ]
+                    }
+                  },
+                  {
+                    "id": "title",
+                    "label": "Title",
+                    "type": "text",
+                    "required": false
+                  },
+                  {
+                    "id": "email",
+                    "label": "E-mail Address",
+                    "type": "email",
+                    "required": true
+                  },
+                  {
+                    "id": "ssn_itin",
+                    "label": "SSN / ITIN",
+                    "type": "text",
+                    "required": false,
+                    "constraints": {
+                      "pattern": "^(\\d{3}-\\d{2}-\\d{4}|\\d{9})$"
+                    },
+                    "ui": {
+                      "placeholder": "XXX-XX-XXXX or 9-digit ITIN"
+                    }
+                  },
+                  {
+                    "id": "ssn_itin_type",
+                    "label": "Did you enter SSN or ITIN?",
+                    "type": "radio",
+                    "requiredCondition": {
+                      "field": "ssn_itin",
+                      "operator": "notEquals",
+                      "value": ""
+                    },
+                    "ui": {
+                      "options": ["SSN", "ITIN"]
+                    }
+                  },
+                  {
+                    "id": "phone",
+                    "label": "Phone Number",
+                    "type": "tel",
+                    "required": true,
+                    "constraints": {
+                      "pattern": "^\\(?[0-9]{3}\\)?[-. ]?[0-9]{3}[-. ]?[0-9]{4}$"
+                    },
+                    "ui": {
+                      "placeholder": "(123) 456-7890"
+                    }
+                  },
+                  {
+                    "id": "tty_phone",
+                    "label": "TTY Phone",
+                    "type": "tel",
+                    "required": false
+                  },
+                  {
+                    "id": "date_of_birth",
+                    "label": "Date of Birth",
+                    "type": "date",
+                    "required": false
+                  },
+                  {
+                    "id": "gender",
+                    "label": "Gender",
+                    "type": "radio",
+                    "required": false,
+                    "ui": {
+                      "options": ["Female", "Male"]
+                    }
+                  }
+                ]
+              }
+            ]
+          }
+        ]
+      },
+
+      {
+        "id": "application_info_1",
+        "title": "Application Specific Information 1",
+        "sections": [
+          {
+            "id": "program_details",
+            "title": "Program Details",
+            "fields": [
+              {
+                "id": "program_type",
+                "label": "Program Type",
+                "type": "select",
+                "required": true,
+                "ui": {
+                  "options": [
+                    "Infant Toddler",
+                    "Preschool"
+                  ]
+                }
+              },
+              {
+                "id": "orientation_cert_number",
+                "label": "Pre Permit Orientation Cert #",
+                "type": "text",
+                "required": true
+              },
+              {
+                "id": "permittee_name",
+                "label": "Permittee (Sponsor Name)",
+                "type": "text",
+                "required": true
+              },
+              {
+                "id": "is_applicant_same_as_permittee",
+                "label": "Applicant same as Permittee?",
+                "type": "checkbox",
+                "ui": {
+                  "defaultChecked": true
+                }
+              },
+              {
+                "id": "permit_expiration_date",
+                "label": "Expiration Date",
+                "type": "date",
+                "required": false
+              },
+              {
+                "id": "permit_number",
+                "label": "Permit #",
+                "type": "text",
+                "required": false
+              }
+            ]
+          },
+          {
+            "id": "program_contact",
+            "title": "Program Contact",
+            "fields": [
+              {
+                "id": "program_phone",
+                "label": "Phone",
+                "type": "tel"
+              },
+              {
+                "id": "program_fax",
+                "label": "Fax",
+                "type": "tel"
+              },
+              {
+                "id": "program_email",
+                "label": "Email",
+                "type": "email",
+                "required": true
+              },
+              {
+                "id": "program_website",
+                "label": "Website",
+                "type": "text"
+              }
+            ]
+          },
+          {
+            "id": "program_days_hours",
+            "title": "Days Open (Hours)",
+            "fields": [
+              {
+                "id": "open_days",
+                "label": "Open Days",
+                "type": "checkbox",
+                "ui": {
+                  "options": [
+                    "Sunday",
+                    "Monday",
+                    "Tuesday",
+                    "Wednesday",
+                    "Thursday",
+                    "Friday",
+                    "Saturday"
+                  ]
+                }
+              },
+              {
+                "id": "nightcare",
+                "label": "Nightcare",
+                "type": "checkbox"
+              },
+              {
+                "id": "open_from",
+                "label": "Open From",
+                "type": "time",
+                "required": true
+              },
+              {
+                "id": "close_at",
+                "label": "Close At",
+                "type": "time",
+                "required": true
+              },
+              {
+                "id": "inspection_delivery_method",
+                "label": "Inspection Report Delivery Method",
+                "type": "select",
+                "ui": {
+                  "options": [
+                    "Email",
+                    "Fax",
+                    "Regular Mail"
+                  ]
+                }
+              },
+              {
+                "id": "inspection_language",
+                "label": "Inspection Language",
+                "type": "select",
+                "ui": {
+                  "options": [
+                    "English",
+                    "Spanish"
+                  ]
+                }
+              }
+            ]
+          },
+          {
+            "id": "school_year_dates",
+            "title": "School Year Dates",
+            "fields": [
+              {
+                "id": "school_year_from",
+                "label": "Regular School Year From",
+                "type": "date"
+              },
+              {
+                "id": "school_year_to",
+                "label": "Regular School Year To",
+                "type": "date"
+              },
+              {
+                "id": "has_summer_program",
+                "label": "Summer Program",
+                "type": "checkbox"
+              }
+            ]
+          },
+          {
+            "id": "school_breaks",
+            "title": "School Breaks",
+            "fields": [
+              {
+                "id": "school_breaks",
+                "label": "School Breaks",
+                "type": "group",
+                "metadata": {
+                  "multiple": true,
+                  "tableColumns": [
+                    "term",
+                    "from",
+                    "to"
+                  ]
+                },
+                "fields": [
+                  {
+                    "id": "term",
+                    "label": "Term",
+                    "type": "select",
+                    "required": true,
+                    "ui": {
+                      "options": [
+                        "Fall",
+                        "Spring",
+                        "Summer",
+                        "Winter"
+                      ]
+                    }
+                  },
+                  {
+                    "id": "from",
+                    "label": "From",
+                    "type": "date",
+                    "required": true
+                  },
+                  {
+                    "id": "to",
+                    "label": "To",
+                    "type": "date",
+                    "required": true
+                  }
+                ]
+              }
+            ]
+          },
+          {
+            "id": "holidays",
+            "title": "Holidays",
+            "fields": [
+              {
+                "id": "holidays",
+                "label": "Holiday List",
+                "type": "group",
+                "metadata": {
+                  "multiple": true,
+                  "tableColumns": [
+                    "holiday_name"
+                  ]
+                },
+                "fields": [
+                  {
+                    "id": "holiday_name",
+                    "label": "Holiday Name",
+                    "type": "text",
+                    "required": true
+                  }
+                ]
+              }
+            ]
+          },
+          {
+            "id": "food_services_info",
+            "title": "Food Services Information",
+            "fields": [
+              {
+                "id": "food_provided",
+                "label": "Is food provided for children in care?",
+                "type": "radio",
+                "required": true,
+                "ui": {
+                  "options": [
+                    "Yes",
+                    "No"
+                  ]
+                }
+              },
+              {
+                "id": "food_prepared_on_site",
+                "label": "Is food prepared on site?",
+                "type": "radio",
+                "ui": {
+                  "options": [
+                    "Yes",
+                    "No"
+                  ]
+                }
+              },
+              {
+                "id": "food_preparation_location",
+                "label": "Where is food prepared?",
+                "type": "text"
+              },
+              {
+                "id": "dohmh_food_service_permit",
+                "label": "DOHMH Food Service Permit #",
+                "type": "text"
+              },
+              {
+                "id": "person_on_certificate",
+                "label": "Person Name on Certificate",
+                "type": "text"
+              },
+              {
+                "id": "food_protection_cert_number",
+                "label": "Food Protection Certificate #",
+                "type": "text"
+              }
+            ]
+          }
+        ]
+      },
+      {
+        "id": "application_info_2",
+        "title": "Application Specific Information 2"
+      },
+      {
+        "id": "document_upload",
+        "title": "Upload Documents",
+        "description": "REQUIRED DOCUMENTS\nIn order for your application to be processed, based on information provided, you are required to upload the following documents:",
+        "sections": [
+          {
+            "id": "initial_site_survey",
+            "title": "Initial Site Survey Form",
+            "fields": [
+              {
+                "id": "site_survey_file",
+                "label": "Upload Initial Site Survey Form",
+                "type": "file",
+                "required": true,
+                "constraints": {
+                  "maxFileSizeMB": 25,
+                  "allowedTypes": [
+                    "application/pdf",
+                    "image/jpeg",
+                    "image/jpg",
+                    "image/png"
+                  ]
+                },
+                "metadata": {
+                  "proofCategory": "Initial Site Survey",
+                  "multiple": false
+                }
+              }
+            ]
+          },
+          {
+            "id": "personal_id_proof",
+            "title": "Proof of Personal Identification",
+            "fields": [
+              {
+                "id": "personal_id_file",
+                "label": "Upload Proof of Personal Identification",
+                "type": "file",
+                "required": true,
+                "constraints": {
+                  "maxFileSizeMB": 25,
+                  "allowedTypes": [
+                    "application/pdf",
+                    "image/jpeg",
+                    "image/jpg",
+                    "image/png"
+                  ]
+                },
+                "metadata": {
+                  "proofCategory": "Personal ID",
+                  "multiple": false
+                }
+              }
+            ]
+          },
+          {
+            "id": "fee_exemption_proof",
+            "title": "Proof of Fee Exemption",
+            "fields": [
+              {
+                "id": "fee_exemption_file",
+                "label": "Upload Proof of Fee Exemption (ACS Affiliation or Municipal Exemption)",
+                "type": "file",
+                "required": true,
+                "constraints": {
+                  "maxFileSizeMB": 25,
+                  "allowedTypes": [
+                    "application/pdf",
+                    "image/jpeg",
+                    "image/jpg",
+                    "image/png"
+                  ]
+                },
+                "metadata": {
+                  "proofCategory": "Fee Exemption",
+                  "multiple": false
+                }
+              }
+            ]
+          }
+        ]
+      },
+      {
+        "id": "step_6_placeholder",
+        "title": "To be defined"
+      },
+      {
+        "id": "step_7_placeholder",
+        "title": "To be defined"
+      },
+      {
+        "id": "step_8_placeholder",
+        "title": "To be defined"
+      }
+    ]
+  }
+}

--- a/test-form/public/data/group_cc_permit.bn.json
+++ b/test-form/public/data/group_cc_permit.bn.json
@@ -1,0 +1,788 @@
+{
+  "form": {
+    "title": "Group Child Care Permit Application",
+    "description": "Multi-step application for obtaining a permit to operate group child care programs.",
+    "layout": {
+      "stepperPosition": "left"
+    },
+    "steps": [
+      {
+        "id": "establishment_information",
+        "title": "Establishment Information",
+        "sections": [
+          {
+            "id": "establishment_address",
+            "title": "Establishment Address",
+            "description": "Enter the physical address where business will operate. If you are applying for a Tattoo License, enter your mailing or home address.",
+            "ui": {
+              "autocomplete": "street_1",
+              "placeholder": "Start typing your street address",
+              "overrideComponent": "AddressAutocomplete"
+            },
+            "metadata": {
+              "integration": {
+                "provider": "Google",
+                "feature": "AddressAutocomplete"
+              },
+              "autofillTargets": [
+                {
+                  "fieldId": "city",
+                  "source": "locality",
+                  "fallbackSources": [
+                    "postal_town",
+                    "sublocality_level_1",
+                    "administrative_area_level_2"
+                  ]
+                },
+                {
+                  "fieldId": "borough",
+                  "source": "sublocality_level_1",
+                  "fallbackSources": [
+                    "administrative_area_level_2"
+                  ],
+                  "mapping": "boroughMap"
+                },
+                { "fieldId": "state", "source": "administrative_area_level_1" },
+                { "fieldId": "building_number", "source": "street_number" },
+                { "fieldId": "house_number", "source": "street_number" }
+              ]
+            },
+            "fields": [
+              {
+                "id": "address_type",
+                "label": "Address Type",
+                "type": "select",
+                "required": true,
+                "ui": {
+                  "options": [
+                    "Select",
+                    "Complete Address",
+                    "Cross Street (Intersection)",
+                    "Place (Landmark)"
+                  ]
+                }
+              },
+              {
+                "id": "street_1",
+                "label": "Street 1",
+                "type": "text",
+                "required": true
+              },
+              {
+                "id": "building_number",
+                "label": "Building #",
+                "type": "text",
+                "required": true
+              },
+              {
+                "id": "street_2",
+                "label": "Street 2",
+                "type": "text",
+                "required": false
+              },
+              {
+                "id": "unit_type",
+                "label": "Unit Type",
+                "type": "select",
+                "required": false,
+                "ui": {
+                  "options": [
+                    "LBBY",
+                    "APT",
+                    "BLDG",
+                    "STE",
+                    "FL",
+                    "BSMT",
+                    "FRNT",
+                    "SIDE",
+                    "REAR",
+                    "UPPR",
+                    "LOWR",
+                    "PIER"
+                  ]
+                }
+              },
+              {
+                "id": "unit",
+                "label": "Unit",
+                "type": "text",
+                "required": false
+              },
+              {
+                "id": "city",
+                "label": "City",
+                "type": "text",
+                "required": true
+              },
+              {
+                "id": "state",
+                "label": "State",
+                "type": "text",
+                "required": true
+              },
+              {
+                "id": "borough",
+                "label": "Borough",
+                "type": "select",
+                "required": true,
+                "ui": {
+                  "options": [
+                    "Bronx",
+                    "Brooklyn",
+                    "Manhattan",
+                    "Queens",
+                    "Staten Island"
+                  ]
+                }
+              },
+              {
+                "id": "bin",
+                "label": "Bin",
+                "type": "text",
+                "required": false,
+                "metadata": {
+                  "source": "Geoclient API"
+                }
+              },
+              {
+                "id": "bbl",
+                "label": "Bbl",
+                "type": "text",
+                "required": false,
+                "metadata": {
+                  "source": "Geoclient API"
+                }
+              },
+              {
+                "id": "community_district",
+                "label": "Community District",
+                "type": "text",
+                "required": false,
+                "metadata": {
+                  "source": "Geoclient API"
+                }
+              },
+              {
+                "id": "council_district",
+                "label": "Council District",
+                "type": "text",
+                "required": false,
+                "metadata": {
+                  "source": "Geoclient API"
+                }
+              },
+              {
+                "id": "police_precinct",
+                "label": "Police Precinct",
+                "type": "text",
+                "required": false,
+                "metadata": {
+                  "source": "Geoclient API"
+                }
+              },
+              {
+                "id": "house_number",
+                "label": "House Number",
+                "type": "text",
+                "required": false,
+                "metadata": {
+                  "source": "Geoclient API"
+                }
+              }
+            ]
+          }
+        ]
+      },
+      {
+        "id": "contact_information",
+        "title": "Contact Information – Applicant and Other Contacts",
+        "sections": [
+          {
+            "id": "contact_info_guidance",
+            "title": "Contact Type Guidance",
+            "type": "info",
+            "ui": {
+              "markdown": true,
+              "collapsible": false,
+              "defaultCollapsed": false
+            },
+            "content": "### Applying as a Corporation, Partnership, or Not-for-Profit?\n\nSelect **\"Business Information\"** as your Type of Contact and complete the required fields.  \nBusinesses also have the opportunity to provide a complete list of the responsible individuals within their organization. To add each individual's information to your application, please select **\"Other Contact\"** as the Type of Contact and complete the required fields that appear.\n\n---\n\n### Applying as an Individual or Sole Proprietorship?\n\nSelect **\"Individual Owner\"** as your Type of Contact and complete the required fields that appear.\n\n---\n\n### Emergency Contact?\n\nUnless a **\"Designated Emergency Contact\"** is specified, the applicant will be assumed to be the Emergency Contact.  \nTo identify someone other than the applicant to be contacted in the event of an emergency, please select **\"Designated Emergency Contact\"** as the Type of Contact and complete the required fields that appear."
+          },
+          {
+            "id": "contact_list",
+            "title": "Contact List",
+            "fields": [
+              {
+                "id": "contacts",
+                "label": "Contacts",
+                "type": "group",
+                "metadata": {
+                  "multiple": true,
+                  "tableColumns": ["contact_type", "first_name", "last_name", "establishment_name", "email"]
+                },
+                "fields": [
+                  {
+                    "id": "contact_type",
+                    "label": "Type of Contact",
+                    "type": "select",
+                    "required": true,
+                    "ui": {
+                      "options": [
+                        "Business Information",
+                        "Individual Owner",
+                        "Other Contact",
+                        "Designated Emergency Contact"
+                      ]
+                    }
+                  },
+                  {
+                    "id": "establishment_name",
+                    "label": "Establishment Name",
+                    "type": "text",
+                    "requiredCondition": {
+                      "field": "contact_type",
+                      "operator": "equals",
+                      "value": "Business Information"
+                    }
+                  },
+                  {
+                    "id": "dba_name",
+                    "label": "DBA / Trade Name",
+                    "type": "text",
+                    "requiredCondition": {
+                      "field": "contact_type",
+                      "operator": "equals",
+                      "value": "Business Information"
+                    }
+                  },
+                  {
+                    "id": "legal_structure",
+                    "label": "Legal Structure",
+                    "type": "select",
+                    "requiredCondition": {
+                      "field": "contact_type",
+                      "operator": "equals",
+                      "value": "Business Information"
+                    },
+                    "ui": {
+                      "options": [
+                        "Corporation",
+                        "Partnership",
+                        "Limited Partnership",
+                        "Limited Liability",
+                        "Not-for-Profit"
+                      ]
+                    }
+                  },
+                  {
+                    "id": "nys_sales_tax_id",
+                    "label": "NYS Sales Tax ID #",
+                    "type": "text",
+                    "requiredCondition": {
+                      "field": "contact_type",
+                      "operator": "equals",
+                      "value": "Business Information"
+                    }
+                  },
+                  {
+                    "id": "is_out_of_state_corp",
+                    "label": "Are you a corporation formed outside of New York State?",
+                    "type": "radio",
+                    "requiredCondition": {
+                      "field": "contact_type",
+                      "operator": "equals",
+                      "value": "Business Information"
+                    },
+                    "ui": {
+                      "options": ["Yes", "No"]
+                    }
+                  },
+                  {
+                    "id": "first_name",
+                    "label": "First Name",
+                    "type": "text",
+                    "requiredCondition": {
+                      "anyOf": [
+                        { "field": "contact_type", "operator": "equals", "value": "Individual Owner" },
+                        { "field": "contact_type", "operator": "equals", "value": "Other Contact" },
+                        { "field": "contact_type", "operator": "equals", "value": "Designated Emergency Contact" }
+                      ]
+                    }
+                  },
+                  {
+                    "id": "last_name",
+                    "label": "Last Name",
+                    "type": "text",
+                    "requiredCondition": {
+                      "anyOf": [
+                        { "field": "contact_type", "operator": "equals", "value": "Individual Owner" },
+                        { "field": "contact_type", "operator": "equals", "value": "Other Contact" },
+                        { "field": "contact_type", "operator": "equals", "value": "Designated Emergency Contact" }
+                      ]
+                    }
+                  },
+                  {
+                    "id": "title",
+                    "label": "Title",
+                    "type": "text",
+                    "required": false
+                  },
+                  {
+                    "id": "email",
+                    "label": "E-mail Address",
+                    "type": "email",
+                    "required": true
+                  },
+                  {
+                    "id": "ssn_itin",
+                    "label": "SSN / ITIN",
+                    "type": "text",
+                    "required": false,
+                    "constraints": {
+                      "pattern": "^(\\d{3}-\\d{2}-\\d{4}|\\d{9})$"
+                    },
+                    "ui": {
+                      "placeholder": "XXX-XX-XXXX or 9-digit ITIN"
+                    }
+                  },
+                  {
+                    "id": "ssn_itin_type",
+                    "label": "Did you enter SSN or ITIN?",
+                    "type": "radio",
+                    "requiredCondition": {
+                      "field": "ssn_itin",
+                      "operator": "notEquals",
+                      "value": ""
+                    },
+                    "ui": {
+                      "options": ["SSN", "ITIN"]
+                    }
+                  },
+                  {
+                    "id": "phone",
+                    "label": "Phone Number",
+                    "type": "tel",
+                    "required": true,
+                    "constraints": {
+                      "pattern": "^\\(?[0-9]{3}\\)?[-. ]?[0-9]{3}[-. ]?[0-9]{4}$"
+                    },
+                    "ui": {
+                      "placeholder": "(123) 456-7890"
+                    }
+                  },
+                  {
+                    "id": "tty_phone",
+                    "label": "TTY Phone",
+                    "type": "tel",
+                    "required": false
+                  },
+                  {
+                    "id": "date_of_birth",
+                    "label": "Date of Birth",
+                    "type": "date",
+                    "required": false
+                  },
+                  {
+                    "id": "gender",
+                    "label": "Gender",
+                    "type": "radio",
+                    "required": false,
+                    "ui": {
+                      "options": ["Female", "Male"]
+                    }
+                  }
+                ]
+              }
+            ]
+          }
+        ]
+      },
+
+      {
+        "id": "application_info_1",
+        "title": "Application Specific Information 1",
+        "sections": [
+          {
+            "id": "program_details",
+            "title": "Program Details",
+            "fields": [
+              {
+                "id": "program_type",
+                "label": "Program Type",
+                "type": "select",
+                "required": true,
+                "ui": {
+                  "options": [
+                    "Infant Toddler",
+                    "Preschool"
+                  ]
+                }
+              },
+              {
+                "id": "orientation_cert_number",
+                "label": "Pre Permit Orientation Cert #",
+                "type": "text",
+                "required": true
+              },
+              {
+                "id": "permittee_name",
+                "label": "Permittee (Sponsor Name)",
+                "type": "text",
+                "required": true
+              },
+              {
+                "id": "is_applicant_same_as_permittee",
+                "label": "Applicant same as Permittee?",
+                "type": "checkbox",
+                "ui": {
+                  "defaultChecked": true
+                }
+              },
+              {
+                "id": "permit_expiration_date",
+                "label": "Expiration Date",
+                "type": "date",
+                "required": false
+              },
+              {
+                "id": "permit_number",
+                "label": "Permit #",
+                "type": "text",
+                "required": false
+              }
+            ]
+          },
+          {
+            "id": "program_contact",
+            "title": "Program Contact",
+            "fields": [
+              {
+                "id": "program_phone",
+                "label": "Phone",
+                "type": "tel"
+              },
+              {
+                "id": "program_fax",
+                "label": "Fax",
+                "type": "tel"
+              },
+              {
+                "id": "program_email",
+                "label": "Email",
+                "type": "email",
+                "required": true
+              },
+              {
+                "id": "program_website",
+                "label": "Website",
+                "type": "text"
+              }
+            ]
+          },
+          {
+            "id": "program_days_hours",
+            "title": "Days Open (Hours)",
+            "fields": [
+              {
+                "id": "open_days",
+                "label": "Open Days",
+                "type": "checkbox",
+                "ui": {
+                  "options": [
+                    "Sunday",
+                    "Monday",
+                    "Tuesday",
+                    "Wednesday",
+                    "Thursday",
+                    "Friday",
+                    "Saturday"
+                  ]
+                }
+              },
+              {
+                "id": "nightcare",
+                "label": "Nightcare",
+                "type": "checkbox"
+              },
+              {
+                "id": "open_from",
+                "label": "Open From",
+                "type": "time",
+                "required": true
+              },
+              {
+                "id": "close_at",
+                "label": "Close At",
+                "type": "time",
+                "required": true
+              },
+              {
+                "id": "inspection_delivery_method",
+                "label": "Inspection Report Delivery Method",
+                "type": "select",
+                "ui": {
+                  "options": [
+                    "Email",
+                    "Fax",
+                    "Regular Mail"
+                  ]
+                }
+              },
+              {
+                "id": "inspection_language",
+                "label": "Inspection Language",
+                "type": "select",
+                "ui": {
+                  "options": [
+                    "English",
+                    "Spanish"
+                  ]
+                }
+              }
+            ]
+          },
+          {
+            "id": "school_year_dates",
+            "title": "School Year Dates",
+            "fields": [
+              {
+                "id": "school_year_from",
+                "label": "Regular School Year From",
+                "type": "date"
+              },
+              {
+                "id": "school_year_to",
+                "label": "Regular School Year To",
+                "type": "date"
+              },
+              {
+                "id": "has_summer_program",
+                "label": "Summer Program",
+                "type": "checkbox"
+              }
+            ]
+          },
+          {
+            "id": "school_breaks",
+            "title": "School Breaks",
+            "fields": [
+              {
+                "id": "school_breaks",
+                "label": "School Breaks",
+                "type": "group",
+                "metadata": {
+                  "multiple": true,
+                  "tableColumns": [
+                    "term",
+                    "from",
+                    "to"
+                  ]
+                },
+                "fields": [
+                  {
+                    "id": "term",
+                    "label": "Term",
+                    "type": "select",
+                    "required": true,
+                    "ui": {
+                      "options": [
+                        "Fall",
+                        "Spring",
+                        "Summer",
+                        "Winter"
+                      ]
+                    }
+                  },
+                  {
+                    "id": "from",
+                    "label": "From",
+                    "type": "date",
+                    "required": true
+                  },
+                  {
+                    "id": "to",
+                    "label": "To",
+                    "type": "date",
+                    "required": true
+                  }
+                ]
+              }
+            ]
+          },
+          {
+            "id": "holidays",
+            "title": "Holidays",
+            "fields": [
+              {
+                "id": "holidays",
+                "label": "Holiday List",
+                "type": "group",
+                "metadata": {
+                  "multiple": true,
+                  "tableColumns": [
+                    "holiday_name"
+                  ]
+                },
+                "fields": [
+                  {
+                    "id": "holiday_name",
+                    "label": "Holiday Name",
+                    "type": "text",
+                    "required": true
+                  }
+                ]
+              }
+            ]
+          },
+          {
+            "id": "food_services_info",
+            "title": "Food Services Information",
+            "fields": [
+              {
+                "id": "food_provided",
+                "label": "Is food provided for children in care?",
+                "type": "radio",
+                "required": true,
+                "ui": {
+                  "options": [
+                    "Yes",
+                    "No"
+                  ]
+                }
+              },
+              {
+                "id": "food_prepared_on_site",
+                "label": "Is food prepared on site?",
+                "type": "radio",
+                "ui": {
+                  "options": [
+                    "Yes",
+                    "No"
+                  ]
+                }
+              },
+              {
+                "id": "food_preparation_location",
+                "label": "Where is food prepared?",
+                "type": "text"
+              },
+              {
+                "id": "dohmh_food_service_permit",
+                "label": "DOHMH Food Service Permit #",
+                "type": "text"
+              },
+              {
+                "id": "person_on_certificate",
+                "label": "Person Name on Certificate",
+                "type": "text"
+              },
+              {
+                "id": "food_protection_cert_number",
+                "label": "Food Protection Certificate #",
+                "type": "text"
+              }
+            ]
+          }
+        ]
+      },
+      {
+        "id": "application_info_2",
+        "title": "Application Specific Information 2"
+      },
+      {
+        "id": "document_upload",
+        "title": "Upload Documents",
+        "description": "REQUIRED DOCUMENTS\nIn order for your application to be processed, based on information provided, you are required to upload the following documents:",
+        "sections": [
+          {
+            "id": "initial_site_survey",
+            "title": "Initial Site Survey Form",
+            "fields": [
+              {
+                "id": "site_survey_file",
+                "label": "Upload Initial Site Survey Form",
+                "type": "file",
+                "required": true,
+                "constraints": {
+                  "maxFileSizeMB": 25,
+                  "allowedTypes": [
+                    "application/pdf",
+                    "image/jpeg",
+                    "image/jpg",
+                    "image/png"
+                  ]
+                },
+                "metadata": {
+                  "proofCategory": "Initial Site Survey",
+                  "multiple": false
+                }
+              }
+            ]
+          },
+          {
+            "id": "personal_id_proof",
+            "title": "Proof of Personal Identification",
+            "fields": [
+              {
+                "id": "personal_id_file",
+                "label": "Upload Proof of Personal Identification",
+                "type": "file",
+                "required": true,
+                "constraints": {
+                  "maxFileSizeMB": 25,
+                  "allowedTypes": [
+                    "application/pdf",
+                    "image/jpeg",
+                    "image/jpg",
+                    "image/png"
+                  ]
+                },
+                "metadata": {
+                  "proofCategory": "Personal ID",
+                  "multiple": false
+                }
+              }
+            ]
+          },
+          {
+            "id": "fee_exemption_proof",
+            "title": "Proof of Fee Exemption",
+            "fields": [
+              {
+                "id": "fee_exemption_file",
+                "label": "Upload Proof of Fee Exemption (ACS Affiliation or Municipal Exemption)",
+                "type": "file",
+                "required": true,
+                "constraints": {
+                  "maxFileSizeMB": 25,
+                  "allowedTypes": [
+                    "application/pdf",
+                    "image/jpeg",
+                    "image/jpg",
+                    "image/png"
+                  ]
+                },
+                "metadata": {
+                  "proofCategory": "Fee Exemption",
+                  "multiple": false
+                }
+              }
+            ]
+          }
+        ]
+      },
+      {
+        "id": "step_6_placeholder",
+        "title": "To be defined"
+      },
+      {
+        "id": "step_7_placeholder",
+        "title": "To be defined"
+      },
+      {
+        "id": "step_8_placeholder",
+        "title": "To be defined"
+      }
+    ]
+  }
+}

--- a/test-form/public/data/group_cc_permit.en.json
+++ b/test-form/public/data/group_cc_permit.en.json
@@ -1,0 +1,788 @@
+{
+  "form": {
+    "title": "Group Child Care Permit Application",
+    "description": "Multi-step application for obtaining a permit to operate group child care programs.",
+    "layout": {
+      "stepperPosition": "left"
+    },
+    "steps": [
+      {
+        "id": "establishment_information",
+        "title": "Establishment Information",
+        "sections": [
+          {
+            "id": "establishment_address",
+            "title": "Establishment Address",
+            "description": "Enter the physical address where business will operate. If you are applying for a Tattoo License, enter your mailing or home address.",
+            "ui": {
+              "autocomplete": "street_1",
+              "placeholder": "Start typing your street address",
+              "overrideComponent": "AddressAutocomplete"
+            },
+            "metadata": {
+              "integration": {
+                "provider": "Google",
+                "feature": "AddressAutocomplete"
+              },
+              "autofillTargets": [
+                {
+                  "fieldId": "city",
+                  "source": "locality",
+                  "fallbackSources": [
+                    "postal_town",
+                    "sublocality_level_1",
+                    "administrative_area_level_2"
+                  ]
+                },
+                {
+                  "fieldId": "borough",
+                  "source": "sublocality_level_1",
+                  "fallbackSources": [
+                    "administrative_area_level_2"
+                  ],
+                  "mapping": "boroughMap"
+                },
+                { "fieldId": "state", "source": "administrative_area_level_1" },
+                { "fieldId": "building_number", "source": "street_number" },
+                { "fieldId": "house_number", "source": "street_number" }
+              ]
+            },
+            "fields": [
+              {
+                "id": "address_type",
+                "label": "Address Type",
+                "type": "select",
+                "required": true,
+                "ui": {
+                  "options": [
+                    "Select",
+                    "Complete Address",
+                    "Cross Street (Intersection)",
+                    "Place (Landmark)"
+                  ]
+                }
+              },
+              {
+                "id": "street_1",
+                "label": "Street 1",
+                "type": "text",
+                "required": true
+              },
+              {
+                "id": "building_number",
+                "label": "Building #",
+                "type": "text",
+                "required": true
+              },
+              {
+                "id": "street_2",
+                "label": "Street 2",
+                "type": "text",
+                "required": false
+              },
+              {
+                "id": "unit_type",
+                "label": "Unit Type",
+                "type": "select",
+                "required": false,
+                "ui": {
+                  "options": [
+                    "LBBY",
+                    "APT",
+                    "BLDG",
+                    "STE",
+                    "FL",
+                    "BSMT",
+                    "FRNT",
+                    "SIDE",
+                    "REAR",
+                    "UPPR",
+                    "LOWR",
+                    "PIER"
+                  ]
+                }
+              },
+              {
+                "id": "unit",
+                "label": "Unit",
+                "type": "text",
+                "required": false
+              },
+              {
+                "id": "city",
+                "label": "City",
+                "type": "text",
+                "required": true
+              },
+              {
+                "id": "state",
+                "label": "State",
+                "type": "text",
+                "required": true
+              },
+              {
+                "id": "borough",
+                "label": "Borough",
+                "type": "select",
+                "required": true,
+                "ui": {
+                  "options": [
+                    "Bronx",
+                    "Brooklyn",
+                    "Manhattan",
+                    "Queens",
+                    "Staten Island"
+                  ]
+                }
+              },
+              {
+                "id": "bin",
+                "label": "Bin",
+                "type": "text",
+                "required": false,
+                "metadata": {
+                  "source": "Geoclient API"
+                }
+              },
+              {
+                "id": "bbl",
+                "label": "Bbl",
+                "type": "text",
+                "required": false,
+                "metadata": {
+                  "source": "Geoclient API"
+                }
+              },
+              {
+                "id": "community_district",
+                "label": "Community District",
+                "type": "text",
+                "required": false,
+                "metadata": {
+                  "source": "Geoclient API"
+                }
+              },
+              {
+                "id": "council_district",
+                "label": "Council District",
+                "type": "text",
+                "required": false,
+                "metadata": {
+                  "source": "Geoclient API"
+                }
+              },
+              {
+                "id": "police_precinct",
+                "label": "Police Precinct",
+                "type": "text",
+                "required": false,
+                "metadata": {
+                  "source": "Geoclient API"
+                }
+              },
+              {
+                "id": "house_number",
+                "label": "House Number",
+                "type": "text",
+                "required": false,
+                "metadata": {
+                  "source": "Geoclient API"
+                }
+              }
+            ]
+          }
+        ]
+      },
+      {
+        "id": "contact_information",
+        "title": "Contact Information – Applicant and Other Contacts",
+        "sections": [
+          {
+            "id": "contact_info_guidance",
+            "title": "Contact Type Guidance",
+            "type": "info",
+            "ui": {
+              "markdown": true,
+              "collapsible": false,
+              "defaultCollapsed": false
+            },
+            "content": "### Applying as a Corporation, Partnership, or Not-for-Profit?\n\nSelect **\"Business Information\"** as your Type of Contact and complete the required fields.  \nBusinesses also have the opportunity to provide a complete list of the responsible individuals within their organization. To add each individual's information to your application, please select **\"Other Contact\"** as the Type of Contact and complete the required fields that appear.\n\n---\n\n### Applying as an Individual or Sole Proprietorship?\n\nSelect **\"Individual Owner\"** as your Type of Contact and complete the required fields that appear.\n\n---\n\n### Emergency Contact?\n\nUnless a **\"Designated Emergency Contact\"** is specified, the applicant will be assumed to be the Emergency Contact.  \nTo identify someone other than the applicant to be contacted in the event of an emergency, please select **\"Designated Emergency Contact\"** as the Type of Contact and complete the required fields that appear."
+          },
+          {
+            "id": "contact_list",
+            "title": "Contact List",
+            "fields": [
+              {
+                "id": "contacts",
+                "label": "Contacts",
+                "type": "group",
+                "metadata": {
+                  "multiple": true,
+                  "tableColumns": ["contact_type", "first_name", "last_name", "establishment_name", "email"]
+                },
+                "fields": [
+                  {
+                    "id": "contact_type",
+                    "label": "Type of Contact",
+                    "type": "select",
+                    "required": true,
+                    "ui": {
+                      "options": [
+                        "Business Information",
+                        "Individual Owner",
+                        "Other Contact",
+                        "Designated Emergency Contact"
+                      ]
+                    }
+                  },
+                  {
+                    "id": "establishment_name",
+                    "label": "Establishment Name",
+                    "type": "text",
+                    "requiredCondition": {
+                      "field": "contact_type",
+                      "operator": "equals",
+                      "value": "Business Information"
+                    }
+                  },
+                  {
+                    "id": "dba_name",
+                    "label": "DBA / Trade Name",
+                    "type": "text",
+                    "requiredCondition": {
+                      "field": "contact_type",
+                      "operator": "equals",
+                      "value": "Business Information"
+                    }
+                  },
+                  {
+                    "id": "legal_structure",
+                    "label": "Legal Structure",
+                    "type": "select",
+                    "requiredCondition": {
+                      "field": "contact_type",
+                      "operator": "equals",
+                      "value": "Business Information"
+                    },
+                    "ui": {
+                      "options": [
+                        "Corporation",
+                        "Partnership",
+                        "Limited Partnership",
+                        "Limited Liability",
+                        "Not-for-Profit"
+                      ]
+                    }
+                  },
+                  {
+                    "id": "nys_sales_tax_id",
+                    "label": "NYS Sales Tax ID #",
+                    "type": "text",
+                    "requiredCondition": {
+                      "field": "contact_type",
+                      "operator": "equals",
+                      "value": "Business Information"
+                    }
+                  },
+                  {
+                    "id": "is_out_of_state_corp",
+                    "label": "Are you a corporation formed outside of New York State?",
+                    "type": "radio",
+                    "requiredCondition": {
+                      "field": "contact_type",
+                      "operator": "equals",
+                      "value": "Business Information"
+                    },
+                    "ui": {
+                      "options": ["Yes", "No"]
+                    }
+                  },
+                  {
+                    "id": "first_name",
+                    "label": "First Name",
+                    "type": "text",
+                    "requiredCondition": {
+                      "anyOf": [
+                        { "field": "contact_type", "operator": "equals", "value": "Individual Owner" },
+                        { "field": "contact_type", "operator": "equals", "value": "Other Contact" },
+                        { "field": "contact_type", "operator": "equals", "value": "Designated Emergency Contact" }
+                      ]
+                    }
+                  },
+                  {
+                    "id": "last_name",
+                    "label": "Last Name",
+                    "type": "text",
+                    "requiredCondition": {
+                      "anyOf": [
+                        { "field": "contact_type", "operator": "equals", "value": "Individual Owner" },
+                        { "field": "contact_type", "operator": "equals", "value": "Other Contact" },
+                        { "field": "contact_type", "operator": "equals", "value": "Designated Emergency Contact" }
+                      ]
+                    }
+                  },
+                  {
+                    "id": "title",
+                    "label": "Title",
+                    "type": "text",
+                    "required": false
+                  },
+                  {
+                    "id": "email",
+                    "label": "E-mail Address",
+                    "type": "email",
+                    "required": true
+                  },
+                  {
+                    "id": "ssn_itin",
+                    "label": "SSN / ITIN",
+                    "type": "text",
+                    "required": false,
+                    "constraints": {
+                      "pattern": "^(\\d{3}-\\d{2}-\\d{4}|\\d{9})$"
+                    },
+                    "ui": {
+                      "placeholder": "XXX-XX-XXXX or 9-digit ITIN"
+                    }
+                  },
+                  {
+                    "id": "ssn_itin_type",
+                    "label": "Did you enter SSN or ITIN?",
+                    "type": "radio",
+                    "requiredCondition": {
+                      "field": "ssn_itin",
+                      "operator": "notEquals",
+                      "value": ""
+                    },
+                    "ui": {
+                      "options": ["SSN", "ITIN"]
+                    }
+                  },
+                  {
+                    "id": "phone",
+                    "label": "Phone Number",
+                    "type": "tel",
+                    "required": true,
+                    "constraints": {
+                      "pattern": "^\\(?[0-9]{3}\\)?[-. ]?[0-9]{3}[-. ]?[0-9]{4}$"
+                    },
+                    "ui": {
+                      "placeholder": "(123) 456-7890"
+                    }
+                  },
+                  {
+                    "id": "tty_phone",
+                    "label": "TTY Phone",
+                    "type": "tel",
+                    "required": false
+                  },
+                  {
+                    "id": "date_of_birth",
+                    "label": "Date of Birth",
+                    "type": "date",
+                    "required": false
+                  },
+                  {
+                    "id": "gender",
+                    "label": "Gender",
+                    "type": "radio",
+                    "required": false,
+                    "ui": {
+                      "options": ["Female", "Male"]
+                    }
+                  }
+                ]
+              }
+            ]
+          }
+        ]
+      },
+
+      {
+        "id": "application_info_1",
+        "title": "Application Specific Information 1",
+        "sections": [
+          {
+            "id": "program_details",
+            "title": "Program Details",
+            "fields": [
+              {
+                "id": "program_type",
+                "label": "Program Type",
+                "type": "select",
+                "required": true,
+                "ui": {
+                  "options": [
+                    "Infant Toddler",
+                    "Preschool"
+                  ]
+                }
+              },
+              {
+                "id": "orientation_cert_number",
+                "label": "Pre Permit Orientation Cert #",
+                "type": "text",
+                "required": true
+              },
+              {
+                "id": "permittee_name",
+                "label": "Permittee (Sponsor Name)",
+                "type": "text",
+                "required": true
+              },
+              {
+                "id": "is_applicant_same_as_permittee",
+                "label": "Applicant same as Permittee?",
+                "type": "checkbox",
+                "ui": {
+                  "defaultChecked": true
+                }
+              },
+              {
+                "id": "permit_expiration_date",
+                "label": "Expiration Date",
+                "type": "date",
+                "required": false
+              },
+              {
+                "id": "permit_number",
+                "label": "Permit #",
+                "type": "text",
+                "required": false
+              }
+            ]
+          },
+          {
+            "id": "program_contact",
+            "title": "Program Contact",
+            "fields": [
+              {
+                "id": "program_phone",
+                "label": "Phone",
+                "type": "tel"
+              },
+              {
+                "id": "program_fax",
+                "label": "Fax",
+                "type": "tel"
+              },
+              {
+                "id": "program_email",
+                "label": "Email",
+                "type": "email",
+                "required": true
+              },
+              {
+                "id": "program_website",
+                "label": "Website",
+                "type": "text"
+              }
+            ]
+          },
+          {
+            "id": "program_days_hours",
+            "title": "Days Open (Hours)",
+            "fields": [
+              {
+                "id": "open_days",
+                "label": "Open Days",
+                "type": "checkbox",
+                "ui": {
+                  "options": [
+                    "Sunday",
+                    "Monday",
+                    "Tuesday",
+                    "Wednesday",
+                    "Thursday",
+                    "Friday",
+                    "Saturday"
+                  ]
+                }
+              },
+              {
+                "id": "nightcare",
+                "label": "Nightcare",
+                "type": "checkbox"
+              },
+              {
+                "id": "open_from",
+                "label": "Open From",
+                "type": "time",
+                "required": true
+              },
+              {
+                "id": "close_at",
+                "label": "Close At",
+                "type": "time",
+                "required": true
+              },
+              {
+                "id": "inspection_delivery_method",
+                "label": "Inspection Report Delivery Method",
+                "type": "select",
+                "ui": {
+                  "options": [
+                    "Email",
+                    "Fax",
+                    "Regular Mail"
+                  ]
+                }
+              },
+              {
+                "id": "inspection_language",
+                "label": "Inspection Language",
+                "type": "select",
+                "ui": {
+                  "options": [
+                    "English",
+                    "Spanish"
+                  ]
+                }
+              }
+            ]
+          },
+          {
+            "id": "school_year_dates",
+            "title": "School Year Dates",
+            "fields": [
+              {
+                "id": "school_year_from",
+                "label": "Regular School Year From",
+                "type": "date"
+              },
+              {
+                "id": "school_year_to",
+                "label": "Regular School Year To",
+                "type": "date"
+              },
+              {
+                "id": "has_summer_program",
+                "label": "Summer Program",
+                "type": "checkbox"
+              }
+            ]
+          },
+          {
+            "id": "school_breaks",
+            "title": "School Breaks",
+            "fields": [
+              {
+                "id": "school_breaks",
+                "label": "School Breaks",
+                "type": "group",
+                "metadata": {
+                  "multiple": true,
+                  "tableColumns": [
+                    "term",
+                    "from",
+                    "to"
+                  ]
+                },
+                "fields": [
+                  {
+                    "id": "term",
+                    "label": "Term",
+                    "type": "select",
+                    "required": true,
+                    "ui": {
+                      "options": [
+                        "Fall",
+                        "Spring",
+                        "Summer",
+                        "Winter"
+                      ]
+                    }
+                  },
+                  {
+                    "id": "from",
+                    "label": "From",
+                    "type": "date",
+                    "required": true
+                  },
+                  {
+                    "id": "to",
+                    "label": "To",
+                    "type": "date",
+                    "required": true
+                  }
+                ]
+              }
+            ]
+          },
+          {
+            "id": "holidays",
+            "title": "Holidays",
+            "fields": [
+              {
+                "id": "holidays",
+                "label": "Holiday List",
+                "type": "group",
+                "metadata": {
+                  "multiple": true,
+                  "tableColumns": [
+                    "holiday_name"
+                  ]
+                },
+                "fields": [
+                  {
+                    "id": "holiday_name",
+                    "label": "Holiday Name",
+                    "type": "text",
+                    "required": true
+                  }
+                ]
+              }
+            ]
+          },
+          {
+            "id": "food_services_info",
+            "title": "Food Services Information",
+            "fields": [
+              {
+                "id": "food_provided",
+                "label": "Is food provided for children in care?",
+                "type": "radio",
+                "required": true,
+                "ui": {
+                  "options": [
+                    "Yes",
+                    "No"
+                  ]
+                }
+              },
+              {
+                "id": "food_prepared_on_site",
+                "label": "Is food prepared on site?",
+                "type": "radio",
+                "ui": {
+                  "options": [
+                    "Yes",
+                    "No"
+                  ]
+                }
+              },
+              {
+                "id": "food_preparation_location",
+                "label": "Where is food prepared?",
+                "type": "text"
+              },
+              {
+                "id": "dohmh_food_service_permit",
+                "label": "DOHMH Food Service Permit #",
+                "type": "text"
+              },
+              {
+                "id": "person_on_certificate",
+                "label": "Person Name on Certificate",
+                "type": "text"
+              },
+              {
+                "id": "food_protection_cert_number",
+                "label": "Food Protection Certificate #",
+                "type": "text"
+              }
+            ]
+          }
+        ]
+      },
+      {
+        "id": "application_info_2",
+        "title": "Application Specific Information 2"
+      },
+      {
+        "id": "document_upload",
+        "title": "Upload Documents",
+        "description": "REQUIRED DOCUMENTS\nIn order for your application to be processed, based on information provided, you are required to upload the following documents:",
+        "sections": [
+          {
+            "id": "initial_site_survey",
+            "title": "Initial Site Survey Form",
+            "fields": [
+              {
+                "id": "site_survey_file",
+                "label": "Upload Initial Site Survey Form",
+                "type": "file",
+                "required": true,
+                "constraints": {
+                  "maxFileSizeMB": 25,
+                  "allowedTypes": [
+                    "application/pdf",
+                    "image/jpeg",
+                    "image/jpg",
+                    "image/png"
+                  ]
+                },
+                "metadata": {
+                  "proofCategory": "Initial Site Survey",
+                  "multiple": false
+                }
+              }
+            ]
+          },
+          {
+            "id": "personal_id_proof",
+            "title": "Proof of Personal Identification",
+            "fields": [
+              {
+                "id": "personal_id_file",
+                "label": "Upload Proof of Personal Identification",
+                "type": "file",
+                "required": true,
+                "constraints": {
+                  "maxFileSizeMB": 25,
+                  "allowedTypes": [
+                    "application/pdf",
+                    "image/jpeg",
+                    "image/jpg",
+                    "image/png"
+                  ]
+                },
+                "metadata": {
+                  "proofCategory": "Personal ID",
+                  "multiple": false
+                }
+              }
+            ]
+          },
+          {
+            "id": "fee_exemption_proof",
+            "title": "Proof of Fee Exemption",
+            "fields": [
+              {
+                "id": "fee_exemption_file",
+                "label": "Upload Proof of Fee Exemption (ACS Affiliation or Municipal Exemption)",
+                "type": "file",
+                "required": true,
+                "constraints": {
+                  "maxFileSizeMB": 25,
+                  "allowedTypes": [
+                    "application/pdf",
+                    "image/jpeg",
+                    "image/jpg",
+                    "image/png"
+                  ]
+                },
+                "metadata": {
+                  "proofCategory": "Fee Exemption",
+                  "multiple": false
+                }
+              }
+            ]
+          }
+        ]
+      },
+      {
+        "id": "step_6_placeholder",
+        "title": "To be defined"
+      },
+      {
+        "id": "step_7_placeholder",
+        "title": "To be defined"
+      },
+      {
+        "id": "step_8_placeholder",
+        "title": "To be defined"
+      }
+    ]
+  }
+}

--- a/test-form/public/data/group_cc_permit.es.json
+++ b/test-form/public/data/group_cc_permit.es.json
@@ -1,0 +1,788 @@
+{
+  "form": {
+    "title": "Group Child Care Permit Application",
+    "description": "Multi-step application for obtaining a permit to operate group child care programs.",
+    "layout": {
+      "stepperPosition": "left"
+    },
+    "steps": [
+      {
+        "id": "establishment_information",
+        "title": "Establishment Information",
+        "sections": [
+          {
+            "id": "establishment_address",
+            "title": "Establishment Address",
+            "description": "Enter the physical address where business will operate. If you are applying for a Tattoo License, enter your mailing or home address.",
+            "ui": {
+              "autocomplete": "street_1",
+              "placeholder": "Start typing your street address",
+              "overrideComponent": "AddressAutocomplete"
+            },
+            "metadata": {
+              "integration": {
+                "provider": "Google",
+                "feature": "AddressAutocomplete"
+              },
+              "autofillTargets": [
+                {
+                  "fieldId": "city",
+                  "source": "locality",
+                  "fallbackSources": [
+                    "postal_town",
+                    "sublocality_level_1",
+                    "administrative_area_level_2"
+                  ]
+                },
+                {
+                  "fieldId": "borough",
+                  "source": "sublocality_level_1",
+                  "fallbackSources": [
+                    "administrative_area_level_2"
+                  ],
+                  "mapping": "boroughMap"
+                },
+                { "fieldId": "state", "source": "administrative_area_level_1" },
+                { "fieldId": "building_number", "source": "street_number" },
+                { "fieldId": "house_number", "source": "street_number" }
+              ]
+            },
+            "fields": [
+              {
+                "id": "address_type",
+                "label": "Address Type",
+                "type": "select",
+                "required": true,
+                "ui": {
+                  "options": [
+                    "Select",
+                    "Complete Address",
+                    "Cross Street (Intersection)",
+                    "Place (Landmark)"
+                  ]
+                }
+              },
+              {
+                "id": "street_1",
+                "label": "Street 1",
+                "type": "text",
+                "required": true
+              },
+              {
+                "id": "building_number",
+                "label": "Building #",
+                "type": "text",
+                "required": true
+              },
+              {
+                "id": "street_2",
+                "label": "Street 2",
+                "type": "text",
+                "required": false
+              },
+              {
+                "id": "unit_type",
+                "label": "Unit Type",
+                "type": "select",
+                "required": false,
+                "ui": {
+                  "options": [
+                    "LBBY",
+                    "APT",
+                    "BLDG",
+                    "STE",
+                    "FL",
+                    "BSMT",
+                    "FRNT",
+                    "SIDE",
+                    "REAR",
+                    "UPPR",
+                    "LOWR",
+                    "PIER"
+                  ]
+                }
+              },
+              {
+                "id": "unit",
+                "label": "Unit",
+                "type": "text",
+                "required": false
+              },
+              {
+                "id": "city",
+                "label": "City",
+                "type": "text",
+                "required": true
+              },
+              {
+                "id": "state",
+                "label": "State",
+                "type": "text",
+                "required": true
+              },
+              {
+                "id": "borough",
+                "label": "Borough",
+                "type": "select",
+                "required": true,
+                "ui": {
+                  "options": [
+                    "Bronx",
+                    "Brooklyn",
+                    "Manhattan",
+                    "Queens",
+                    "Staten Island"
+                  ]
+                }
+              },
+              {
+                "id": "bin",
+                "label": "Bin",
+                "type": "text",
+                "required": false,
+                "metadata": {
+                  "source": "Geoclient API"
+                }
+              },
+              {
+                "id": "bbl",
+                "label": "Bbl",
+                "type": "text",
+                "required": false,
+                "metadata": {
+                  "source": "Geoclient API"
+                }
+              },
+              {
+                "id": "community_district",
+                "label": "Community District",
+                "type": "text",
+                "required": false,
+                "metadata": {
+                  "source": "Geoclient API"
+                }
+              },
+              {
+                "id": "council_district",
+                "label": "Council District",
+                "type": "text",
+                "required": false,
+                "metadata": {
+                  "source": "Geoclient API"
+                }
+              },
+              {
+                "id": "police_precinct",
+                "label": "Police Precinct",
+                "type": "text",
+                "required": false,
+                "metadata": {
+                  "source": "Geoclient API"
+                }
+              },
+              {
+                "id": "house_number",
+                "label": "House Number",
+                "type": "text",
+                "required": false,
+                "metadata": {
+                  "source": "Geoclient API"
+                }
+              }
+            ]
+          }
+        ]
+      },
+      {
+        "id": "contact_information",
+        "title": "Contact Information – Applicant and Other Contacts",
+        "sections": [
+          {
+            "id": "contact_info_guidance",
+            "title": "Contact Type Guidance",
+            "type": "info",
+            "ui": {
+              "markdown": true,
+              "collapsible": false,
+              "defaultCollapsed": false
+            },
+            "content": "### Applying as a Corporation, Partnership, or Not-for-Profit?\n\nSelect **\"Business Information\"** as your Type of Contact and complete the required fields.  \nBusinesses also have the opportunity to provide a complete list of the responsible individuals within their organization. To add each individual's information to your application, please select **\"Other Contact\"** as the Type of Contact and complete the required fields that appear.\n\n---\n\n### Applying as an Individual or Sole Proprietorship?\n\nSelect **\"Individual Owner\"** as your Type of Contact and complete the required fields that appear.\n\n---\n\n### Emergency Contact?\n\nUnless a **\"Designated Emergency Contact\"** is specified, the applicant will be assumed to be the Emergency Contact.  \nTo identify someone other than the applicant to be contacted in the event of an emergency, please select **\"Designated Emergency Contact\"** as the Type of Contact and complete the required fields that appear."
+          },
+          {
+            "id": "contact_list",
+            "title": "Contact List",
+            "fields": [
+              {
+                "id": "contacts",
+                "label": "Contacts",
+                "type": "group",
+                "metadata": {
+                  "multiple": true,
+                  "tableColumns": ["contact_type", "first_name", "last_name", "establishment_name", "email"]
+                },
+                "fields": [
+                  {
+                    "id": "contact_type",
+                    "label": "Type of Contact",
+                    "type": "select",
+                    "required": true,
+                    "ui": {
+                      "options": [
+                        "Business Information",
+                        "Individual Owner",
+                        "Other Contact",
+                        "Designated Emergency Contact"
+                      ]
+                    }
+                  },
+                  {
+                    "id": "establishment_name",
+                    "label": "Establishment Name",
+                    "type": "text",
+                    "requiredCondition": {
+                      "field": "contact_type",
+                      "operator": "equals",
+                      "value": "Business Information"
+                    }
+                  },
+                  {
+                    "id": "dba_name",
+                    "label": "DBA / Trade Name",
+                    "type": "text",
+                    "requiredCondition": {
+                      "field": "contact_type",
+                      "operator": "equals",
+                      "value": "Business Information"
+                    }
+                  },
+                  {
+                    "id": "legal_structure",
+                    "label": "Legal Structure",
+                    "type": "select",
+                    "requiredCondition": {
+                      "field": "contact_type",
+                      "operator": "equals",
+                      "value": "Business Information"
+                    },
+                    "ui": {
+                      "options": [
+                        "Corporation",
+                        "Partnership",
+                        "Limited Partnership",
+                        "Limited Liability",
+                        "Not-for-Profit"
+                      ]
+                    }
+                  },
+                  {
+                    "id": "nys_sales_tax_id",
+                    "label": "NYS Sales Tax ID #",
+                    "type": "text",
+                    "requiredCondition": {
+                      "field": "contact_type",
+                      "operator": "equals",
+                      "value": "Business Information"
+                    }
+                  },
+                  {
+                    "id": "is_out_of_state_corp",
+                    "label": "Are you a corporation formed outside of New York State?",
+                    "type": "radio",
+                    "requiredCondition": {
+                      "field": "contact_type",
+                      "operator": "equals",
+                      "value": "Business Information"
+                    },
+                    "ui": {
+                      "options": ["Yes", "No"]
+                    }
+                  },
+                  {
+                    "id": "first_name",
+                    "label": "First Name",
+                    "type": "text",
+                    "requiredCondition": {
+                      "anyOf": [
+                        { "field": "contact_type", "operator": "equals", "value": "Individual Owner" },
+                        { "field": "contact_type", "operator": "equals", "value": "Other Contact" },
+                        { "field": "contact_type", "operator": "equals", "value": "Designated Emergency Contact" }
+                      ]
+                    }
+                  },
+                  {
+                    "id": "last_name",
+                    "label": "Last Name",
+                    "type": "text",
+                    "requiredCondition": {
+                      "anyOf": [
+                        { "field": "contact_type", "operator": "equals", "value": "Individual Owner" },
+                        { "field": "contact_type", "operator": "equals", "value": "Other Contact" },
+                        { "field": "contact_type", "operator": "equals", "value": "Designated Emergency Contact" }
+                      ]
+                    }
+                  },
+                  {
+                    "id": "title",
+                    "label": "Title",
+                    "type": "text",
+                    "required": false
+                  },
+                  {
+                    "id": "email",
+                    "label": "E-mail Address",
+                    "type": "email",
+                    "required": true
+                  },
+                  {
+                    "id": "ssn_itin",
+                    "label": "SSN / ITIN",
+                    "type": "text",
+                    "required": false,
+                    "constraints": {
+                      "pattern": "^(\\d{3}-\\d{2}-\\d{4}|\\d{9})$"
+                    },
+                    "ui": {
+                      "placeholder": "XXX-XX-XXXX or 9-digit ITIN"
+                    }
+                  },
+                  {
+                    "id": "ssn_itin_type",
+                    "label": "Did you enter SSN or ITIN?",
+                    "type": "radio",
+                    "requiredCondition": {
+                      "field": "ssn_itin",
+                      "operator": "notEquals",
+                      "value": ""
+                    },
+                    "ui": {
+                      "options": ["SSN", "ITIN"]
+                    }
+                  },
+                  {
+                    "id": "phone",
+                    "label": "Phone Number",
+                    "type": "tel",
+                    "required": true,
+                    "constraints": {
+                      "pattern": "^\\(?[0-9]{3}\\)?[-. ]?[0-9]{3}[-. ]?[0-9]{4}$"
+                    },
+                    "ui": {
+                      "placeholder": "(123) 456-7890"
+                    }
+                  },
+                  {
+                    "id": "tty_phone",
+                    "label": "TTY Phone",
+                    "type": "tel",
+                    "required": false
+                  },
+                  {
+                    "id": "date_of_birth",
+                    "label": "Date of Birth",
+                    "type": "date",
+                    "required": false
+                  },
+                  {
+                    "id": "gender",
+                    "label": "Gender",
+                    "type": "radio",
+                    "required": false,
+                    "ui": {
+                      "options": ["Female", "Male"]
+                    }
+                  }
+                ]
+              }
+            ]
+          }
+        ]
+      },
+
+      {
+        "id": "application_info_1",
+        "title": "Application Specific Information 1",
+        "sections": [
+          {
+            "id": "program_details",
+            "title": "Program Details",
+            "fields": [
+              {
+                "id": "program_type",
+                "label": "Program Type",
+                "type": "select",
+                "required": true,
+                "ui": {
+                  "options": [
+                    "Infant Toddler",
+                    "Preschool"
+                  ]
+                }
+              },
+              {
+                "id": "orientation_cert_number",
+                "label": "Pre Permit Orientation Cert #",
+                "type": "text",
+                "required": true
+              },
+              {
+                "id": "permittee_name",
+                "label": "Permittee (Sponsor Name)",
+                "type": "text",
+                "required": true
+              },
+              {
+                "id": "is_applicant_same_as_permittee",
+                "label": "Applicant same as Permittee?",
+                "type": "checkbox",
+                "ui": {
+                  "defaultChecked": true
+                }
+              },
+              {
+                "id": "permit_expiration_date",
+                "label": "Expiration Date",
+                "type": "date",
+                "required": false
+              },
+              {
+                "id": "permit_number",
+                "label": "Permit #",
+                "type": "text",
+                "required": false
+              }
+            ]
+          },
+          {
+            "id": "program_contact",
+            "title": "Program Contact",
+            "fields": [
+              {
+                "id": "program_phone",
+                "label": "Phone",
+                "type": "tel"
+              },
+              {
+                "id": "program_fax",
+                "label": "Fax",
+                "type": "tel"
+              },
+              {
+                "id": "program_email",
+                "label": "Email",
+                "type": "email",
+                "required": true
+              },
+              {
+                "id": "program_website",
+                "label": "Website",
+                "type": "text"
+              }
+            ]
+          },
+          {
+            "id": "program_days_hours",
+            "title": "Days Open (Hours)",
+            "fields": [
+              {
+                "id": "open_days",
+                "label": "Open Days",
+                "type": "checkbox",
+                "ui": {
+                  "options": [
+                    "Sunday",
+                    "Monday",
+                    "Tuesday",
+                    "Wednesday",
+                    "Thursday",
+                    "Friday",
+                    "Saturday"
+                  ]
+                }
+              },
+              {
+                "id": "nightcare",
+                "label": "Nightcare",
+                "type": "checkbox"
+              },
+              {
+                "id": "open_from",
+                "label": "Open From",
+                "type": "time",
+                "required": true
+              },
+              {
+                "id": "close_at",
+                "label": "Close At",
+                "type": "time",
+                "required": true
+              },
+              {
+                "id": "inspection_delivery_method",
+                "label": "Inspection Report Delivery Method",
+                "type": "select",
+                "ui": {
+                  "options": [
+                    "Email",
+                    "Fax",
+                    "Regular Mail"
+                  ]
+                }
+              },
+              {
+                "id": "inspection_language",
+                "label": "Inspection Language",
+                "type": "select",
+                "ui": {
+                  "options": [
+                    "English",
+                    "Spanish"
+                  ]
+                }
+              }
+            ]
+          },
+          {
+            "id": "school_year_dates",
+            "title": "School Year Dates",
+            "fields": [
+              {
+                "id": "school_year_from",
+                "label": "Regular School Year From",
+                "type": "date"
+              },
+              {
+                "id": "school_year_to",
+                "label": "Regular School Year To",
+                "type": "date"
+              },
+              {
+                "id": "has_summer_program",
+                "label": "Summer Program",
+                "type": "checkbox"
+              }
+            ]
+          },
+          {
+            "id": "school_breaks",
+            "title": "School Breaks",
+            "fields": [
+              {
+                "id": "school_breaks",
+                "label": "School Breaks",
+                "type": "group",
+                "metadata": {
+                  "multiple": true,
+                  "tableColumns": [
+                    "term",
+                    "from",
+                    "to"
+                  ]
+                },
+                "fields": [
+                  {
+                    "id": "term",
+                    "label": "Term",
+                    "type": "select",
+                    "required": true,
+                    "ui": {
+                      "options": [
+                        "Fall",
+                        "Spring",
+                        "Summer",
+                        "Winter"
+                      ]
+                    }
+                  },
+                  {
+                    "id": "from",
+                    "label": "From",
+                    "type": "date",
+                    "required": true
+                  },
+                  {
+                    "id": "to",
+                    "label": "To",
+                    "type": "date",
+                    "required": true
+                  }
+                ]
+              }
+            ]
+          },
+          {
+            "id": "holidays",
+            "title": "Holidays",
+            "fields": [
+              {
+                "id": "holidays",
+                "label": "Holiday List",
+                "type": "group",
+                "metadata": {
+                  "multiple": true,
+                  "tableColumns": [
+                    "holiday_name"
+                  ]
+                },
+                "fields": [
+                  {
+                    "id": "holiday_name",
+                    "label": "Holiday Name",
+                    "type": "text",
+                    "required": true
+                  }
+                ]
+              }
+            ]
+          },
+          {
+            "id": "food_services_info",
+            "title": "Food Services Information",
+            "fields": [
+              {
+                "id": "food_provided",
+                "label": "Is food provided for children in care?",
+                "type": "radio",
+                "required": true,
+                "ui": {
+                  "options": [
+                    "Yes",
+                    "No"
+                  ]
+                }
+              },
+              {
+                "id": "food_prepared_on_site",
+                "label": "Is food prepared on site?",
+                "type": "radio",
+                "ui": {
+                  "options": [
+                    "Yes",
+                    "No"
+                  ]
+                }
+              },
+              {
+                "id": "food_preparation_location",
+                "label": "Where is food prepared?",
+                "type": "text"
+              },
+              {
+                "id": "dohmh_food_service_permit",
+                "label": "DOHMH Food Service Permit #",
+                "type": "text"
+              },
+              {
+                "id": "person_on_certificate",
+                "label": "Person Name on Certificate",
+                "type": "text"
+              },
+              {
+                "id": "food_protection_cert_number",
+                "label": "Food Protection Certificate #",
+                "type": "text"
+              }
+            ]
+          }
+        ]
+      },
+      {
+        "id": "application_info_2",
+        "title": "Application Specific Information 2"
+      },
+      {
+        "id": "document_upload",
+        "title": "Upload Documents",
+        "description": "REQUIRED DOCUMENTS\nIn order for your application to be processed, based on information provided, you are required to upload the following documents:",
+        "sections": [
+          {
+            "id": "initial_site_survey",
+            "title": "Initial Site Survey Form",
+            "fields": [
+              {
+                "id": "site_survey_file",
+                "label": "Upload Initial Site Survey Form",
+                "type": "file",
+                "required": true,
+                "constraints": {
+                  "maxFileSizeMB": 25,
+                  "allowedTypes": [
+                    "application/pdf",
+                    "image/jpeg",
+                    "image/jpg",
+                    "image/png"
+                  ]
+                },
+                "metadata": {
+                  "proofCategory": "Initial Site Survey",
+                  "multiple": false
+                }
+              }
+            ]
+          },
+          {
+            "id": "personal_id_proof",
+            "title": "Proof of Personal Identification",
+            "fields": [
+              {
+                "id": "personal_id_file",
+                "label": "Upload Proof of Personal Identification",
+                "type": "file",
+                "required": true,
+                "constraints": {
+                  "maxFileSizeMB": 25,
+                  "allowedTypes": [
+                    "application/pdf",
+                    "image/jpeg",
+                    "image/jpg",
+                    "image/png"
+                  ]
+                },
+                "metadata": {
+                  "proofCategory": "Personal ID",
+                  "multiple": false
+                }
+              }
+            ]
+          },
+          {
+            "id": "fee_exemption_proof",
+            "title": "Proof of Fee Exemption",
+            "fields": [
+              {
+                "id": "fee_exemption_file",
+                "label": "Upload Proof of Fee Exemption (ACS Affiliation or Municipal Exemption)",
+                "type": "file",
+                "required": true,
+                "constraints": {
+                  "maxFileSizeMB": 25,
+                  "allowedTypes": [
+                    "application/pdf",
+                    "image/jpeg",
+                    "image/jpg",
+                    "image/png"
+                  ]
+                },
+                "metadata": {
+                  "proofCategory": "Fee Exemption",
+                  "multiple": false
+                }
+              }
+            ]
+          }
+        ]
+      },
+      {
+        "id": "step_6_placeholder",
+        "title": "To be defined"
+      },
+      {
+        "id": "step_7_placeholder",
+        "title": "To be defined"
+      },
+      {
+        "id": "step_8_placeholder",
+        "title": "To be defined"
+      }
+    ]
+  }
+}

--- a/test-form/public/data/group_cc_permit.fr.json
+++ b/test-form/public/data/group_cc_permit.fr.json
@@ -1,0 +1,788 @@
+{
+  "form": {
+    "title": "Group Child Care Permit Application",
+    "description": "Multi-step application for obtaining a permit to operate group child care programs.",
+    "layout": {
+      "stepperPosition": "left"
+    },
+    "steps": [
+      {
+        "id": "establishment_information",
+        "title": "Establishment Information",
+        "sections": [
+          {
+            "id": "establishment_address",
+            "title": "Establishment Address",
+            "description": "Enter the physical address where business will operate. If you are applying for a Tattoo License, enter your mailing or home address.",
+            "ui": {
+              "autocomplete": "street_1",
+              "placeholder": "Start typing your street address",
+              "overrideComponent": "AddressAutocomplete"
+            },
+            "metadata": {
+              "integration": {
+                "provider": "Google",
+                "feature": "AddressAutocomplete"
+              },
+              "autofillTargets": [
+                {
+                  "fieldId": "city",
+                  "source": "locality",
+                  "fallbackSources": [
+                    "postal_town",
+                    "sublocality_level_1",
+                    "administrative_area_level_2"
+                  ]
+                },
+                {
+                  "fieldId": "borough",
+                  "source": "sublocality_level_1",
+                  "fallbackSources": [
+                    "administrative_area_level_2"
+                  ],
+                  "mapping": "boroughMap"
+                },
+                { "fieldId": "state", "source": "administrative_area_level_1" },
+                { "fieldId": "building_number", "source": "street_number" },
+                { "fieldId": "house_number", "source": "street_number" }
+              ]
+            },
+            "fields": [
+              {
+                "id": "address_type",
+                "label": "Address Type",
+                "type": "select",
+                "required": true,
+                "ui": {
+                  "options": [
+                    "Select",
+                    "Complete Address",
+                    "Cross Street (Intersection)",
+                    "Place (Landmark)"
+                  ]
+                }
+              },
+              {
+                "id": "street_1",
+                "label": "Street 1",
+                "type": "text",
+                "required": true
+              },
+              {
+                "id": "building_number",
+                "label": "Building #",
+                "type": "text",
+                "required": true
+              },
+              {
+                "id": "street_2",
+                "label": "Street 2",
+                "type": "text",
+                "required": false
+              },
+              {
+                "id": "unit_type",
+                "label": "Unit Type",
+                "type": "select",
+                "required": false,
+                "ui": {
+                  "options": [
+                    "LBBY",
+                    "APT",
+                    "BLDG",
+                    "STE",
+                    "FL",
+                    "BSMT",
+                    "FRNT",
+                    "SIDE",
+                    "REAR",
+                    "UPPR",
+                    "LOWR",
+                    "PIER"
+                  ]
+                }
+              },
+              {
+                "id": "unit",
+                "label": "Unit",
+                "type": "text",
+                "required": false
+              },
+              {
+                "id": "city",
+                "label": "City",
+                "type": "text",
+                "required": true
+              },
+              {
+                "id": "state",
+                "label": "State",
+                "type": "text",
+                "required": true
+              },
+              {
+                "id": "borough",
+                "label": "Borough",
+                "type": "select",
+                "required": true,
+                "ui": {
+                  "options": [
+                    "Bronx",
+                    "Brooklyn",
+                    "Manhattan",
+                    "Queens",
+                    "Staten Island"
+                  ]
+                }
+              },
+              {
+                "id": "bin",
+                "label": "Bin",
+                "type": "text",
+                "required": false,
+                "metadata": {
+                  "source": "Geoclient API"
+                }
+              },
+              {
+                "id": "bbl",
+                "label": "Bbl",
+                "type": "text",
+                "required": false,
+                "metadata": {
+                  "source": "Geoclient API"
+                }
+              },
+              {
+                "id": "community_district",
+                "label": "Community District",
+                "type": "text",
+                "required": false,
+                "metadata": {
+                  "source": "Geoclient API"
+                }
+              },
+              {
+                "id": "council_district",
+                "label": "Council District",
+                "type": "text",
+                "required": false,
+                "metadata": {
+                  "source": "Geoclient API"
+                }
+              },
+              {
+                "id": "police_precinct",
+                "label": "Police Precinct",
+                "type": "text",
+                "required": false,
+                "metadata": {
+                  "source": "Geoclient API"
+                }
+              },
+              {
+                "id": "house_number",
+                "label": "House Number",
+                "type": "text",
+                "required": false,
+                "metadata": {
+                  "source": "Geoclient API"
+                }
+              }
+            ]
+          }
+        ]
+      },
+      {
+        "id": "contact_information",
+        "title": "Contact Information – Applicant and Other Contacts",
+        "sections": [
+          {
+            "id": "contact_info_guidance",
+            "title": "Contact Type Guidance",
+            "type": "info",
+            "ui": {
+              "markdown": true,
+              "collapsible": false,
+              "defaultCollapsed": false
+            },
+            "content": "### Applying as a Corporation, Partnership, or Not-for-Profit?\n\nSelect **\"Business Information\"** as your Type of Contact and complete the required fields.  \nBusinesses also have the opportunity to provide a complete list of the responsible individuals within their organization. To add each individual's information to your application, please select **\"Other Contact\"** as the Type of Contact and complete the required fields that appear.\n\n---\n\n### Applying as an Individual or Sole Proprietorship?\n\nSelect **\"Individual Owner\"** as your Type of Contact and complete the required fields that appear.\n\n---\n\n### Emergency Contact?\n\nUnless a **\"Designated Emergency Contact\"** is specified, the applicant will be assumed to be the Emergency Contact.  \nTo identify someone other than the applicant to be contacted in the event of an emergency, please select **\"Designated Emergency Contact\"** as the Type of Contact and complete the required fields that appear."
+          },
+          {
+            "id": "contact_list",
+            "title": "Contact List",
+            "fields": [
+              {
+                "id": "contacts",
+                "label": "Contacts",
+                "type": "group",
+                "metadata": {
+                  "multiple": true,
+                  "tableColumns": ["contact_type", "first_name", "last_name", "establishment_name", "email"]
+                },
+                "fields": [
+                  {
+                    "id": "contact_type",
+                    "label": "Type of Contact",
+                    "type": "select",
+                    "required": true,
+                    "ui": {
+                      "options": [
+                        "Business Information",
+                        "Individual Owner",
+                        "Other Contact",
+                        "Designated Emergency Contact"
+                      ]
+                    }
+                  },
+                  {
+                    "id": "establishment_name",
+                    "label": "Establishment Name",
+                    "type": "text",
+                    "requiredCondition": {
+                      "field": "contact_type",
+                      "operator": "equals",
+                      "value": "Business Information"
+                    }
+                  },
+                  {
+                    "id": "dba_name",
+                    "label": "DBA / Trade Name",
+                    "type": "text",
+                    "requiredCondition": {
+                      "field": "contact_type",
+                      "operator": "equals",
+                      "value": "Business Information"
+                    }
+                  },
+                  {
+                    "id": "legal_structure",
+                    "label": "Legal Structure",
+                    "type": "select",
+                    "requiredCondition": {
+                      "field": "contact_type",
+                      "operator": "equals",
+                      "value": "Business Information"
+                    },
+                    "ui": {
+                      "options": [
+                        "Corporation",
+                        "Partnership",
+                        "Limited Partnership",
+                        "Limited Liability",
+                        "Not-for-Profit"
+                      ]
+                    }
+                  },
+                  {
+                    "id": "nys_sales_tax_id",
+                    "label": "NYS Sales Tax ID #",
+                    "type": "text",
+                    "requiredCondition": {
+                      "field": "contact_type",
+                      "operator": "equals",
+                      "value": "Business Information"
+                    }
+                  },
+                  {
+                    "id": "is_out_of_state_corp",
+                    "label": "Are you a corporation formed outside of New York State?",
+                    "type": "radio",
+                    "requiredCondition": {
+                      "field": "contact_type",
+                      "operator": "equals",
+                      "value": "Business Information"
+                    },
+                    "ui": {
+                      "options": ["Yes", "No"]
+                    }
+                  },
+                  {
+                    "id": "first_name",
+                    "label": "First Name",
+                    "type": "text",
+                    "requiredCondition": {
+                      "anyOf": [
+                        { "field": "contact_type", "operator": "equals", "value": "Individual Owner" },
+                        { "field": "contact_type", "operator": "equals", "value": "Other Contact" },
+                        { "field": "contact_type", "operator": "equals", "value": "Designated Emergency Contact" }
+                      ]
+                    }
+                  },
+                  {
+                    "id": "last_name",
+                    "label": "Last Name",
+                    "type": "text",
+                    "requiredCondition": {
+                      "anyOf": [
+                        { "field": "contact_type", "operator": "equals", "value": "Individual Owner" },
+                        { "field": "contact_type", "operator": "equals", "value": "Other Contact" },
+                        { "field": "contact_type", "operator": "equals", "value": "Designated Emergency Contact" }
+                      ]
+                    }
+                  },
+                  {
+                    "id": "title",
+                    "label": "Title",
+                    "type": "text",
+                    "required": false
+                  },
+                  {
+                    "id": "email",
+                    "label": "E-mail Address",
+                    "type": "email",
+                    "required": true
+                  },
+                  {
+                    "id": "ssn_itin",
+                    "label": "SSN / ITIN",
+                    "type": "text",
+                    "required": false,
+                    "constraints": {
+                      "pattern": "^(\\d{3}-\\d{2}-\\d{4}|\\d{9})$"
+                    },
+                    "ui": {
+                      "placeholder": "XXX-XX-XXXX or 9-digit ITIN"
+                    }
+                  },
+                  {
+                    "id": "ssn_itin_type",
+                    "label": "Did you enter SSN or ITIN?",
+                    "type": "radio",
+                    "requiredCondition": {
+                      "field": "ssn_itin",
+                      "operator": "notEquals",
+                      "value": ""
+                    },
+                    "ui": {
+                      "options": ["SSN", "ITIN"]
+                    }
+                  },
+                  {
+                    "id": "phone",
+                    "label": "Phone Number",
+                    "type": "tel",
+                    "required": true,
+                    "constraints": {
+                      "pattern": "^\\(?[0-9]{3}\\)?[-. ]?[0-9]{3}[-. ]?[0-9]{4}$"
+                    },
+                    "ui": {
+                      "placeholder": "(123) 456-7890"
+                    }
+                  },
+                  {
+                    "id": "tty_phone",
+                    "label": "TTY Phone",
+                    "type": "tel",
+                    "required": false
+                  },
+                  {
+                    "id": "date_of_birth",
+                    "label": "Date of Birth",
+                    "type": "date",
+                    "required": false
+                  },
+                  {
+                    "id": "gender",
+                    "label": "Gender",
+                    "type": "radio",
+                    "required": false,
+                    "ui": {
+                      "options": ["Female", "Male"]
+                    }
+                  }
+                ]
+              }
+            ]
+          }
+        ]
+      },
+
+      {
+        "id": "application_info_1",
+        "title": "Application Specific Information 1",
+        "sections": [
+          {
+            "id": "program_details",
+            "title": "Program Details",
+            "fields": [
+              {
+                "id": "program_type",
+                "label": "Program Type",
+                "type": "select",
+                "required": true,
+                "ui": {
+                  "options": [
+                    "Infant Toddler",
+                    "Preschool"
+                  ]
+                }
+              },
+              {
+                "id": "orientation_cert_number",
+                "label": "Pre Permit Orientation Cert #",
+                "type": "text",
+                "required": true
+              },
+              {
+                "id": "permittee_name",
+                "label": "Permittee (Sponsor Name)",
+                "type": "text",
+                "required": true
+              },
+              {
+                "id": "is_applicant_same_as_permittee",
+                "label": "Applicant same as Permittee?",
+                "type": "checkbox",
+                "ui": {
+                  "defaultChecked": true
+                }
+              },
+              {
+                "id": "permit_expiration_date",
+                "label": "Expiration Date",
+                "type": "date",
+                "required": false
+              },
+              {
+                "id": "permit_number",
+                "label": "Permit #",
+                "type": "text",
+                "required": false
+              }
+            ]
+          },
+          {
+            "id": "program_contact",
+            "title": "Program Contact",
+            "fields": [
+              {
+                "id": "program_phone",
+                "label": "Phone",
+                "type": "tel"
+              },
+              {
+                "id": "program_fax",
+                "label": "Fax",
+                "type": "tel"
+              },
+              {
+                "id": "program_email",
+                "label": "Email",
+                "type": "email",
+                "required": true
+              },
+              {
+                "id": "program_website",
+                "label": "Website",
+                "type": "text"
+              }
+            ]
+          },
+          {
+            "id": "program_days_hours",
+            "title": "Days Open (Hours)",
+            "fields": [
+              {
+                "id": "open_days",
+                "label": "Open Days",
+                "type": "checkbox",
+                "ui": {
+                  "options": [
+                    "Sunday",
+                    "Monday",
+                    "Tuesday",
+                    "Wednesday",
+                    "Thursday",
+                    "Friday",
+                    "Saturday"
+                  ]
+                }
+              },
+              {
+                "id": "nightcare",
+                "label": "Nightcare",
+                "type": "checkbox"
+              },
+              {
+                "id": "open_from",
+                "label": "Open From",
+                "type": "time",
+                "required": true
+              },
+              {
+                "id": "close_at",
+                "label": "Close At",
+                "type": "time",
+                "required": true
+              },
+              {
+                "id": "inspection_delivery_method",
+                "label": "Inspection Report Delivery Method",
+                "type": "select",
+                "ui": {
+                  "options": [
+                    "Email",
+                    "Fax",
+                    "Regular Mail"
+                  ]
+                }
+              },
+              {
+                "id": "inspection_language",
+                "label": "Inspection Language",
+                "type": "select",
+                "ui": {
+                  "options": [
+                    "English",
+                    "Spanish"
+                  ]
+                }
+              }
+            ]
+          },
+          {
+            "id": "school_year_dates",
+            "title": "School Year Dates",
+            "fields": [
+              {
+                "id": "school_year_from",
+                "label": "Regular School Year From",
+                "type": "date"
+              },
+              {
+                "id": "school_year_to",
+                "label": "Regular School Year To",
+                "type": "date"
+              },
+              {
+                "id": "has_summer_program",
+                "label": "Summer Program",
+                "type": "checkbox"
+              }
+            ]
+          },
+          {
+            "id": "school_breaks",
+            "title": "School Breaks",
+            "fields": [
+              {
+                "id": "school_breaks",
+                "label": "School Breaks",
+                "type": "group",
+                "metadata": {
+                  "multiple": true,
+                  "tableColumns": [
+                    "term",
+                    "from",
+                    "to"
+                  ]
+                },
+                "fields": [
+                  {
+                    "id": "term",
+                    "label": "Term",
+                    "type": "select",
+                    "required": true,
+                    "ui": {
+                      "options": [
+                        "Fall",
+                        "Spring",
+                        "Summer",
+                        "Winter"
+                      ]
+                    }
+                  },
+                  {
+                    "id": "from",
+                    "label": "From",
+                    "type": "date",
+                    "required": true
+                  },
+                  {
+                    "id": "to",
+                    "label": "To",
+                    "type": "date",
+                    "required": true
+                  }
+                ]
+              }
+            ]
+          },
+          {
+            "id": "holidays",
+            "title": "Holidays",
+            "fields": [
+              {
+                "id": "holidays",
+                "label": "Holiday List",
+                "type": "group",
+                "metadata": {
+                  "multiple": true,
+                  "tableColumns": [
+                    "holiday_name"
+                  ]
+                },
+                "fields": [
+                  {
+                    "id": "holiday_name",
+                    "label": "Holiday Name",
+                    "type": "text",
+                    "required": true
+                  }
+                ]
+              }
+            ]
+          },
+          {
+            "id": "food_services_info",
+            "title": "Food Services Information",
+            "fields": [
+              {
+                "id": "food_provided",
+                "label": "Is food provided for children in care?",
+                "type": "radio",
+                "required": true,
+                "ui": {
+                  "options": [
+                    "Yes",
+                    "No"
+                  ]
+                }
+              },
+              {
+                "id": "food_prepared_on_site",
+                "label": "Is food prepared on site?",
+                "type": "radio",
+                "ui": {
+                  "options": [
+                    "Yes",
+                    "No"
+                  ]
+                }
+              },
+              {
+                "id": "food_preparation_location",
+                "label": "Where is food prepared?",
+                "type": "text"
+              },
+              {
+                "id": "dohmh_food_service_permit",
+                "label": "DOHMH Food Service Permit #",
+                "type": "text"
+              },
+              {
+                "id": "person_on_certificate",
+                "label": "Person Name on Certificate",
+                "type": "text"
+              },
+              {
+                "id": "food_protection_cert_number",
+                "label": "Food Protection Certificate #",
+                "type": "text"
+              }
+            ]
+          }
+        ]
+      },
+      {
+        "id": "application_info_2",
+        "title": "Application Specific Information 2"
+      },
+      {
+        "id": "document_upload",
+        "title": "Upload Documents",
+        "description": "REQUIRED DOCUMENTS\nIn order for your application to be processed, based on information provided, you are required to upload the following documents:",
+        "sections": [
+          {
+            "id": "initial_site_survey",
+            "title": "Initial Site Survey Form",
+            "fields": [
+              {
+                "id": "site_survey_file",
+                "label": "Upload Initial Site Survey Form",
+                "type": "file",
+                "required": true,
+                "constraints": {
+                  "maxFileSizeMB": 25,
+                  "allowedTypes": [
+                    "application/pdf",
+                    "image/jpeg",
+                    "image/jpg",
+                    "image/png"
+                  ]
+                },
+                "metadata": {
+                  "proofCategory": "Initial Site Survey",
+                  "multiple": false
+                }
+              }
+            ]
+          },
+          {
+            "id": "personal_id_proof",
+            "title": "Proof of Personal Identification",
+            "fields": [
+              {
+                "id": "personal_id_file",
+                "label": "Upload Proof of Personal Identification",
+                "type": "file",
+                "required": true,
+                "constraints": {
+                  "maxFileSizeMB": 25,
+                  "allowedTypes": [
+                    "application/pdf",
+                    "image/jpeg",
+                    "image/jpg",
+                    "image/png"
+                  ]
+                },
+                "metadata": {
+                  "proofCategory": "Personal ID",
+                  "multiple": false
+                }
+              }
+            ]
+          },
+          {
+            "id": "fee_exemption_proof",
+            "title": "Proof of Fee Exemption",
+            "fields": [
+              {
+                "id": "fee_exemption_file",
+                "label": "Upload Proof of Fee Exemption (ACS Affiliation or Municipal Exemption)",
+                "type": "file",
+                "required": true,
+                "constraints": {
+                  "maxFileSizeMB": 25,
+                  "allowedTypes": [
+                    "application/pdf",
+                    "image/jpeg",
+                    "image/jpg",
+                    "image/png"
+                  ]
+                },
+                "metadata": {
+                  "proofCategory": "Fee Exemption",
+                  "multiple": false
+                }
+              }
+            ]
+          }
+        ]
+      },
+      {
+        "id": "step_6_placeholder",
+        "title": "To be defined"
+      },
+      {
+        "id": "step_7_placeholder",
+        "title": "To be defined"
+      },
+      {
+        "id": "step_8_placeholder",
+        "title": "To be defined"
+      }
+    ]
+  }
+}

--- a/test-form/public/data/group_cc_permit.ht.json
+++ b/test-form/public/data/group_cc_permit.ht.json
@@ -1,0 +1,788 @@
+{
+  "form": {
+    "title": "Group Child Care Permit Application",
+    "description": "Multi-step application for obtaining a permit to operate group child care programs.",
+    "layout": {
+      "stepperPosition": "left"
+    },
+    "steps": [
+      {
+        "id": "establishment_information",
+        "title": "Establishment Information",
+        "sections": [
+          {
+            "id": "establishment_address",
+            "title": "Establishment Address",
+            "description": "Enter the physical address where business will operate. If you are applying for a Tattoo License, enter your mailing or home address.",
+            "ui": {
+              "autocomplete": "street_1",
+              "placeholder": "Start typing your street address",
+              "overrideComponent": "AddressAutocomplete"
+            },
+            "metadata": {
+              "integration": {
+                "provider": "Google",
+                "feature": "AddressAutocomplete"
+              },
+              "autofillTargets": [
+                {
+                  "fieldId": "city",
+                  "source": "locality",
+                  "fallbackSources": [
+                    "postal_town",
+                    "sublocality_level_1",
+                    "administrative_area_level_2"
+                  ]
+                },
+                {
+                  "fieldId": "borough",
+                  "source": "sublocality_level_1",
+                  "fallbackSources": [
+                    "administrative_area_level_2"
+                  ],
+                  "mapping": "boroughMap"
+                },
+                { "fieldId": "state", "source": "administrative_area_level_1" },
+                { "fieldId": "building_number", "source": "street_number" },
+                { "fieldId": "house_number", "source": "street_number" }
+              ]
+            },
+            "fields": [
+              {
+                "id": "address_type",
+                "label": "Address Type",
+                "type": "select",
+                "required": true,
+                "ui": {
+                  "options": [
+                    "Select",
+                    "Complete Address",
+                    "Cross Street (Intersection)",
+                    "Place (Landmark)"
+                  ]
+                }
+              },
+              {
+                "id": "street_1",
+                "label": "Street 1",
+                "type": "text",
+                "required": true
+              },
+              {
+                "id": "building_number",
+                "label": "Building #",
+                "type": "text",
+                "required": true
+              },
+              {
+                "id": "street_2",
+                "label": "Street 2",
+                "type": "text",
+                "required": false
+              },
+              {
+                "id": "unit_type",
+                "label": "Unit Type",
+                "type": "select",
+                "required": false,
+                "ui": {
+                  "options": [
+                    "LBBY",
+                    "APT",
+                    "BLDG",
+                    "STE",
+                    "FL",
+                    "BSMT",
+                    "FRNT",
+                    "SIDE",
+                    "REAR",
+                    "UPPR",
+                    "LOWR",
+                    "PIER"
+                  ]
+                }
+              },
+              {
+                "id": "unit",
+                "label": "Unit",
+                "type": "text",
+                "required": false
+              },
+              {
+                "id": "city",
+                "label": "City",
+                "type": "text",
+                "required": true
+              },
+              {
+                "id": "state",
+                "label": "State",
+                "type": "text",
+                "required": true
+              },
+              {
+                "id": "borough",
+                "label": "Borough",
+                "type": "select",
+                "required": true,
+                "ui": {
+                  "options": [
+                    "Bronx",
+                    "Brooklyn",
+                    "Manhattan",
+                    "Queens",
+                    "Staten Island"
+                  ]
+                }
+              },
+              {
+                "id": "bin",
+                "label": "Bin",
+                "type": "text",
+                "required": false,
+                "metadata": {
+                  "source": "Geoclient API"
+                }
+              },
+              {
+                "id": "bbl",
+                "label": "Bbl",
+                "type": "text",
+                "required": false,
+                "metadata": {
+                  "source": "Geoclient API"
+                }
+              },
+              {
+                "id": "community_district",
+                "label": "Community District",
+                "type": "text",
+                "required": false,
+                "metadata": {
+                  "source": "Geoclient API"
+                }
+              },
+              {
+                "id": "council_district",
+                "label": "Council District",
+                "type": "text",
+                "required": false,
+                "metadata": {
+                  "source": "Geoclient API"
+                }
+              },
+              {
+                "id": "police_precinct",
+                "label": "Police Precinct",
+                "type": "text",
+                "required": false,
+                "metadata": {
+                  "source": "Geoclient API"
+                }
+              },
+              {
+                "id": "house_number",
+                "label": "House Number",
+                "type": "text",
+                "required": false,
+                "metadata": {
+                  "source": "Geoclient API"
+                }
+              }
+            ]
+          }
+        ]
+      },
+      {
+        "id": "contact_information",
+        "title": "Contact Information – Applicant and Other Contacts",
+        "sections": [
+          {
+            "id": "contact_info_guidance",
+            "title": "Contact Type Guidance",
+            "type": "info",
+            "ui": {
+              "markdown": true,
+              "collapsible": false,
+              "defaultCollapsed": false
+            },
+            "content": "### Applying as a Corporation, Partnership, or Not-for-Profit?\n\nSelect **\"Business Information\"** as your Type of Contact and complete the required fields.  \nBusinesses also have the opportunity to provide a complete list of the responsible individuals within their organization. To add each individual's information to your application, please select **\"Other Contact\"** as the Type of Contact and complete the required fields that appear.\n\n---\n\n### Applying as an Individual or Sole Proprietorship?\n\nSelect **\"Individual Owner\"** as your Type of Contact and complete the required fields that appear.\n\n---\n\n### Emergency Contact?\n\nUnless a **\"Designated Emergency Contact\"** is specified, the applicant will be assumed to be the Emergency Contact.  \nTo identify someone other than the applicant to be contacted in the event of an emergency, please select **\"Designated Emergency Contact\"** as the Type of Contact and complete the required fields that appear."
+          },
+          {
+            "id": "contact_list",
+            "title": "Contact List",
+            "fields": [
+              {
+                "id": "contacts",
+                "label": "Contacts",
+                "type": "group",
+                "metadata": {
+                  "multiple": true,
+                  "tableColumns": ["contact_type", "first_name", "last_name", "establishment_name", "email"]
+                },
+                "fields": [
+                  {
+                    "id": "contact_type",
+                    "label": "Type of Contact",
+                    "type": "select",
+                    "required": true,
+                    "ui": {
+                      "options": [
+                        "Business Information",
+                        "Individual Owner",
+                        "Other Contact",
+                        "Designated Emergency Contact"
+                      ]
+                    }
+                  },
+                  {
+                    "id": "establishment_name",
+                    "label": "Establishment Name",
+                    "type": "text",
+                    "requiredCondition": {
+                      "field": "contact_type",
+                      "operator": "equals",
+                      "value": "Business Information"
+                    }
+                  },
+                  {
+                    "id": "dba_name",
+                    "label": "DBA / Trade Name",
+                    "type": "text",
+                    "requiredCondition": {
+                      "field": "contact_type",
+                      "operator": "equals",
+                      "value": "Business Information"
+                    }
+                  },
+                  {
+                    "id": "legal_structure",
+                    "label": "Legal Structure",
+                    "type": "select",
+                    "requiredCondition": {
+                      "field": "contact_type",
+                      "operator": "equals",
+                      "value": "Business Information"
+                    },
+                    "ui": {
+                      "options": [
+                        "Corporation",
+                        "Partnership",
+                        "Limited Partnership",
+                        "Limited Liability",
+                        "Not-for-Profit"
+                      ]
+                    }
+                  },
+                  {
+                    "id": "nys_sales_tax_id",
+                    "label": "NYS Sales Tax ID #",
+                    "type": "text",
+                    "requiredCondition": {
+                      "field": "contact_type",
+                      "operator": "equals",
+                      "value": "Business Information"
+                    }
+                  },
+                  {
+                    "id": "is_out_of_state_corp",
+                    "label": "Are you a corporation formed outside of New York State?",
+                    "type": "radio",
+                    "requiredCondition": {
+                      "field": "contact_type",
+                      "operator": "equals",
+                      "value": "Business Information"
+                    },
+                    "ui": {
+                      "options": ["Yes", "No"]
+                    }
+                  },
+                  {
+                    "id": "first_name",
+                    "label": "First Name",
+                    "type": "text",
+                    "requiredCondition": {
+                      "anyOf": [
+                        { "field": "contact_type", "operator": "equals", "value": "Individual Owner" },
+                        { "field": "contact_type", "operator": "equals", "value": "Other Contact" },
+                        { "field": "contact_type", "operator": "equals", "value": "Designated Emergency Contact" }
+                      ]
+                    }
+                  },
+                  {
+                    "id": "last_name",
+                    "label": "Last Name",
+                    "type": "text",
+                    "requiredCondition": {
+                      "anyOf": [
+                        { "field": "contact_type", "operator": "equals", "value": "Individual Owner" },
+                        { "field": "contact_type", "operator": "equals", "value": "Other Contact" },
+                        { "field": "contact_type", "operator": "equals", "value": "Designated Emergency Contact" }
+                      ]
+                    }
+                  },
+                  {
+                    "id": "title",
+                    "label": "Title",
+                    "type": "text",
+                    "required": false
+                  },
+                  {
+                    "id": "email",
+                    "label": "E-mail Address",
+                    "type": "email",
+                    "required": true
+                  },
+                  {
+                    "id": "ssn_itin",
+                    "label": "SSN / ITIN",
+                    "type": "text",
+                    "required": false,
+                    "constraints": {
+                      "pattern": "^(\\d{3}-\\d{2}-\\d{4}|\\d{9})$"
+                    },
+                    "ui": {
+                      "placeholder": "XXX-XX-XXXX or 9-digit ITIN"
+                    }
+                  },
+                  {
+                    "id": "ssn_itin_type",
+                    "label": "Did you enter SSN or ITIN?",
+                    "type": "radio",
+                    "requiredCondition": {
+                      "field": "ssn_itin",
+                      "operator": "notEquals",
+                      "value": ""
+                    },
+                    "ui": {
+                      "options": ["SSN", "ITIN"]
+                    }
+                  },
+                  {
+                    "id": "phone",
+                    "label": "Phone Number",
+                    "type": "tel",
+                    "required": true,
+                    "constraints": {
+                      "pattern": "^\\(?[0-9]{3}\\)?[-. ]?[0-9]{3}[-. ]?[0-9]{4}$"
+                    },
+                    "ui": {
+                      "placeholder": "(123) 456-7890"
+                    }
+                  },
+                  {
+                    "id": "tty_phone",
+                    "label": "TTY Phone",
+                    "type": "tel",
+                    "required": false
+                  },
+                  {
+                    "id": "date_of_birth",
+                    "label": "Date of Birth",
+                    "type": "date",
+                    "required": false
+                  },
+                  {
+                    "id": "gender",
+                    "label": "Gender",
+                    "type": "radio",
+                    "required": false,
+                    "ui": {
+                      "options": ["Female", "Male"]
+                    }
+                  }
+                ]
+              }
+            ]
+          }
+        ]
+      },
+
+      {
+        "id": "application_info_1",
+        "title": "Application Specific Information 1",
+        "sections": [
+          {
+            "id": "program_details",
+            "title": "Program Details",
+            "fields": [
+              {
+                "id": "program_type",
+                "label": "Program Type",
+                "type": "select",
+                "required": true,
+                "ui": {
+                  "options": [
+                    "Infant Toddler",
+                    "Preschool"
+                  ]
+                }
+              },
+              {
+                "id": "orientation_cert_number",
+                "label": "Pre Permit Orientation Cert #",
+                "type": "text",
+                "required": true
+              },
+              {
+                "id": "permittee_name",
+                "label": "Permittee (Sponsor Name)",
+                "type": "text",
+                "required": true
+              },
+              {
+                "id": "is_applicant_same_as_permittee",
+                "label": "Applicant same as Permittee?",
+                "type": "checkbox",
+                "ui": {
+                  "defaultChecked": true
+                }
+              },
+              {
+                "id": "permit_expiration_date",
+                "label": "Expiration Date",
+                "type": "date",
+                "required": false
+              },
+              {
+                "id": "permit_number",
+                "label": "Permit #",
+                "type": "text",
+                "required": false
+              }
+            ]
+          },
+          {
+            "id": "program_contact",
+            "title": "Program Contact",
+            "fields": [
+              {
+                "id": "program_phone",
+                "label": "Phone",
+                "type": "tel"
+              },
+              {
+                "id": "program_fax",
+                "label": "Fax",
+                "type": "tel"
+              },
+              {
+                "id": "program_email",
+                "label": "Email",
+                "type": "email",
+                "required": true
+              },
+              {
+                "id": "program_website",
+                "label": "Website",
+                "type": "text"
+              }
+            ]
+          },
+          {
+            "id": "program_days_hours",
+            "title": "Days Open (Hours)",
+            "fields": [
+              {
+                "id": "open_days",
+                "label": "Open Days",
+                "type": "checkbox",
+                "ui": {
+                  "options": [
+                    "Sunday",
+                    "Monday",
+                    "Tuesday",
+                    "Wednesday",
+                    "Thursday",
+                    "Friday",
+                    "Saturday"
+                  ]
+                }
+              },
+              {
+                "id": "nightcare",
+                "label": "Nightcare",
+                "type": "checkbox"
+              },
+              {
+                "id": "open_from",
+                "label": "Open From",
+                "type": "time",
+                "required": true
+              },
+              {
+                "id": "close_at",
+                "label": "Close At",
+                "type": "time",
+                "required": true
+              },
+              {
+                "id": "inspection_delivery_method",
+                "label": "Inspection Report Delivery Method",
+                "type": "select",
+                "ui": {
+                  "options": [
+                    "Email",
+                    "Fax",
+                    "Regular Mail"
+                  ]
+                }
+              },
+              {
+                "id": "inspection_language",
+                "label": "Inspection Language",
+                "type": "select",
+                "ui": {
+                  "options": [
+                    "English",
+                    "Spanish"
+                  ]
+                }
+              }
+            ]
+          },
+          {
+            "id": "school_year_dates",
+            "title": "School Year Dates",
+            "fields": [
+              {
+                "id": "school_year_from",
+                "label": "Regular School Year From",
+                "type": "date"
+              },
+              {
+                "id": "school_year_to",
+                "label": "Regular School Year To",
+                "type": "date"
+              },
+              {
+                "id": "has_summer_program",
+                "label": "Summer Program",
+                "type": "checkbox"
+              }
+            ]
+          },
+          {
+            "id": "school_breaks",
+            "title": "School Breaks",
+            "fields": [
+              {
+                "id": "school_breaks",
+                "label": "School Breaks",
+                "type": "group",
+                "metadata": {
+                  "multiple": true,
+                  "tableColumns": [
+                    "term",
+                    "from",
+                    "to"
+                  ]
+                },
+                "fields": [
+                  {
+                    "id": "term",
+                    "label": "Term",
+                    "type": "select",
+                    "required": true,
+                    "ui": {
+                      "options": [
+                        "Fall",
+                        "Spring",
+                        "Summer",
+                        "Winter"
+                      ]
+                    }
+                  },
+                  {
+                    "id": "from",
+                    "label": "From",
+                    "type": "date",
+                    "required": true
+                  },
+                  {
+                    "id": "to",
+                    "label": "To",
+                    "type": "date",
+                    "required": true
+                  }
+                ]
+              }
+            ]
+          },
+          {
+            "id": "holidays",
+            "title": "Holidays",
+            "fields": [
+              {
+                "id": "holidays",
+                "label": "Holiday List",
+                "type": "group",
+                "metadata": {
+                  "multiple": true,
+                  "tableColumns": [
+                    "holiday_name"
+                  ]
+                },
+                "fields": [
+                  {
+                    "id": "holiday_name",
+                    "label": "Holiday Name",
+                    "type": "text",
+                    "required": true
+                  }
+                ]
+              }
+            ]
+          },
+          {
+            "id": "food_services_info",
+            "title": "Food Services Information",
+            "fields": [
+              {
+                "id": "food_provided",
+                "label": "Is food provided for children in care?",
+                "type": "radio",
+                "required": true,
+                "ui": {
+                  "options": [
+                    "Yes",
+                    "No"
+                  ]
+                }
+              },
+              {
+                "id": "food_prepared_on_site",
+                "label": "Is food prepared on site?",
+                "type": "radio",
+                "ui": {
+                  "options": [
+                    "Yes",
+                    "No"
+                  ]
+                }
+              },
+              {
+                "id": "food_preparation_location",
+                "label": "Where is food prepared?",
+                "type": "text"
+              },
+              {
+                "id": "dohmh_food_service_permit",
+                "label": "DOHMH Food Service Permit #",
+                "type": "text"
+              },
+              {
+                "id": "person_on_certificate",
+                "label": "Person Name on Certificate",
+                "type": "text"
+              },
+              {
+                "id": "food_protection_cert_number",
+                "label": "Food Protection Certificate #",
+                "type": "text"
+              }
+            ]
+          }
+        ]
+      },
+      {
+        "id": "application_info_2",
+        "title": "Application Specific Information 2"
+      },
+      {
+        "id": "document_upload",
+        "title": "Upload Documents",
+        "description": "REQUIRED DOCUMENTS\nIn order for your application to be processed, based on information provided, you are required to upload the following documents:",
+        "sections": [
+          {
+            "id": "initial_site_survey",
+            "title": "Initial Site Survey Form",
+            "fields": [
+              {
+                "id": "site_survey_file",
+                "label": "Upload Initial Site Survey Form",
+                "type": "file",
+                "required": true,
+                "constraints": {
+                  "maxFileSizeMB": 25,
+                  "allowedTypes": [
+                    "application/pdf",
+                    "image/jpeg",
+                    "image/jpg",
+                    "image/png"
+                  ]
+                },
+                "metadata": {
+                  "proofCategory": "Initial Site Survey",
+                  "multiple": false
+                }
+              }
+            ]
+          },
+          {
+            "id": "personal_id_proof",
+            "title": "Proof of Personal Identification",
+            "fields": [
+              {
+                "id": "personal_id_file",
+                "label": "Upload Proof of Personal Identification",
+                "type": "file",
+                "required": true,
+                "constraints": {
+                  "maxFileSizeMB": 25,
+                  "allowedTypes": [
+                    "application/pdf",
+                    "image/jpeg",
+                    "image/jpg",
+                    "image/png"
+                  ]
+                },
+                "metadata": {
+                  "proofCategory": "Personal ID",
+                  "multiple": false
+                }
+              }
+            ]
+          },
+          {
+            "id": "fee_exemption_proof",
+            "title": "Proof of Fee Exemption",
+            "fields": [
+              {
+                "id": "fee_exemption_file",
+                "label": "Upload Proof of Fee Exemption (ACS Affiliation or Municipal Exemption)",
+                "type": "file",
+                "required": true,
+                "constraints": {
+                  "maxFileSizeMB": 25,
+                  "allowedTypes": [
+                    "application/pdf",
+                    "image/jpeg",
+                    "image/jpg",
+                    "image/png"
+                  ]
+                },
+                "metadata": {
+                  "proofCategory": "Fee Exemption",
+                  "multiple": false
+                }
+              }
+            ]
+          }
+        ]
+      },
+      {
+        "id": "step_6_placeholder",
+        "title": "To be defined"
+      },
+      {
+        "id": "step_7_placeholder",
+        "title": "To be defined"
+      },
+      {
+        "id": "step_8_placeholder",
+        "title": "To be defined"
+      }
+    ]
+  }
+}

--- a/test-form/public/data/group_cc_permit.ko.json
+++ b/test-form/public/data/group_cc_permit.ko.json
@@ -1,0 +1,788 @@
+{
+  "form": {
+    "title": "Group Child Care Permit Application",
+    "description": "Multi-step application for obtaining a permit to operate group child care programs.",
+    "layout": {
+      "stepperPosition": "left"
+    },
+    "steps": [
+      {
+        "id": "establishment_information",
+        "title": "Establishment Information",
+        "sections": [
+          {
+            "id": "establishment_address",
+            "title": "Establishment Address",
+            "description": "Enter the physical address where business will operate. If you are applying for a Tattoo License, enter your mailing or home address.",
+            "ui": {
+              "autocomplete": "street_1",
+              "placeholder": "Start typing your street address",
+              "overrideComponent": "AddressAutocomplete"
+            },
+            "metadata": {
+              "integration": {
+                "provider": "Google",
+                "feature": "AddressAutocomplete"
+              },
+              "autofillTargets": [
+                {
+                  "fieldId": "city",
+                  "source": "locality",
+                  "fallbackSources": [
+                    "postal_town",
+                    "sublocality_level_1",
+                    "administrative_area_level_2"
+                  ]
+                },
+                {
+                  "fieldId": "borough",
+                  "source": "sublocality_level_1",
+                  "fallbackSources": [
+                    "administrative_area_level_2"
+                  ],
+                  "mapping": "boroughMap"
+                },
+                { "fieldId": "state", "source": "administrative_area_level_1" },
+                { "fieldId": "building_number", "source": "street_number" },
+                { "fieldId": "house_number", "source": "street_number" }
+              ]
+            },
+            "fields": [
+              {
+                "id": "address_type",
+                "label": "Address Type",
+                "type": "select",
+                "required": true,
+                "ui": {
+                  "options": [
+                    "Select",
+                    "Complete Address",
+                    "Cross Street (Intersection)",
+                    "Place (Landmark)"
+                  ]
+                }
+              },
+              {
+                "id": "street_1",
+                "label": "Street 1",
+                "type": "text",
+                "required": true
+              },
+              {
+                "id": "building_number",
+                "label": "Building #",
+                "type": "text",
+                "required": true
+              },
+              {
+                "id": "street_2",
+                "label": "Street 2",
+                "type": "text",
+                "required": false
+              },
+              {
+                "id": "unit_type",
+                "label": "Unit Type",
+                "type": "select",
+                "required": false,
+                "ui": {
+                  "options": [
+                    "LBBY",
+                    "APT",
+                    "BLDG",
+                    "STE",
+                    "FL",
+                    "BSMT",
+                    "FRNT",
+                    "SIDE",
+                    "REAR",
+                    "UPPR",
+                    "LOWR",
+                    "PIER"
+                  ]
+                }
+              },
+              {
+                "id": "unit",
+                "label": "Unit",
+                "type": "text",
+                "required": false
+              },
+              {
+                "id": "city",
+                "label": "City",
+                "type": "text",
+                "required": true
+              },
+              {
+                "id": "state",
+                "label": "State",
+                "type": "text",
+                "required": true
+              },
+              {
+                "id": "borough",
+                "label": "Borough",
+                "type": "select",
+                "required": true,
+                "ui": {
+                  "options": [
+                    "Bronx",
+                    "Brooklyn",
+                    "Manhattan",
+                    "Queens",
+                    "Staten Island"
+                  ]
+                }
+              },
+              {
+                "id": "bin",
+                "label": "Bin",
+                "type": "text",
+                "required": false,
+                "metadata": {
+                  "source": "Geoclient API"
+                }
+              },
+              {
+                "id": "bbl",
+                "label": "Bbl",
+                "type": "text",
+                "required": false,
+                "metadata": {
+                  "source": "Geoclient API"
+                }
+              },
+              {
+                "id": "community_district",
+                "label": "Community District",
+                "type": "text",
+                "required": false,
+                "metadata": {
+                  "source": "Geoclient API"
+                }
+              },
+              {
+                "id": "council_district",
+                "label": "Council District",
+                "type": "text",
+                "required": false,
+                "metadata": {
+                  "source": "Geoclient API"
+                }
+              },
+              {
+                "id": "police_precinct",
+                "label": "Police Precinct",
+                "type": "text",
+                "required": false,
+                "metadata": {
+                  "source": "Geoclient API"
+                }
+              },
+              {
+                "id": "house_number",
+                "label": "House Number",
+                "type": "text",
+                "required": false,
+                "metadata": {
+                  "source": "Geoclient API"
+                }
+              }
+            ]
+          }
+        ]
+      },
+      {
+        "id": "contact_information",
+        "title": "Contact Information – Applicant and Other Contacts",
+        "sections": [
+          {
+            "id": "contact_info_guidance",
+            "title": "Contact Type Guidance",
+            "type": "info",
+            "ui": {
+              "markdown": true,
+              "collapsible": false,
+              "defaultCollapsed": false
+            },
+            "content": "### Applying as a Corporation, Partnership, or Not-for-Profit?\n\nSelect **\"Business Information\"** as your Type of Contact and complete the required fields.  \nBusinesses also have the opportunity to provide a complete list of the responsible individuals within their organization. To add each individual's information to your application, please select **\"Other Contact\"** as the Type of Contact and complete the required fields that appear.\n\n---\n\n### Applying as an Individual or Sole Proprietorship?\n\nSelect **\"Individual Owner\"** as your Type of Contact and complete the required fields that appear.\n\n---\n\n### Emergency Contact?\n\nUnless a **\"Designated Emergency Contact\"** is specified, the applicant will be assumed to be the Emergency Contact.  \nTo identify someone other than the applicant to be contacted in the event of an emergency, please select **\"Designated Emergency Contact\"** as the Type of Contact and complete the required fields that appear."
+          },
+          {
+            "id": "contact_list",
+            "title": "Contact List",
+            "fields": [
+              {
+                "id": "contacts",
+                "label": "Contacts",
+                "type": "group",
+                "metadata": {
+                  "multiple": true,
+                  "tableColumns": ["contact_type", "first_name", "last_name", "establishment_name", "email"]
+                },
+                "fields": [
+                  {
+                    "id": "contact_type",
+                    "label": "Type of Contact",
+                    "type": "select",
+                    "required": true,
+                    "ui": {
+                      "options": [
+                        "Business Information",
+                        "Individual Owner",
+                        "Other Contact",
+                        "Designated Emergency Contact"
+                      ]
+                    }
+                  },
+                  {
+                    "id": "establishment_name",
+                    "label": "Establishment Name",
+                    "type": "text",
+                    "requiredCondition": {
+                      "field": "contact_type",
+                      "operator": "equals",
+                      "value": "Business Information"
+                    }
+                  },
+                  {
+                    "id": "dba_name",
+                    "label": "DBA / Trade Name",
+                    "type": "text",
+                    "requiredCondition": {
+                      "field": "contact_type",
+                      "operator": "equals",
+                      "value": "Business Information"
+                    }
+                  },
+                  {
+                    "id": "legal_structure",
+                    "label": "Legal Structure",
+                    "type": "select",
+                    "requiredCondition": {
+                      "field": "contact_type",
+                      "operator": "equals",
+                      "value": "Business Information"
+                    },
+                    "ui": {
+                      "options": [
+                        "Corporation",
+                        "Partnership",
+                        "Limited Partnership",
+                        "Limited Liability",
+                        "Not-for-Profit"
+                      ]
+                    }
+                  },
+                  {
+                    "id": "nys_sales_tax_id",
+                    "label": "NYS Sales Tax ID #",
+                    "type": "text",
+                    "requiredCondition": {
+                      "field": "contact_type",
+                      "operator": "equals",
+                      "value": "Business Information"
+                    }
+                  },
+                  {
+                    "id": "is_out_of_state_corp",
+                    "label": "Are you a corporation formed outside of New York State?",
+                    "type": "radio",
+                    "requiredCondition": {
+                      "field": "contact_type",
+                      "operator": "equals",
+                      "value": "Business Information"
+                    },
+                    "ui": {
+                      "options": ["Yes", "No"]
+                    }
+                  },
+                  {
+                    "id": "first_name",
+                    "label": "First Name",
+                    "type": "text",
+                    "requiredCondition": {
+                      "anyOf": [
+                        { "field": "contact_type", "operator": "equals", "value": "Individual Owner" },
+                        { "field": "contact_type", "operator": "equals", "value": "Other Contact" },
+                        { "field": "contact_type", "operator": "equals", "value": "Designated Emergency Contact" }
+                      ]
+                    }
+                  },
+                  {
+                    "id": "last_name",
+                    "label": "Last Name",
+                    "type": "text",
+                    "requiredCondition": {
+                      "anyOf": [
+                        { "field": "contact_type", "operator": "equals", "value": "Individual Owner" },
+                        { "field": "contact_type", "operator": "equals", "value": "Other Contact" },
+                        { "field": "contact_type", "operator": "equals", "value": "Designated Emergency Contact" }
+                      ]
+                    }
+                  },
+                  {
+                    "id": "title",
+                    "label": "Title",
+                    "type": "text",
+                    "required": false
+                  },
+                  {
+                    "id": "email",
+                    "label": "E-mail Address",
+                    "type": "email",
+                    "required": true
+                  },
+                  {
+                    "id": "ssn_itin",
+                    "label": "SSN / ITIN",
+                    "type": "text",
+                    "required": false,
+                    "constraints": {
+                      "pattern": "^(\\d{3}-\\d{2}-\\d{4}|\\d{9})$"
+                    },
+                    "ui": {
+                      "placeholder": "XXX-XX-XXXX or 9-digit ITIN"
+                    }
+                  },
+                  {
+                    "id": "ssn_itin_type",
+                    "label": "Did you enter SSN or ITIN?",
+                    "type": "radio",
+                    "requiredCondition": {
+                      "field": "ssn_itin",
+                      "operator": "notEquals",
+                      "value": ""
+                    },
+                    "ui": {
+                      "options": ["SSN", "ITIN"]
+                    }
+                  },
+                  {
+                    "id": "phone",
+                    "label": "Phone Number",
+                    "type": "tel",
+                    "required": true,
+                    "constraints": {
+                      "pattern": "^\\(?[0-9]{3}\\)?[-. ]?[0-9]{3}[-. ]?[0-9]{4}$"
+                    },
+                    "ui": {
+                      "placeholder": "(123) 456-7890"
+                    }
+                  },
+                  {
+                    "id": "tty_phone",
+                    "label": "TTY Phone",
+                    "type": "tel",
+                    "required": false
+                  },
+                  {
+                    "id": "date_of_birth",
+                    "label": "Date of Birth",
+                    "type": "date",
+                    "required": false
+                  },
+                  {
+                    "id": "gender",
+                    "label": "Gender",
+                    "type": "radio",
+                    "required": false,
+                    "ui": {
+                      "options": ["Female", "Male"]
+                    }
+                  }
+                ]
+              }
+            ]
+          }
+        ]
+      },
+
+      {
+        "id": "application_info_1",
+        "title": "Application Specific Information 1",
+        "sections": [
+          {
+            "id": "program_details",
+            "title": "Program Details",
+            "fields": [
+              {
+                "id": "program_type",
+                "label": "Program Type",
+                "type": "select",
+                "required": true,
+                "ui": {
+                  "options": [
+                    "Infant Toddler",
+                    "Preschool"
+                  ]
+                }
+              },
+              {
+                "id": "orientation_cert_number",
+                "label": "Pre Permit Orientation Cert #",
+                "type": "text",
+                "required": true
+              },
+              {
+                "id": "permittee_name",
+                "label": "Permittee (Sponsor Name)",
+                "type": "text",
+                "required": true
+              },
+              {
+                "id": "is_applicant_same_as_permittee",
+                "label": "Applicant same as Permittee?",
+                "type": "checkbox",
+                "ui": {
+                  "defaultChecked": true
+                }
+              },
+              {
+                "id": "permit_expiration_date",
+                "label": "Expiration Date",
+                "type": "date",
+                "required": false
+              },
+              {
+                "id": "permit_number",
+                "label": "Permit #",
+                "type": "text",
+                "required": false
+              }
+            ]
+          },
+          {
+            "id": "program_contact",
+            "title": "Program Contact",
+            "fields": [
+              {
+                "id": "program_phone",
+                "label": "Phone",
+                "type": "tel"
+              },
+              {
+                "id": "program_fax",
+                "label": "Fax",
+                "type": "tel"
+              },
+              {
+                "id": "program_email",
+                "label": "Email",
+                "type": "email",
+                "required": true
+              },
+              {
+                "id": "program_website",
+                "label": "Website",
+                "type": "text"
+              }
+            ]
+          },
+          {
+            "id": "program_days_hours",
+            "title": "Days Open (Hours)",
+            "fields": [
+              {
+                "id": "open_days",
+                "label": "Open Days",
+                "type": "checkbox",
+                "ui": {
+                  "options": [
+                    "Sunday",
+                    "Monday",
+                    "Tuesday",
+                    "Wednesday",
+                    "Thursday",
+                    "Friday",
+                    "Saturday"
+                  ]
+                }
+              },
+              {
+                "id": "nightcare",
+                "label": "Nightcare",
+                "type": "checkbox"
+              },
+              {
+                "id": "open_from",
+                "label": "Open From",
+                "type": "time",
+                "required": true
+              },
+              {
+                "id": "close_at",
+                "label": "Close At",
+                "type": "time",
+                "required": true
+              },
+              {
+                "id": "inspection_delivery_method",
+                "label": "Inspection Report Delivery Method",
+                "type": "select",
+                "ui": {
+                  "options": [
+                    "Email",
+                    "Fax",
+                    "Regular Mail"
+                  ]
+                }
+              },
+              {
+                "id": "inspection_language",
+                "label": "Inspection Language",
+                "type": "select",
+                "ui": {
+                  "options": [
+                    "English",
+                    "Spanish"
+                  ]
+                }
+              }
+            ]
+          },
+          {
+            "id": "school_year_dates",
+            "title": "School Year Dates",
+            "fields": [
+              {
+                "id": "school_year_from",
+                "label": "Regular School Year From",
+                "type": "date"
+              },
+              {
+                "id": "school_year_to",
+                "label": "Regular School Year To",
+                "type": "date"
+              },
+              {
+                "id": "has_summer_program",
+                "label": "Summer Program",
+                "type": "checkbox"
+              }
+            ]
+          },
+          {
+            "id": "school_breaks",
+            "title": "School Breaks",
+            "fields": [
+              {
+                "id": "school_breaks",
+                "label": "School Breaks",
+                "type": "group",
+                "metadata": {
+                  "multiple": true,
+                  "tableColumns": [
+                    "term",
+                    "from",
+                    "to"
+                  ]
+                },
+                "fields": [
+                  {
+                    "id": "term",
+                    "label": "Term",
+                    "type": "select",
+                    "required": true,
+                    "ui": {
+                      "options": [
+                        "Fall",
+                        "Spring",
+                        "Summer",
+                        "Winter"
+                      ]
+                    }
+                  },
+                  {
+                    "id": "from",
+                    "label": "From",
+                    "type": "date",
+                    "required": true
+                  },
+                  {
+                    "id": "to",
+                    "label": "To",
+                    "type": "date",
+                    "required": true
+                  }
+                ]
+              }
+            ]
+          },
+          {
+            "id": "holidays",
+            "title": "Holidays",
+            "fields": [
+              {
+                "id": "holidays",
+                "label": "Holiday List",
+                "type": "group",
+                "metadata": {
+                  "multiple": true,
+                  "tableColumns": [
+                    "holiday_name"
+                  ]
+                },
+                "fields": [
+                  {
+                    "id": "holiday_name",
+                    "label": "Holiday Name",
+                    "type": "text",
+                    "required": true
+                  }
+                ]
+              }
+            ]
+          },
+          {
+            "id": "food_services_info",
+            "title": "Food Services Information",
+            "fields": [
+              {
+                "id": "food_provided",
+                "label": "Is food provided for children in care?",
+                "type": "radio",
+                "required": true,
+                "ui": {
+                  "options": [
+                    "Yes",
+                    "No"
+                  ]
+                }
+              },
+              {
+                "id": "food_prepared_on_site",
+                "label": "Is food prepared on site?",
+                "type": "radio",
+                "ui": {
+                  "options": [
+                    "Yes",
+                    "No"
+                  ]
+                }
+              },
+              {
+                "id": "food_preparation_location",
+                "label": "Where is food prepared?",
+                "type": "text"
+              },
+              {
+                "id": "dohmh_food_service_permit",
+                "label": "DOHMH Food Service Permit #",
+                "type": "text"
+              },
+              {
+                "id": "person_on_certificate",
+                "label": "Person Name on Certificate",
+                "type": "text"
+              },
+              {
+                "id": "food_protection_cert_number",
+                "label": "Food Protection Certificate #",
+                "type": "text"
+              }
+            ]
+          }
+        ]
+      },
+      {
+        "id": "application_info_2",
+        "title": "Application Specific Information 2"
+      },
+      {
+        "id": "document_upload",
+        "title": "Upload Documents",
+        "description": "REQUIRED DOCUMENTS\nIn order for your application to be processed, based on information provided, you are required to upload the following documents:",
+        "sections": [
+          {
+            "id": "initial_site_survey",
+            "title": "Initial Site Survey Form",
+            "fields": [
+              {
+                "id": "site_survey_file",
+                "label": "Upload Initial Site Survey Form",
+                "type": "file",
+                "required": true,
+                "constraints": {
+                  "maxFileSizeMB": 25,
+                  "allowedTypes": [
+                    "application/pdf",
+                    "image/jpeg",
+                    "image/jpg",
+                    "image/png"
+                  ]
+                },
+                "metadata": {
+                  "proofCategory": "Initial Site Survey",
+                  "multiple": false
+                }
+              }
+            ]
+          },
+          {
+            "id": "personal_id_proof",
+            "title": "Proof of Personal Identification",
+            "fields": [
+              {
+                "id": "personal_id_file",
+                "label": "Upload Proof of Personal Identification",
+                "type": "file",
+                "required": true,
+                "constraints": {
+                  "maxFileSizeMB": 25,
+                  "allowedTypes": [
+                    "application/pdf",
+                    "image/jpeg",
+                    "image/jpg",
+                    "image/png"
+                  ]
+                },
+                "metadata": {
+                  "proofCategory": "Personal ID",
+                  "multiple": false
+                }
+              }
+            ]
+          },
+          {
+            "id": "fee_exemption_proof",
+            "title": "Proof of Fee Exemption",
+            "fields": [
+              {
+                "id": "fee_exemption_file",
+                "label": "Upload Proof of Fee Exemption (ACS Affiliation or Municipal Exemption)",
+                "type": "file",
+                "required": true,
+                "constraints": {
+                  "maxFileSizeMB": 25,
+                  "allowedTypes": [
+                    "application/pdf",
+                    "image/jpeg",
+                    "image/jpg",
+                    "image/png"
+                  ]
+                },
+                "metadata": {
+                  "proofCategory": "Fee Exemption",
+                  "multiple": false
+                }
+              }
+            ]
+          }
+        ]
+      },
+      {
+        "id": "step_6_placeholder",
+        "title": "To be defined"
+      },
+      {
+        "id": "step_7_placeholder",
+        "title": "To be defined"
+      },
+      {
+        "id": "step_8_placeholder",
+        "title": "To be defined"
+      }
+    ]
+  }
+}

--- a/test-form/public/data/group_cc_permit.pl.json
+++ b/test-form/public/data/group_cc_permit.pl.json
@@ -1,0 +1,788 @@
+{
+  "form": {
+    "title": "Group Child Care Permit Application",
+    "description": "Multi-step application for obtaining a permit to operate group child care programs.",
+    "layout": {
+      "stepperPosition": "left"
+    },
+    "steps": [
+      {
+        "id": "establishment_information",
+        "title": "Establishment Information",
+        "sections": [
+          {
+            "id": "establishment_address",
+            "title": "Establishment Address",
+            "description": "Enter the physical address where business will operate. If you are applying for a Tattoo License, enter your mailing or home address.",
+            "ui": {
+              "autocomplete": "street_1",
+              "placeholder": "Start typing your street address",
+              "overrideComponent": "AddressAutocomplete"
+            },
+            "metadata": {
+              "integration": {
+                "provider": "Google",
+                "feature": "AddressAutocomplete"
+              },
+              "autofillTargets": [
+                {
+                  "fieldId": "city",
+                  "source": "locality",
+                  "fallbackSources": [
+                    "postal_town",
+                    "sublocality_level_1",
+                    "administrative_area_level_2"
+                  ]
+                },
+                {
+                  "fieldId": "borough",
+                  "source": "sublocality_level_1",
+                  "fallbackSources": [
+                    "administrative_area_level_2"
+                  ],
+                  "mapping": "boroughMap"
+                },
+                { "fieldId": "state", "source": "administrative_area_level_1" },
+                { "fieldId": "building_number", "source": "street_number" },
+                { "fieldId": "house_number", "source": "street_number" }
+              ]
+            },
+            "fields": [
+              {
+                "id": "address_type",
+                "label": "Address Type",
+                "type": "select",
+                "required": true,
+                "ui": {
+                  "options": [
+                    "Select",
+                    "Complete Address",
+                    "Cross Street (Intersection)",
+                    "Place (Landmark)"
+                  ]
+                }
+              },
+              {
+                "id": "street_1",
+                "label": "Street 1",
+                "type": "text",
+                "required": true
+              },
+              {
+                "id": "building_number",
+                "label": "Building #",
+                "type": "text",
+                "required": true
+              },
+              {
+                "id": "street_2",
+                "label": "Street 2",
+                "type": "text",
+                "required": false
+              },
+              {
+                "id": "unit_type",
+                "label": "Unit Type",
+                "type": "select",
+                "required": false,
+                "ui": {
+                  "options": [
+                    "LBBY",
+                    "APT",
+                    "BLDG",
+                    "STE",
+                    "FL",
+                    "BSMT",
+                    "FRNT",
+                    "SIDE",
+                    "REAR",
+                    "UPPR",
+                    "LOWR",
+                    "PIER"
+                  ]
+                }
+              },
+              {
+                "id": "unit",
+                "label": "Unit",
+                "type": "text",
+                "required": false
+              },
+              {
+                "id": "city",
+                "label": "City",
+                "type": "text",
+                "required": true
+              },
+              {
+                "id": "state",
+                "label": "State",
+                "type": "text",
+                "required": true
+              },
+              {
+                "id": "borough",
+                "label": "Borough",
+                "type": "select",
+                "required": true,
+                "ui": {
+                  "options": [
+                    "Bronx",
+                    "Brooklyn",
+                    "Manhattan",
+                    "Queens",
+                    "Staten Island"
+                  ]
+                }
+              },
+              {
+                "id": "bin",
+                "label": "Bin",
+                "type": "text",
+                "required": false,
+                "metadata": {
+                  "source": "Geoclient API"
+                }
+              },
+              {
+                "id": "bbl",
+                "label": "Bbl",
+                "type": "text",
+                "required": false,
+                "metadata": {
+                  "source": "Geoclient API"
+                }
+              },
+              {
+                "id": "community_district",
+                "label": "Community District",
+                "type": "text",
+                "required": false,
+                "metadata": {
+                  "source": "Geoclient API"
+                }
+              },
+              {
+                "id": "council_district",
+                "label": "Council District",
+                "type": "text",
+                "required": false,
+                "metadata": {
+                  "source": "Geoclient API"
+                }
+              },
+              {
+                "id": "police_precinct",
+                "label": "Police Precinct",
+                "type": "text",
+                "required": false,
+                "metadata": {
+                  "source": "Geoclient API"
+                }
+              },
+              {
+                "id": "house_number",
+                "label": "House Number",
+                "type": "text",
+                "required": false,
+                "metadata": {
+                  "source": "Geoclient API"
+                }
+              }
+            ]
+          }
+        ]
+      },
+      {
+        "id": "contact_information",
+        "title": "Contact Information – Applicant and Other Contacts",
+        "sections": [
+          {
+            "id": "contact_info_guidance",
+            "title": "Contact Type Guidance",
+            "type": "info",
+            "ui": {
+              "markdown": true,
+              "collapsible": false,
+              "defaultCollapsed": false
+            },
+            "content": "### Applying as a Corporation, Partnership, or Not-for-Profit?\n\nSelect **\"Business Information\"** as your Type of Contact and complete the required fields.  \nBusinesses also have the opportunity to provide a complete list of the responsible individuals within their organization. To add each individual's information to your application, please select **\"Other Contact\"** as the Type of Contact and complete the required fields that appear.\n\n---\n\n### Applying as an Individual or Sole Proprietorship?\n\nSelect **\"Individual Owner\"** as your Type of Contact and complete the required fields that appear.\n\n---\n\n### Emergency Contact?\n\nUnless a **\"Designated Emergency Contact\"** is specified, the applicant will be assumed to be the Emergency Contact.  \nTo identify someone other than the applicant to be contacted in the event of an emergency, please select **\"Designated Emergency Contact\"** as the Type of Contact and complete the required fields that appear."
+          },
+          {
+            "id": "contact_list",
+            "title": "Contact List",
+            "fields": [
+              {
+                "id": "contacts",
+                "label": "Contacts",
+                "type": "group",
+                "metadata": {
+                  "multiple": true,
+                  "tableColumns": ["contact_type", "first_name", "last_name", "establishment_name", "email"]
+                },
+                "fields": [
+                  {
+                    "id": "contact_type",
+                    "label": "Type of Contact",
+                    "type": "select",
+                    "required": true,
+                    "ui": {
+                      "options": [
+                        "Business Information",
+                        "Individual Owner",
+                        "Other Contact",
+                        "Designated Emergency Contact"
+                      ]
+                    }
+                  },
+                  {
+                    "id": "establishment_name",
+                    "label": "Establishment Name",
+                    "type": "text",
+                    "requiredCondition": {
+                      "field": "contact_type",
+                      "operator": "equals",
+                      "value": "Business Information"
+                    }
+                  },
+                  {
+                    "id": "dba_name",
+                    "label": "DBA / Trade Name",
+                    "type": "text",
+                    "requiredCondition": {
+                      "field": "contact_type",
+                      "operator": "equals",
+                      "value": "Business Information"
+                    }
+                  },
+                  {
+                    "id": "legal_structure",
+                    "label": "Legal Structure",
+                    "type": "select",
+                    "requiredCondition": {
+                      "field": "contact_type",
+                      "operator": "equals",
+                      "value": "Business Information"
+                    },
+                    "ui": {
+                      "options": [
+                        "Corporation",
+                        "Partnership",
+                        "Limited Partnership",
+                        "Limited Liability",
+                        "Not-for-Profit"
+                      ]
+                    }
+                  },
+                  {
+                    "id": "nys_sales_tax_id",
+                    "label": "NYS Sales Tax ID #",
+                    "type": "text",
+                    "requiredCondition": {
+                      "field": "contact_type",
+                      "operator": "equals",
+                      "value": "Business Information"
+                    }
+                  },
+                  {
+                    "id": "is_out_of_state_corp",
+                    "label": "Are you a corporation formed outside of New York State?",
+                    "type": "radio",
+                    "requiredCondition": {
+                      "field": "contact_type",
+                      "operator": "equals",
+                      "value": "Business Information"
+                    },
+                    "ui": {
+                      "options": ["Yes", "No"]
+                    }
+                  },
+                  {
+                    "id": "first_name",
+                    "label": "First Name",
+                    "type": "text",
+                    "requiredCondition": {
+                      "anyOf": [
+                        { "field": "contact_type", "operator": "equals", "value": "Individual Owner" },
+                        { "field": "contact_type", "operator": "equals", "value": "Other Contact" },
+                        { "field": "contact_type", "operator": "equals", "value": "Designated Emergency Contact" }
+                      ]
+                    }
+                  },
+                  {
+                    "id": "last_name",
+                    "label": "Last Name",
+                    "type": "text",
+                    "requiredCondition": {
+                      "anyOf": [
+                        { "field": "contact_type", "operator": "equals", "value": "Individual Owner" },
+                        { "field": "contact_type", "operator": "equals", "value": "Other Contact" },
+                        { "field": "contact_type", "operator": "equals", "value": "Designated Emergency Contact" }
+                      ]
+                    }
+                  },
+                  {
+                    "id": "title",
+                    "label": "Title",
+                    "type": "text",
+                    "required": false
+                  },
+                  {
+                    "id": "email",
+                    "label": "E-mail Address",
+                    "type": "email",
+                    "required": true
+                  },
+                  {
+                    "id": "ssn_itin",
+                    "label": "SSN / ITIN",
+                    "type": "text",
+                    "required": false,
+                    "constraints": {
+                      "pattern": "^(\\d{3}-\\d{2}-\\d{4}|\\d{9})$"
+                    },
+                    "ui": {
+                      "placeholder": "XXX-XX-XXXX or 9-digit ITIN"
+                    }
+                  },
+                  {
+                    "id": "ssn_itin_type",
+                    "label": "Did you enter SSN or ITIN?",
+                    "type": "radio",
+                    "requiredCondition": {
+                      "field": "ssn_itin",
+                      "operator": "notEquals",
+                      "value": ""
+                    },
+                    "ui": {
+                      "options": ["SSN", "ITIN"]
+                    }
+                  },
+                  {
+                    "id": "phone",
+                    "label": "Phone Number",
+                    "type": "tel",
+                    "required": true,
+                    "constraints": {
+                      "pattern": "^\\(?[0-9]{3}\\)?[-. ]?[0-9]{3}[-. ]?[0-9]{4}$"
+                    },
+                    "ui": {
+                      "placeholder": "(123) 456-7890"
+                    }
+                  },
+                  {
+                    "id": "tty_phone",
+                    "label": "TTY Phone",
+                    "type": "tel",
+                    "required": false
+                  },
+                  {
+                    "id": "date_of_birth",
+                    "label": "Date of Birth",
+                    "type": "date",
+                    "required": false
+                  },
+                  {
+                    "id": "gender",
+                    "label": "Gender",
+                    "type": "radio",
+                    "required": false,
+                    "ui": {
+                      "options": ["Female", "Male"]
+                    }
+                  }
+                ]
+              }
+            ]
+          }
+        ]
+      },
+
+      {
+        "id": "application_info_1",
+        "title": "Application Specific Information 1",
+        "sections": [
+          {
+            "id": "program_details",
+            "title": "Program Details",
+            "fields": [
+              {
+                "id": "program_type",
+                "label": "Program Type",
+                "type": "select",
+                "required": true,
+                "ui": {
+                  "options": [
+                    "Infant Toddler",
+                    "Preschool"
+                  ]
+                }
+              },
+              {
+                "id": "orientation_cert_number",
+                "label": "Pre Permit Orientation Cert #",
+                "type": "text",
+                "required": true
+              },
+              {
+                "id": "permittee_name",
+                "label": "Permittee (Sponsor Name)",
+                "type": "text",
+                "required": true
+              },
+              {
+                "id": "is_applicant_same_as_permittee",
+                "label": "Applicant same as Permittee?",
+                "type": "checkbox",
+                "ui": {
+                  "defaultChecked": true
+                }
+              },
+              {
+                "id": "permit_expiration_date",
+                "label": "Expiration Date",
+                "type": "date",
+                "required": false
+              },
+              {
+                "id": "permit_number",
+                "label": "Permit #",
+                "type": "text",
+                "required": false
+              }
+            ]
+          },
+          {
+            "id": "program_contact",
+            "title": "Program Contact",
+            "fields": [
+              {
+                "id": "program_phone",
+                "label": "Phone",
+                "type": "tel"
+              },
+              {
+                "id": "program_fax",
+                "label": "Fax",
+                "type": "tel"
+              },
+              {
+                "id": "program_email",
+                "label": "Email",
+                "type": "email",
+                "required": true
+              },
+              {
+                "id": "program_website",
+                "label": "Website",
+                "type": "text"
+              }
+            ]
+          },
+          {
+            "id": "program_days_hours",
+            "title": "Days Open (Hours)",
+            "fields": [
+              {
+                "id": "open_days",
+                "label": "Open Days",
+                "type": "checkbox",
+                "ui": {
+                  "options": [
+                    "Sunday",
+                    "Monday",
+                    "Tuesday",
+                    "Wednesday",
+                    "Thursday",
+                    "Friday",
+                    "Saturday"
+                  ]
+                }
+              },
+              {
+                "id": "nightcare",
+                "label": "Nightcare",
+                "type": "checkbox"
+              },
+              {
+                "id": "open_from",
+                "label": "Open From",
+                "type": "time",
+                "required": true
+              },
+              {
+                "id": "close_at",
+                "label": "Close At",
+                "type": "time",
+                "required": true
+              },
+              {
+                "id": "inspection_delivery_method",
+                "label": "Inspection Report Delivery Method",
+                "type": "select",
+                "ui": {
+                  "options": [
+                    "Email",
+                    "Fax",
+                    "Regular Mail"
+                  ]
+                }
+              },
+              {
+                "id": "inspection_language",
+                "label": "Inspection Language",
+                "type": "select",
+                "ui": {
+                  "options": [
+                    "English",
+                    "Spanish"
+                  ]
+                }
+              }
+            ]
+          },
+          {
+            "id": "school_year_dates",
+            "title": "School Year Dates",
+            "fields": [
+              {
+                "id": "school_year_from",
+                "label": "Regular School Year From",
+                "type": "date"
+              },
+              {
+                "id": "school_year_to",
+                "label": "Regular School Year To",
+                "type": "date"
+              },
+              {
+                "id": "has_summer_program",
+                "label": "Summer Program",
+                "type": "checkbox"
+              }
+            ]
+          },
+          {
+            "id": "school_breaks",
+            "title": "School Breaks",
+            "fields": [
+              {
+                "id": "school_breaks",
+                "label": "School Breaks",
+                "type": "group",
+                "metadata": {
+                  "multiple": true,
+                  "tableColumns": [
+                    "term",
+                    "from",
+                    "to"
+                  ]
+                },
+                "fields": [
+                  {
+                    "id": "term",
+                    "label": "Term",
+                    "type": "select",
+                    "required": true,
+                    "ui": {
+                      "options": [
+                        "Fall",
+                        "Spring",
+                        "Summer",
+                        "Winter"
+                      ]
+                    }
+                  },
+                  {
+                    "id": "from",
+                    "label": "From",
+                    "type": "date",
+                    "required": true
+                  },
+                  {
+                    "id": "to",
+                    "label": "To",
+                    "type": "date",
+                    "required": true
+                  }
+                ]
+              }
+            ]
+          },
+          {
+            "id": "holidays",
+            "title": "Holidays",
+            "fields": [
+              {
+                "id": "holidays",
+                "label": "Holiday List",
+                "type": "group",
+                "metadata": {
+                  "multiple": true,
+                  "tableColumns": [
+                    "holiday_name"
+                  ]
+                },
+                "fields": [
+                  {
+                    "id": "holiday_name",
+                    "label": "Holiday Name",
+                    "type": "text",
+                    "required": true
+                  }
+                ]
+              }
+            ]
+          },
+          {
+            "id": "food_services_info",
+            "title": "Food Services Information",
+            "fields": [
+              {
+                "id": "food_provided",
+                "label": "Is food provided for children in care?",
+                "type": "radio",
+                "required": true,
+                "ui": {
+                  "options": [
+                    "Yes",
+                    "No"
+                  ]
+                }
+              },
+              {
+                "id": "food_prepared_on_site",
+                "label": "Is food prepared on site?",
+                "type": "radio",
+                "ui": {
+                  "options": [
+                    "Yes",
+                    "No"
+                  ]
+                }
+              },
+              {
+                "id": "food_preparation_location",
+                "label": "Where is food prepared?",
+                "type": "text"
+              },
+              {
+                "id": "dohmh_food_service_permit",
+                "label": "DOHMH Food Service Permit #",
+                "type": "text"
+              },
+              {
+                "id": "person_on_certificate",
+                "label": "Person Name on Certificate",
+                "type": "text"
+              },
+              {
+                "id": "food_protection_cert_number",
+                "label": "Food Protection Certificate #",
+                "type": "text"
+              }
+            ]
+          }
+        ]
+      },
+      {
+        "id": "application_info_2",
+        "title": "Application Specific Information 2"
+      },
+      {
+        "id": "document_upload",
+        "title": "Upload Documents",
+        "description": "REQUIRED DOCUMENTS\nIn order for your application to be processed, based on information provided, you are required to upload the following documents:",
+        "sections": [
+          {
+            "id": "initial_site_survey",
+            "title": "Initial Site Survey Form",
+            "fields": [
+              {
+                "id": "site_survey_file",
+                "label": "Upload Initial Site Survey Form",
+                "type": "file",
+                "required": true,
+                "constraints": {
+                  "maxFileSizeMB": 25,
+                  "allowedTypes": [
+                    "application/pdf",
+                    "image/jpeg",
+                    "image/jpg",
+                    "image/png"
+                  ]
+                },
+                "metadata": {
+                  "proofCategory": "Initial Site Survey",
+                  "multiple": false
+                }
+              }
+            ]
+          },
+          {
+            "id": "personal_id_proof",
+            "title": "Proof of Personal Identification",
+            "fields": [
+              {
+                "id": "personal_id_file",
+                "label": "Upload Proof of Personal Identification",
+                "type": "file",
+                "required": true,
+                "constraints": {
+                  "maxFileSizeMB": 25,
+                  "allowedTypes": [
+                    "application/pdf",
+                    "image/jpeg",
+                    "image/jpg",
+                    "image/png"
+                  ]
+                },
+                "metadata": {
+                  "proofCategory": "Personal ID",
+                  "multiple": false
+                }
+              }
+            ]
+          },
+          {
+            "id": "fee_exemption_proof",
+            "title": "Proof of Fee Exemption",
+            "fields": [
+              {
+                "id": "fee_exemption_file",
+                "label": "Upload Proof of Fee Exemption (ACS Affiliation or Municipal Exemption)",
+                "type": "file",
+                "required": true,
+                "constraints": {
+                  "maxFileSizeMB": 25,
+                  "allowedTypes": [
+                    "application/pdf",
+                    "image/jpeg",
+                    "image/jpg",
+                    "image/png"
+                  ]
+                },
+                "metadata": {
+                  "proofCategory": "Fee Exemption",
+                  "multiple": false
+                }
+              }
+            ]
+          }
+        ]
+      },
+      {
+        "id": "step_6_placeholder",
+        "title": "To be defined"
+      },
+      {
+        "id": "step_7_placeholder",
+        "title": "To be defined"
+      },
+      {
+        "id": "step_8_placeholder",
+        "title": "To be defined"
+      }
+    ]
+  }
+}

--- a/test-form/public/data/group_cc_permit.ru.json
+++ b/test-form/public/data/group_cc_permit.ru.json
@@ -1,0 +1,788 @@
+{
+  "form": {
+    "title": "Group Child Care Permit Application",
+    "description": "Multi-step application for obtaining a permit to operate group child care programs.",
+    "layout": {
+      "stepperPosition": "left"
+    },
+    "steps": [
+      {
+        "id": "establishment_information",
+        "title": "Establishment Information",
+        "sections": [
+          {
+            "id": "establishment_address",
+            "title": "Establishment Address",
+            "description": "Enter the physical address where business will operate. If you are applying for a Tattoo License, enter your mailing or home address.",
+            "ui": {
+              "autocomplete": "street_1",
+              "placeholder": "Start typing your street address",
+              "overrideComponent": "AddressAutocomplete"
+            },
+            "metadata": {
+              "integration": {
+                "provider": "Google",
+                "feature": "AddressAutocomplete"
+              },
+              "autofillTargets": [
+                {
+                  "fieldId": "city",
+                  "source": "locality",
+                  "fallbackSources": [
+                    "postal_town",
+                    "sublocality_level_1",
+                    "administrative_area_level_2"
+                  ]
+                },
+                {
+                  "fieldId": "borough",
+                  "source": "sublocality_level_1",
+                  "fallbackSources": [
+                    "administrative_area_level_2"
+                  ],
+                  "mapping": "boroughMap"
+                },
+                { "fieldId": "state", "source": "administrative_area_level_1" },
+                { "fieldId": "building_number", "source": "street_number" },
+                { "fieldId": "house_number", "source": "street_number" }
+              ]
+            },
+            "fields": [
+              {
+                "id": "address_type",
+                "label": "Address Type",
+                "type": "select",
+                "required": true,
+                "ui": {
+                  "options": [
+                    "Select",
+                    "Complete Address",
+                    "Cross Street (Intersection)",
+                    "Place (Landmark)"
+                  ]
+                }
+              },
+              {
+                "id": "street_1",
+                "label": "Street 1",
+                "type": "text",
+                "required": true
+              },
+              {
+                "id": "building_number",
+                "label": "Building #",
+                "type": "text",
+                "required": true
+              },
+              {
+                "id": "street_2",
+                "label": "Street 2",
+                "type": "text",
+                "required": false
+              },
+              {
+                "id": "unit_type",
+                "label": "Unit Type",
+                "type": "select",
+                "required": false,
+                "ui": {
+                  "options": [
+                    "LBBY",
+                    "APT",
+                    "BLDG",
+                    "STE",
+                    "FL",
+                    "BSMT",
+                    "FRNT",
+                    "SIDE",
+                    "REAR",
+                    "UPPR",
+                    "LOWR",
+                    "PIER"
+                  ]
+                }
+              },
+              {
+                "id": "unit",
+                "label": "Unit",
+                "type": "text",
+                "required": false
+              },
+              {
+                "id": "city",
+                "label": "City",
+                "type": "text",
+                "required": true
+              },
+              {
+                "id": "state",
+                "label": "State",
+                "type": "text",
+                "required": true
+              },
+              {
+                "id": "borough",
+                "label": "Borough",
+                "type": "select",
+                "required": true,
+                "ui": {
+                  "options": [
+                    "Bronx",
+                    "Brooklyn",
+                    "Manhattan",
+                    "Queens",
+                    "Staten Island"
+                  ]
+                }
+              },
+              {
+                "id": "bin",
+                "label": "Bin",
+                "type": "text",
+                "required": false,
+                "metadata": {
+                  "source": "Geoclient API"
+                }
+              },
+              {
+                "id": "bbl",
+                "label": "Bbl",
+                "type": "text",
+                "required": false,
+                "metadata": {
+                  "source": "Geoclient API"
+                }
+              },
+              {
+                "id": "community_district",
+                "label": "Community District",
+                "type": "text",
+                "required": false,
+                "metadata": {
+                  "source": "Geoclient API"
+                }
+              },
+              {
+                "id": "council_district",
+                "label": "Council District",
+                "type": "text",
+                "required": false,
+                "metadata": {
+                  "source": "Geoclient API"
+                }
+              },
+              {
+                "id": "police_precinct",
+                "label": "Police Precinct",
+                "type": "text",
+                "required": false,
+                "metadata": {
+                  "source": "Geoclient API"
+                }
+              },
+              {
+                "id": "house_number",
+                "label": "House Number",
+                "type": "text",
+                "required": false,
+                "metadata": {
+                  "source": "Geoclient API"
+                }
+              }
+            ]
+          }
+        ]
+      },
+      {
+        "id": "contact_information",
+        "title": "Contact Information – Applicant and Other Contacts",
+        "sections": [
+          {
+            "id": "contact_info_guidance",
+            "title": "Contact Type Guidance",
+            "type": "info",
+            "ui": {
+              "markdown": true,
+              "collapsible": false,
+              "defaultCollapsed": false
+            },
+            "content": "### Applying as a Corporation, Partnership, or Not-for-Profit?\n\nSelect **\"Business Information\"** as your Type of Contact and complete the required fields.  \nBusinesses also have the opportunity to provide a complete list of the responsible individuals within their organization. To add each individual's information to your application, please select **\"Other Contact\"** as the Type of Contact and complete the required fields that appear.\n\n---\n\n### Applying as an Individual or Sole Proprietorship?\n\nSelect **\"Individual Owner\"** as your Type of Contact and complete the required fields that appear.\n\n---\n\n### Emergency Contact?\n\nUnless a **\"Designated Emergency Contact\"** is specified, the applicant will be assumed to be the Emergency Contact.  \nTo identify someone other than the applicant to be contacted in the event of an emergency, please select **\"Designated Emergency Contact\"** as the Type of Contact and complete the required fields that appear."
+          },
+          {
+            "id": "contact_list",
+            "title": "Contact List",
+            "fields": [
+              {
+                "id": "contacts",
+                "label": "Contacts",
+                "type": "group",
+                "metadata": {
+                  "multiple": true,
+                  "tableColumns": ["contact_type", "first_name", "last_name", "establishment_name", "email"]
+                },
+                "fields": [
+                  {
+                    "id": "contact_type",
+                    "label": "Type of Contact",
+                    "type": "select",
+                    "required": true,
+                    "ui": {
+                      "options": [
+                        "Business Information",
+                        "Individual Owner",
+                        "Other Contact",
+                        "Designated Emergency Contact"
+                      ]
+                    }
+                  },
+                  {
+                    "id": "establishment_name",
+                    "label": "Establishment Name",
+                    "type": "text",
+                    "requiredCondition": {
+                      "field": "contact_type",
+                      "operator": "equals",
+                      "value": "Business Information"
+                    }
+                  },
+                  {
+                    "id": "dba_name",
+                    "label": "DBA / Trade Name",
+                    "type": "text",
+                    "requiredCondition": {
+                      "field": "contact_type",
+                      "operator": "equals",
+                      "value": "Business Information"
+                    }
+                  },
+                  {
+                    "id": "legal_structure",
+                    "label": "Legal Structure",
+                    "type": "select",
+                    "requiredCondition": {
+                      "field": "contact_type",
+                      "operator": "equals",
+                      "value": "Business Information"
+                    },
+                    "ui": {
+                      "options": [
+                        "Corporation",
+                        "Partnership",
+                        "Limited Partnership",
+                        "Limited Liability",
+                        "Not-for-Profit"
+                      ]
+                    }
+                  },
+                  {
+                    "id": "nys_sales_tax_id",
+                    "label": "NYS Sales Tax ID #",
+                    "type": "text",
+                    "requiredCondition": {
+                      "field": "contact_type",
+                      "operator": "equals",
+                      "value": "Business Information"
+                    }
+                  },
+                  {
+                    "id": "is_out_of_state_corp",
+                    "label": "Are you a corporation formed outside of New York State?",
+                    "type": "radio",
+                    "requiredCondition": {
+                      "field": "contact_type",
+                      "operator": "equals",
+                      "value": "Business Information"
+                    },
+                    "ui": {
+                      "options": ["Yes", "No"]
+                    }
+                  },
+                  {
+                    "id": "first_name",
+                    "label": "First Name",
+                    "type": "text",
+                    "requiredCondition": {
+                      "anyOf": [
+                        { "field": "contact_type", "operator": "equals", "value": "Individual Owner" },
+                        { "field": "contact_type", "operator": "equals", "value": "Other Contact" },
+                        { "field": "contact_type", "operator": "equals", "value": "Designated Emergency Contact" }
+                      ]
+                    }
+                  },
+                  {
+                    "id": "last_name",
+                    "label": "Last Name",
+                    "type": "text",
+                    "requiredCondition": {
+                      "anyOf": [
+                        { "field": "contact_type", "operator": "equals", "value": "Individual Owner" },
+                        { "field": "contact_type", "operator": "equals", "value": "Other Contact" },
+                        { "field": "contact_type", "operator": "equals", "value": "Designated Emergency Contact" }
+                      ]
+                    }
+                  },
+                  {
+                    "id": "title",
+                    "label": "Title",
+                    "type": "text",
+                    "required": false
+                  },
+                  {
+                    "id": "email",
+                    "label": "E-mail Address",
+                    "type": "email",
+                    "required": true
+                  },
+                  {
+                    "id": "ssn_itin",
+                    "label": "SSN / ITIN",
+                    "type": "text",
+                    "required": false,
+                    "constraints": {
+                      "pattern": "^(\\d{3}-\\d{2}-\\d{4}|\\d{9})$"
+                    },
+                    "ui": {
+                      "placeholder": "XXX-XX-XXXX or 9-digit ITIN"
+                    }
+                  },
+                  {
+                    "id": "ssn_itin_type",
+                    "label": "Did you enter SSN or ITIN?",
+                    "type": "radio",
+                    "requiredCondition": {
+                      "field": "ssn_itin",
+                      "operator": "notEquals",
+                      "value": ""
+                    },
+                    "ui": {
+                      "options": ["SSN", "ITIN"]
+                    }
+                  },
+                  {
+                    "id": "phone",
+                    "label": "Phone Number",
+                    "type": "tel",
+                    "required": true,
+                    "constraints": {
+                      "pattern": "^\\(?[0-9]{3}\\)?[-. ]?[0-9]{3}[-. ]?[0-9]{4}$"
+                    },
+                    "ui": {
+                      "placeholder": "(123) 456-7890"
+                    }
+                  },
+                  {
+                    "id": "tty_phone",
+                    "label": "TTY Phone",
+                    "type": "tel",
+                    "required": false
+                  },
+                  {
+                    "id": "date_of_birth",
+                    "label": "Date of Birth",
+                    "type": "date",
+                    "required": false
+                  },
+                  {
+                    "id": "gender",
+                    "label": "Gender",
+                    "type": "radio",
+                    "required": false,
+                    "ui": {
+                      "options": ["Female", "Male"]
+                    }
+                  }
+                ]
+              }
+            ]
+          }
+        ]
+      },
+
+      {
+        "id": "application_info_1",
+        "title": "Application Specific Information 1",
+        "sections": [
+          {
+            "id": "program_details",
+            "title": "Program Details",
+            "fields": [
+              {
+                "id": "program_type",
+                "label": "Program Type",
+                "type": "select",
+                "required": true,
+                "ui": {
+                  "options": [
+                    "Infant Toddler",
+                    "Preschool"
+                  ]
+                }
+              },
+              {
+                "id": "orientation_cert_number",
+                "label": "Pre Permit Orientation Cert #",
+                "type": "text",
+                "required": true
+              },
+              {
+                "id": "permittee_name",
+                "label": "Permittee (Sponsor Name)",
+                "type": "text",
+                "required": true
+              },
+              {
+                "id": "is_applicant_same_as_permittee",
+                "label": "Applicant same as Permittee?",
+                "type": "checkbox",
+                "ui": {
+                  "defaultChecked": true
+                }
+              },
+              {
+                "id": "permit_expiration_date",
+                "label": "Expiration Date",
+                "type": "date",
+                "required": false
+              },
+              {
+                "id": "permit_number",
+                "label": "Permit #",
+                "type": "text",
+                "required": false
+              }
+            ]
+          },
+          {
+            "id": "program_contact",
+            "title": "Program Contact",
+            "fields": [
+              {
+                "id": "program_phone",
+                "label": "Phone",
+                "type": "tel"
+              },
+              {
+                "id": "program_fax",
+                "label": "Fax",
+                "type": "tel"
+              },
+              {
+                "id": "program_email",
+                "label": "Email",
+                "type": "email",
+                "required": true
+              },
+              {
+                "id": "program_website",
+                "label": "Website",
+                "type": "text"
+              }
+            ]
+          },
+          {
+            "id": "program_days_hours",
+            "title": "Days Open (Hours)",
+            "fields": [
+              {
+                "id": "open_days",
+                "label": "Open Days",
+                "type": "checkbox",
+                "ui": {
+                  "options": [
+                    "Sunday",
+                    "Monday",
+                    "Tuesday",
+                    "Wednesday",
+                    "Thursday",
+                    "Friday",
+                    "Saturday"
+                  ]
+                }
+              },
+              {
+                "id": "nightcare",
+                "label": "Nightcare",
+                "type": "checkbox"
+              },
+              {
+                "id": "open_from",
+                "label": "Open From",
+                "type": "time",
+                "required": true
+              },
+              {
+                "id": "close_at",
+                "label": "Close At",
+                "type": "time",
+                "required": true
+              },
+              {
+                "id": "inspection_delivery_method",
+                "label": "Inspection Report Delivery Method",
+                "type": "select",
+                "ui": {
+                  "options": [
+                    "Email",
+                    "Fax",
+                    "Regular Mail"
+                  ]
+                }
+              },
+              {
+                "id": "inspection_language",
+                "label": "Inspection Language",
+                "type": "select",
+                "ui": {
+                  "options": [
+                    "English",
+                    "Spanish"
+                  ]
+                }
+              }
+            ]
+          },
+          {
+            "id": "school_year_dates",
+            "title": "School Year Dates",
+            "fields": [
+              {
+                "id": "school_year_from",
+                "label": "Regular School Year From",
+                "type": "date"
+              },
+              {
+                "id": "school_year_to",
+                "label": "Regular School Year To",
+                "type": "date"
+              },
+              {
+                "id": "has_summer_program",
+                "label": "Summer Program",
+                "type": "checkbox"
+              }
+            ]
+          },
+          {
+            "id": "school_breaks",
+            "title": "School Breaks",
+            "fields": [
+              {
+                "id": "school_breaks",
+                "label": "School Breaks",
+                "type": "group",
+                "metadata": {
+                  "multiple": true,
+                  "tableColumns": [
+                    "term",
+                    "from",
+                    "to"
+                  ]
+                },
+                "fields": [
+                  {
+                    "id": "term",
+                    "label": "Term",
+                    "type": "select",
+                    "required": true,
+                    "ui": {
+                      "options": [
+                        "Fall",
+                        "Spring",
+                        "Summer",
+                        "Winter"
+                      ]
+                    }
+                  },
+                  {
+                    "id": "from",
+                    "label": "From",
+                    "type": "date",
+                    "required": true
+                  },
+                  {
+                    "id": "to",
+                    "label": "To",
+                    "type": "date",
+                    "required": true
+                  }
+                ]
+              }
+            ]
+          },
+          {
+            "id": "holidays",
+            "title": "Holidays",
+            "fields": [
+              {
+                "id": "holidays",
+                "label": "Holiday List",
+                "type": "group",
+                "metadata": {
+                  "multiple": true,
+                  "tableColumns": [
+                    "holiday_name"
+                  ]
+                },
+                "fields": [
+                  {
+                    "id": "holiday_name",
+                    "label": "Holiday Name",
+                    "type": "text",
+                    "required": true
+                  }
+                ]
+              }
+            ]
+          },
+          {
+            "id": "food_services_info",
+            "title": "Food Services Information",
+            "fields": [
+              {
+                "id": "food_provided",
+                "label": "Is food provided for children in care?",
+                "type": "radio",
+                "required": true,
+                "ui": {
+                  "options": [
+                    "Yes",
+                    "No"
+                  ]
+                }
+              },
+              {
+                "id": "food_prepared_on_site",
+                "label": "Is food prepared on site?",
+                "type": "radio",
+                "ui": {
+                  "options": [
+                    "Yes",
+                    "No"
+                  ]
+                }
+              },
+              {
+                "id": "food_preparation_location",
+                "label": "Where is food prepared?",
+                "type": "text"
+              },
+              {
+                "id": "dohmh_food_service_permit",
+                "label": "DOHMH Food Service Permit #",
+                "type": "text"
+              },
+              {
+                "id": "person_on_certificate",
+                "label": "Person Name on Certificate",
+                "type": "text"
+              },
+              {
+                "id": "food_protection_cert_number",
+                "label": "Food Protection Certificate #",
+                "type": "text"
+              }
+            ]
+          }
+        ]
+      },
+      {
+        "id": "application_info_2",
+        "title": "Application Specific Information 2"
+      },
+      {
+        "id": "document_upload",
+        "title": "Upload Documents",
+        "description": "REQUIRED DOCUMENTS\nIn order for your application to be processed, based on information provided, you are required to upload the following documents:",
+        "sections": [
+          {
+            "id": "initial_site_survey",
+            "title": "Initial Site Survey Form",
+            "fields": [
+              {
+                "id": "site_survey_file",
+                "label": "Upload Initial Site Survey Form",
+                "type": "file",
+                "required": true,
+                "constraints": {
+                  "maxFileSizeMB": 25,
+                  "allowedTypes": [
+                    "application/pdf",
+                    "image/jpeg",
+                    "image/jpg",
+                    "image/png"
+                  ]
+                },
+                "metadata": {
+                  "proofCategory": "Initial Site Survey",
+                  "multiple": false
+                }
+              }
+            ]
+          },
+          {
+            "id": "personal_id_proof",
+            "title": "Proof of Personal Identification",
+            "fields": [
+              {
+                "id": "personal_id_file",
+                "label": "Upload Proof of Personal Identification",
+                "type": "file",
+                "required": true,
+                "constraints": {
+                  "maxFileSizeMB": 25,
+                  "allowedTypes": [
+                    "application/pdf",
+                    "image/jpeg",
+                    "image/jpg",
+                    "image/png"
+                  ]
+                },
+                "metadata": {
+                  "proofCategory": "Personal ID",
+                  "multiple": false
+                }
+              }
+            ]
+          },
+          {
+            "id": "fee_exemption_proof",
+            "title": "Proof of Fee Exemption",
+            "fields": [
+              {
+                "id": "fee_exemption_file",
+                "label": "Upload Proof of Fee Exemption (ACS Affiliation or Municipal Exemption)",
+                "type": "file",
+                "required": true,
+                "constraints": {
+                  "maxFileSizeMB": 25,
+                  "allowedTypes": [
+                    "application/pdf",
+                    "image/jpeg",
+                    "image/jpg",
+                    "image/png"
+                  ]
+                },
+                "metadata": {
+                  "proofCategory": "Fee Exemption",
+                  "multiple": false
+                }
+              }
+            ]
+          }
+        ]
+      },
+      {
+        "id": "step_6_placeholder",
+        "title": "To be defined"
+      },
+      {
+        "id": "step_7_placeholder",
+        "title": "To be defined"
+      },
+      {
+        "id": "step_8_placeholder",
+        "title": "To be defined"
+      }
+    ]
+  }
+}

--- a/test-form/public/data/group_cc_permit.ur.json
+++ b/test-form/public/data/group_cc_permit.ur.json
@@ -1,0 +1,788 @@
+{
+  "form": {
+    "title": "Group Child Care Permit Application",
+    "description": "Multi-step application for obtaining a permit to operate group child care programs.",
+    "layout": {
+      "stepperPosition": "left"
+    },
+    "steps": [
+      {
+        "id": "establishment_information",
+        "title": "Establishment Information",
+        "sections": [
+          {
+            "id": "establishment_address",
+            "title": "Establishment Address",
+            "description": "Enter the physical address where business will operate. If you are applying for a Tattoo License, enter your mailing or home address.",
+            "ui": {
+              "autocomplete": "street_1",
+              "placeholder": "Start typing your street address",
+              "overrideComponent": "AddressAutocomplete"
+            },
+            "metadata": {
+              "integration": {
+                "provider": "Google",
+                "feature": "AddressAutocomplete"
+              },
+              "autofillTargets": [
+                {
+                  "fieldId": "city",
+                  "source": "locality",
+                  "fallbackSources": [
+                    "postal_town",
+                    "sublocality_level_1",
+                    "administrative_area_level_2"
+                  ]
+                },
+                {
+                  "fieldId": "borough",
+                  "source": "sublocality_level_1",
+                  "fallbackSources": [
+                    "administrative_area_level_2"
+                  ],
+                  "mapping": "boroughMap"
+                },
+                { "fieldId": "state", "source": "administrative_area_level_1" },
+                { "fieldId": "building_number", "source": "street_number" },
+                { "fieldId": "house_number", "source": "street_number" }
+              ]
+            },
+            "fields": [
+              {
+                "id": "address_type",
+                "label": "Address Type",
+                "type": "select",
+                "required": true,
+                "ui": {
+                  "options": [
+                    "Select",
+                    "Complete Address",
+                    "Cross Street (Intersection)",
+                    "Place (Landmark)"
+                  ]
+                }
+              },
+              {
+                "id": "street_1",
+                "label": "Street 1",
+                "type": "text",
+                "required": true
+              },
+              {
+                "id": "building_number",
+                "label": "Building #",
+                "type": "text",
+                "required": true
+              },
+              {
+                "id": "street_2",
+                "label": "Street 2",
+                "type": "text",
+                "required": false
+              },
+              {
+                "id": "unit_type",
+                "label": "Unit Type",
+                "type": "select",
+                "required": false,
+                "ui": {
+                  "options": [
+                    "LBBY",
+                    "APT",
+                    "BLDG",
+                    "STE",
+                    "FL",
+                    "BSMT",
+                    "FRNT",
+                    "SIDE",
+                    "REAR",
+                    "UPPR",
+                    "LOWR",
+                    "PIER"
+                  ]
+                }
+              },
+              {
+                "id": "unit",
+                "label": "Unit",
+                "type": "text",
+                "required": false
+              },
+              {
+                "id": "city",
+                "label": "City",
+                "type": "text",
+                "required": true
+              },
+              {
+                "id": "state",
+                "label": "State",
+                "type": "text",
+                "required": true
+              },
+              {
+                "id": "borough",
+                "label": "Borough",
+                "type": "select",
+                "required": true,
+                "ui": {
+                  "options": [
+                    "Bronx",
+                    "Brooklyn",
+                    "Manhattan",
+                    "Queens",
+                    "Staten Island"
+                  ]
+                }
+              },
+              {
+                "id": "bin",
+                "label": "Bin",
+                "type": "text",
+                "required": false,
+                "metadata": {
+                  "source": "Geoclient API"
+                }
+              },
+              {
+                "id": "bbl",
+                "label": "Bbl",
+                "type": "text",
+                "required": false,
+                "metadata": {
+                  "source": "Geoclient API"
+                }
+              },
+              {
+                "id": "community_district",
+                "label": "Community District",
+                "type": "text",
+                "required": false,
+                "metadata": {
+                  "source": "Geoclient API"
+                }
+              },
+              {
+                "id": "council_district",
+                "label": "Council District",
+                "type": "text",
+                "required": false,
+                "metadata": {
+                  "source": "Geoclient API"
+                }
+              },
+              {
+                "id": "police_precinct",
+                "label": "Police Precinct",
+                "type": "text",
+                "required": false,
+                "metadata": {
+                  "source": "Geoclient API"
+                }
+              },
+              {
+                "id": "house_number",
+                "label": "House Number",
+                "type": "text",
+                "required": false,
+                "metadata": {
+                  "source": "Geoclient API"
+                }
+              }
+            ]
+          }
+        ]
+      },
+      {
+        "id": "contact_information",
+        "title": "Contact Information – Applicant and Other Contacts",
+        "sections": [
+          {
+            "id": "contact_info_guidance",
+            "title": "Contact Type Guidance",
+            "type": "info",
+            "ui": {
+              "markdown": true,
+              "collapsible": false,
+              "defaultCollapsed": false
+            },
+            "content": "### Applying as a Corporation, Partnership, or Not-for-Profit?\n\nSelect **\"Business Information\"** as your Type of Contact and complete the required fields.  \nBusinesses also have the opportunity to provide a complete list of the responsible individuals within their organization. To add each individual's information to your application, please select **\"Other Contact\"** as the Type of Contact and complete the required fields that appear.\n\n---\n\n### Applying as an Individual or Sole Proprietorship?\n\nSelect **\"Individual Owner\"** as your Type of Contact and complete the required fields that appear.\n\n---\n\n### Emergency Contact?\n\nUnless a **\"Designated Emergency Contact\"** is specified, the applicant will be assumed to be the Emergency Contact.  \nTo identify someone other than the applicant to be contacted in the event of an emergency, please select **\"Designated Emergency Contact\"** as the Type of Contact and complete the required fields that appear."
+          },
+          {
+            "id": "contact_list",
+            "title": "Contact List",
+            "fields": [
+              {
+                "id": "contacts",
+                "label": "Contacts",
+                "type": "group",
+                "metadata": {
+                  "multiple": true,
+                  "tableColumns": ["contact_type", "first_name", "last_name", "establishment_name", "email"]
+                },
+                "fields": [
+                  {
+                    "id": "contact_type",
+                    "label": "Type of Contact",
+                    "type": "select",
+                    "required": true,
+                    "ui": {
+                      "options": [
+                        "Business Information",
+                        "Individual Owner",
+                        "Other Contact",
+                        "Designated Emergency Contact"
+                      ]
+                    }
+                  },
+                  {
+                    "id": "establishment_name",
+                    "label": "Establishment Name",
+                    "type": "text",
+                    "requiredCondition": {
+                      "field": "contact_type",
+                      "operator": "equals",
+                      "value": "Business Information"
+                    }
+                  },
+                  {
+                    "id": "dba_name",
+                    "label": "DBA / Trade Name",
+                    "type": "text",
+                    "requiredCondition": {
+                      "field": "contact_type",
+                      "operator": "equals",
+                      "value": "Business Information"
+                    }
+                  },
+                  {
+                    "id": "legal_structure",
+                    "label": "Legal Structure",
+                    "type": "select",
+                    "requiredCondition": {
+                      "field": "contact_type",
+                      "operator": "equals",
+                      "value": "Business Information"
+                    },
+                    "ui": {
+                      "options": [
+                        "Corporation",
+                        "Partnership",
+                        "Limited Partnership",
+                        "Limited Liability",
+                        "Not-for-Profit"
+                      ]
+                    }
+                  },
+                  {
+                    "id": "nys_sales_tax_id",
+                    "label": "NYS Sales Tax ID #",
+                    "type": "text",
+                    "requiredCondition": {
+                      "field": "contact_type",
+                      "operator": "equals",
+                      "value": "Business Information"
+                    }
+                  },
+                  {
+                    "id": "is_out_of_state_corp",
+                    "label": "Are you a corporation formed outside of New York State?",
+                    "type": "radio",
+                    "requiredCondition": {
+                      "field": "contact_type",
+                      "operator": "equals",
+                      "value": "Business Information"
+                    },
+                    "ui": {
+                      "options": ["Yes", "No"]
+                    }
+                  },
+                  {
+                    "id": "first_name",
+                    "label": "First Name",
+                    "type": "text",
+                    "requiredCondition": {
+                      "anyOf": [
+                        { "field": "contact_type", "operator": "equals", "value": "Individual Owner" },
+                        { "field": "contact_type", "operator": "equals", "value": "Other Contact" },
+                        { "field": "contact_type", "operator": "equals", "value": "Designated Emergency Contact" }
+                      ]
+                    }
+                  },
+                  {
+                    "id": "last_name",
+                    "label": "Last Name",
+                    "type": "text",
+                    "requiredCondition": {
+                      "anyOf": [
+                        { "field": "contact_type", "operator": "equals", "value": "Individual Owner" },
+                        { "field": "contact_type", "operator": "equals", "value": "Other Contact" },
+                        { "field": "contact_type", "operator": "equals", "value": "Designated Emergency Contact" }
+                      ]
+                    }
+                  },
+                  {
+                    "id": "title",
+                    "label": "Title",
+                    "type": "text",
+                    "required": false
+                  },
+                  {
+                    "id": "email",
+                    "label": "E-mail Address",
+                    "type": "email",
+                    "required": true
+                  },
+                  {
+                    "id": "ssn_itin",
+                    "label": "SSN / ITIN",
+                    "type": "text",
+                    "required": false,
+                    "constraints": {
+                      "pattern": "^(\\d{3}-\\d{2}-\\d{4}|\\d{9})$"
+                    },
+                    "ui": {
+                      "placeholder": "XXX-XX-XXXX or 9-digit ITIN"
+                    }
+                  },
+                  {
+                    "id": "ssn_itin_type",
+                    "label": "Did you enter SSN or ITIN?",
+                    "type": "radio",
+                    "requiredCondition": {
+                      "field": "ssn_itin",
+                      "operator": "notEquals",
+                      "value": ""
+                    },
+                    "ui": {
+                      "options": ["SSN", "ITIN"]
+                    }
+                  },
+                  {
+                    "id": "phone",
+                    "label": "Phone Number",
+                    "type": "tel",
+                    "required": true,
+                    "constraints": {
+                      "pattern": "^\\(?[0-9]{3}\\)?[-. ]?[0-9]{3}[-. ]?[0-9]{4}$"
+                    },
+                    "ui": {
+                      "placeholder": "(123) 456-7890"
+                    }
+                  },
+                  {
+                    "id": "tty_phone",
+                    "label": "TTY Phone",
+                    "type": "tel",
+                    "required": false
+                  },
+                  {
+                    "id": "date_of_birth",
+                    "label": "Date of Birth",
+                    "type": "date",
+                    "required": false
+                  },
+                  {
+                    "id": "gender",
+                    "label": "Gender",
+                    "type": "radio",
+                    "required": false,
+                    "ui": {
+                      "options": ["Female", "Male"]
+                    }
+                  }
+                ]
+              }
+            ]
+          }
+        ]
+      },
+
+      {
+        "id": "application_info_1",
+        "title": "Application Specific Information 1",
+        "sections": [
+          {
+            "id": "program_details",
+            "title": "Program Details",
+            "fields": [
+              {
+                "id": "program_type",
+                "label": "Program Type",
+                "type": "select",
+                "required": true,
+                "ui": {
+                  "options": [
+                    "Infant Toddler",
+                    "Preschool"
+                  ]
+                }
+              },
+              {
+                "id": "orientation_cert_number",
+                "label": "Pre Permit Orientation Cert #",
+                "type": "text",
+                "required": true
+              },
+              {
+                "id": "permittee_name",
+                "label": "Permittee (Sponsor Name)",
+                "type": "text",
+                "required": true
+              },
+              {
+                "id": "is_applicant_same_as_permittee",
+                "label": "Applicant same as Permittee?",
+                "type": "checkbox",
+                "ui": {
+                  "defaultChecked": true
+                }
+              },
+              {
+                "id": "permit_expiration_date",
+                "label": "Expiration Date",
+                "type": "date",
+                "required": false
+              },
+              {
+                "id": "permit_number",
+                "label": "Permit #",
+                "type": "text",
+                "required": false
+              }
+            ]
+          },
+          {
+            "id": "program_contact",
+            "title": "Program Contact",
+            "fields": [
+              {
+                "id": "program_phone",
+                "label": "Phone",
+                "type": "tel"
+              },
+              {
+                "id": "program_fax",
+                "label": "Fax",
+                "type": "tel"
+              },
+              {
+                "id": "program_email",
+                "label": "Email",
+                "type": "email",
+                "required": true
+              },
+              {
+                "id": "program_website",
+                "label": "Website",
+                "type": "text"
+              }
+            ]
+          },
+          {
+            "id": "program_days_hours",
+            "title": "Days Open (Hours)",
+            "fields": [
+              {
+                "id": "open_days",
+                "label": "Open Days",
+                "type": "checkbox",
+                "ui": {
+                  "options": [
+                    "Sunday",
+                    "Monday",
+                    "Tuesday",
+                    "Wednesday",
+                    "Thursday",
+                    "Friday",
+                    "Saturday"
+                  ]
+                }
+              },
+              {
+                "id": "nightcare",
+                "label": "Nightcare",
+                "type": "checkbox"
+              },
+              {
+                "id": "open_from",
+                "label": "Open From",
+                "type": "time",
+                "required": true
+              },
+              {
+                "id": "close_at",
+                "label": "Close At",
+                "type": "time",
+                "required": true
+              },
+              {
+                "id": "inspection_delivery_method",
+                "label": "Inspection Report Delivery Method",
+                "type": "select",
+                "ui": {
+                  "options": [
+                    "Email",
+                    "Fax",
+                    "Regular Mail"
+                  ]
+                }
+              },
+              {
+                "id": "inspection_language",
+                "label": "Inspection Language",
+                "type": "select",
+                "ui": {
+                  "options": [
+                    "English",
+                    "Spanish"
+                  ]
+                }
+              }
+            ]
+          },
+          {
+            "id": "school_year_dates",
+            "title": "School Year Dates",
+            "fields": [
+              {
+                "id": "school_year_from",
+                "label": "Regular School Year From",
+                "type": "date"
+              },
+              {
+                "id": "school_year_to",
+                "label": "Regular School Year To",
+                "type": "date"
+              },
+              {
+                "id": "has_summer_program",
+                "label": "Summer Program",
+                "type": "checkbox"
+              }
+            ]
+          },
+          {
+            "id": "school_breaks",
+            "title": "School Breaks",
+            "fields": [
+              {
+                "id": "school_breaks",
+                "label": "School Breaks",
+                "type": "group",
+                "metadata": {
+                  "multiple": true,
+                  "tableColumns": [
+                    "term",
+                    "from",
+                    "to"
+                  ]
+                },
+                "fields": [
+                  {
+                    "id": "term",
+                    "label": "Term",
+                    "type": "select",
+                    "required": true,
+                    "ui": {
+                      "options": [
+                        "Fall",
+                        "Spring",
+                        "Summer",
+                        "Winter"
+                      ]
+                    }
+                  },
+                  {
+                    "id": "from",
+                    "label": "From",
+                    "type": "date",
+                    "required": true
+                  },
+                  {
+                    "id": "to",
+                    "label": "To",
+                    "type": "date",
+                    "required": true
+                  }
+                ]
+              }
+            ]
+          },
+          {
+            "id": "holidays",
+            "title": "Holidays",
+            "fields": [
+              {
+                "id": "holidays",
+                "label": "Holiday List",
+                "type": "group",
+                "metadata": {
+                  "multiple": true,
+                  "tableColumns": [
+                    "holiday_name"
+                  ]
+                },
+                "fields": [
+                  {
+                    "id": "holiday_name",
+                    "label": "Holiday Name",
+                    "type": "text",
+                    "required": true
+                  }
+                ]
+              }
+            ]
+          },
+          {
+            "id": "food_services_info",
+            "title": "Food Services Information",
+            "fields": [
+              {
+                "id": "food_provided",
+                "label": "Is food provided for children in care?",
+                "type": "radio",
+                "required": true,
+                "ui": {
+                  "options": [
+                    "Yes",
+                    "No"
+                  ]
+                }
+              },
+              {
+                "id": "food_prepared_on_site",
+                "label": "Is food prepared on site?",
+                "type": "radio",
+                "ui": {
+                  "options": [
+                    "Yes",
+                    "No"
+                  ]
+                }
+              },
+              {
+                "id": "food_preparation_location",
+                "label": "Where is food prepared?",
+                "type": "text"
+              },
+              {
+                "id": "dohmh_food_service_permit",
+                "label": "DOHMH Food Service Permit #",
+                "type": "text"
+              },
+              {
+                "id": "person_on_certificate",
+                "label": "Person Name on Certificate",
+                "type": "text"
+              },
+              {
+                "id": "food_protection_cert_number",
+                "label": "Food Protection Certificate #",
+                "type": "text"
+              }
+            ]
+          }
+        ]
+      },
+      {
+        "id": "application_info_2",
+        "title": "Application Specific Information 2"
+      },
+      {
+        "id": "document_upload",
+        "title": "Upload Documents",
+        "description": "REQUIRED DOCUMENTS\nIn order for your application to be processed, based on information provided, you are required to upload the following documents:",
+        "sections": [
+          {
+            "id": "initial_site_survey",
+            "title": "Initial Site Survey Form",
+            "fields": [
+              {
+                "id": "site_survey_file",
+                "label": "Upload Initial Site Survey Form",
+                "type": "file",
+                "required": true,
+                "constraints": {
+                  "maxFileSizeMB": 25,
+                  "allowedTypes": [
+                    "application/pdf",
+                    "image/jpeg",
+                    "image/jpg",
+                    "image/png"
+                  ]
+                },
+                "metadata": {
+                  "proofCategory": "Initial Site Survey",
+                  "multiple": false
+                }
+              }
+            ]
+          },
+          {
+            "id": "personal_id_proof",
+            "title": "Proof of Personal Identification",
+            "fields": [
+              {
+                "id": "personal_id_file",
+                "label": "Upload Proof of Personal Identification",
+                "type": "file",
+                "required": true,
+                "constraints": {
+                  "maxFileSizeMB": 25,
+                  "allowedTypes": [
+                    "application/pdf",
+                    "image/jpeg",
+                    "image/jpg",
+                    "image/png"
+                  ]
+                },
+                "metadata": {
+                  "proofCategory": "Personal ID",
+                  "multiple": false
+                }
+              }
+            ]
+          },
+          {
+            "id": "fee_exemption_proof",
+            "title": "Proof of Fee Exemption",
+            "fields": [
+              {
+                "id": "fee_exemption_file",
+                "label": "Upload Proof of Fee Exemption (ACS Affiliation or Municipal Exemption)",
+                "type": "file",
+                "required": true,
+                "constraints": {
+                  "maxFileSizeMB": 25,
+                  "allowedTypes": [
+                    "application/pdf",
+                    "image/jpeg",
+                    "image/jpg",
+                    "image/png"
+                  ]
+                },
+                "metadata": {
+                  "proofCategory": "Fee Exemption",
+                  "multiple": false
+                }
+              }
+            ]
+          }
+        ]
+      },
+      {
+        "id": "step_6_placeholder",
+        "title": "To be defined"
+      },
+      {
+        "id": "step_7_placeholder",
+        "title": "To be defined"
+      },
+      {
+        "id": "step_8_placeholder",
+        "title": "To be defined"
+      }
+    ]
+  }
+}

--- a/test-form/public/data/group_cc_permit.zh.json
+++ b/test-form/public/data/group_cc_permit.zh.json
@@ -1,0 +1,788 @@
+{
+  "form": {
+    "title": "Group Child Care Permit Application",
+    "description": "Multi-step application for obtaining a permit to operate group child care programs.",
+    "layout": {
+      "stepperPosition": "left"
+    },
+    "steps": [
+      {
+        "id": "establishment_information",
+        "title": "Establishment Information",
+        "sections": [
+          {
+            "id": "establishment_address",
+            "title": "Establishment Address",
+            "description": "Enter the physical address where business will operate. If you are applying for a Tattoo License, enter your mailing or home address.",
+            "ui": {
+              "autocomplete": "street_1",
+              "placeholder": "Start typing your street address",
+              "overrideComponent": "AddressAutocomplete"
+            },
+            "metadata": {
+              "integration": {
+                "provider": "Google",
+                "feature": "AddressAutocomplete"
+              },
+              "autofillTargets": [
+                {
+                  "fieldId": "city",
+                  "source": "locality",
+                  "fallbackSources": [
+                    "postal_town",
+                    "sublocality_level_1",
+                    "administrative_area_level_2"
+                  ]
+                },
+                {
+                  "fieldId": "borough",
+                  "source": "sublocality_level_1",
+                  "fallbackSources": [
+                    "administrative_area_level_2"
+                  ],
+                  "mapping": "boroughMap"
+                },
+                { "fieldId": "state", "source": "administrative_area_level_1" },
+                { "fieldId": "building_number", "source": "street_number" },
+                { "fieldId": "house_number", "source": "street_number" }
+              ]
+            },
+            "fields": [
+              {
+                "id": "address_type",
+                "label": "Address Type",
+                "type": "select",
+                "required": true,
+                "ui": {
+                  "options": [
+                    "Select",
+                    "Complete Address",
+                    "Cross Street (Intersection)",
+                    "Place (Landmark)"
+                  ]
+                }
+              },
+              {
+                "id": "street_1",
+                "label": "Street 1",
+                "type": "text",
+                "required": true
+              },
+              {
+                "id": "building_number",
+                "label": "Building #",
+                "type": "text",
+                "required": true
+              },
+              {
+                "id": "street_2",
+                "label": "Street 2",
+                "type": "text",
+                "required": false
+              },
+              {
+                "id": "unit_type",
+                "label": "Unit Type",
+                "type": "select",
+                "required": false,
+                "ui": {
+                  "options": [
+                    "LBBY",
+                    "APT",
+                    "BLDG",
+                    "STE",
+                    "FL",
+                    "BSMT",
+                    "FRNT",
+                    "SIDE",
+                    "REAR",
+                    "UPPR",
+                    "LOWR",
+                    "PIER"
+                  ]
+                }
+              },
+              {
+                "id": "unit",
+                "label": "Unit",
+                "type": "text",
+                "required": false
+              },
+              {
+                "id": "city",
+                "label": "City",
+                "type": "text",
+                "required": true
+              },
+              {
+                "id": "state",
+                "label": "State",
+                "type": "text",
+                "required": true
+              },
+              {
+                "id": "borough",
+                "label": "Borough",
+                "type": "select",
+                "required": true,
+                "ui": {
+                  "options": [
+                    "Bronx",
+                    "Brooklyn",
+                    "Manhattan",
+                    "Queens",
+                    "Staten Island"
+                  ]
+                }
+              },
+              {
+                "id": "bin",
+                "label": "Bin",
+                "type": "text",
+                "required": false,
+                "metadata": {
+                  "source": "Geoclient API"
+                }
+              },
+              {
+                "id": "bbl",
+                "label": "Bbl",
+                "type": "text",
+                "required": false,
+                "metadata": {
+                  "source": "Geoclient API"
+                }
+              },
+              {
+                "id": "community_district",
+                "label": "Community District",
+                "type": "text",
+                "required": false,
+                "metadata": {
+                  "source": "Geoclient API"
+                }
+              },
+              {
+                "id": "council_district",
+                "label": "Council District",
+                "type": "text",
+                "required": false,
+                "metadata": {
+                  "source": "Geoclient API"
+                }
+              },
+              {
+                "id": "police_precinct",
+                "label": "Police Precinct",
+                "type": "text",
+                "required": false,
+                "metadata": {
+                  "source": "Geoclient API"
+                }
+              },
+              {
+                "id": "house_number",
+                "label": "House Number",
+                "type": "text",
+                "required": false,
+                "metadata": {
+                  "source": "Geoclient API"
+                }
+              }
+            ]
+          }
+        ]
+      },
+      {
+        "id": "contact_information",
+        "title": "Contact Information – Applicant and Other Contacts",
+        "sections": [
+          {
+            "id": "contact_info_guidance",
+            "title": "Contact Type Guidance",
+            "type": "info",
+            "ui": {
+              "markdown": true,
+              "collapsible": false,
+              "defaultCollapsed": false
+            },
+            "content": "### Applying as a Corporation, Partnership, or Not-for-Profit?\n\nSelect **\"Business Information\"** as your Type of Contact and complete the required fields.  \nBusinesses also have the opportunity to provide a complete list of the responsible individuals within their organization. To add each individual's information to your application, please select **\"Other Contact\"** as the Type of Contact and complete the required fields that appear.\n\n---\n\n### Applying as an Individual or Sole Proprietorship?\n\nSelect **\"Individual Owner\"** as your Type of Contact and complete the required fields that appear.\n\n---\n\n### Emergency Contact?\n\nUnless a **\"Designated Emergency Contact\"** is specified, the applicant will be assumed to be the Emergency Contact.  \nTo identify someone other than the applicant to be contacted in the event of an emergency, please select **\"Designated Emergency Contact\"** as the Type of Contact and complete the required fields that appear."
+          },
+          {
+            "id": "contact_list",
+            "title": "Contact List",
+            "fields": [
+              {
+                "id": "contacts",
+                "label": "Contacts",
+                "type": "group",
+                "metadata": {
+                  "multiple": true,
+                  "tableColumns": ["contact_type", "first_name", "last_name", "establishment_name", "email"]
+                },
+                "fields": [
+                  {
+                    "id": "contact_type",
+                    "label": "Type of Contact",
+                    "type": "select",
+                    "required": true,
+                    "ui": {
+                      "options": [
+                        "Business Information",
+                        "Individual Owner",
+                        "Other Contact",
+                        "Designated Emergency Contact"
+                      ]
+                    }
+                  },
+                  {
+                    "id": "establishment_name",
+                    "label": "Establishment Name",
+                    "type": "text",
+                    "requiredCondition": {
+                      "field": "contact_type",
+                      "operator": "equals",
+                      "value": "Business Information"
+                    }
+                  },
+                  {
+                    "id": "dba_name",
+                    "label": "DBA / Trade Name",
+                    "type": "text",
+                    "requiredCondition": {
+                      "field": "contact_type",
+                      "operator": "equals",
+                      "value": "Business Information"
+                    }
+                  },
+                  {
+                    "id": "legal_structure",
+                    "label": "Legal Structure",
+                    "type": "select",
+                    "requiredCondition": {
+                      "field": "contact_type",
+                      "operator": "equals",
+                      "value": "Business Information"
+                    },
+                    "ui": {
+                      "options": [
+                        "Corporation",
+                        "Partnership",
+                        "Limited Partnership",
+                        "Limited Liability",
+                        "Not-for-Profit"
+                      ]
+                    }
+                  },
+                  {
+                    "id": "nys_sales_tax_id",
+                    "label": "NYS Sales Tax ID #",
+                    "type": "text",
+                    "requiredCondition": {
+                      "field": "contact_type",
+                      "operator": "equals",
+                      "value": "Business Information"
+                    }
+                  },
+                  {
+                    "id": "is_out_of_state_corp",
+                    "label": "Are you a corporation formed outside of New York State?",
+                    "type": "radio",
+                    "requiredCondition": {
+                      "field": "contact_type",
+                      "operator": "equals",
+                      "value": "Business Information"
+                    },
+                    "ui": {
+                      "options": ["Yes", "No"]
+                    }
+                  },
+                  {
+                    "id": "first_name",
+                    "label": "First Name",
+                    "type": "text",
+                    "requiredCondition": {
+                      "anyOf": [
+                        { "field": "contact_type", "operator": "equals", "value": "Individual Owner" },
+                        { "field": "contact_type", "operator": "equals", "value": "Other Contact" },
+                        { "field": "contact_type", "operator": "equals", "value": "Designated Emergency Contact" }
+                      ]
+                    }
+                  },
+                  {
+                    "id": "last_name",
+                    "label": "Last Name",
+                    "type": "text",
+                    "requiredCondition": {
+                      "anyOf": [
+                        { "field": "contact_type", "operator": "equals", "value": "Individual Owner" },
+                        { "field": "contact_type", "operator": "equals", "value": "Other Contact" },
+                        { "field": "contact_type", "operator": "equals", "value": "Designated Emergency Contact" }
+                      ]
+                    }
+                  },
+                  {
+                    "id": "title",
+                    "label": "Title",
+                    "type": "text",
+                    "required": false
+                  },
+                  {
+                    "id": "email",
+                    "label": "E-mail Address",
+                    "type": "email",
+                    "required": true
+                  },
+                  {
+                    "id": "ssn_itin",
+                    "label": "SSN / ITIN",
+                    "type": "text",
+                    "required": false,
+                    "constraints": {
+                      "pattern": "^(\\d{3}-\\d{2}-\\d{4}|\\d{9})$"
+                    },
+                    "ui": {
+                      "placeholder": "XXX-XX-XXXX or 9-digit ITIN"
+                    }
+                  },
+                  {
+                    "id": "ssn_itin_type",
+                    "label": "Did you enter SSN or ITIN?",
+                    "type": "radio",
+                    "requiredCondition": {
+                      "field": "ssn_itin",
+                      "operator": "notEquals",
+                      "value": ""
+                    },
+                    "ui": {
+                      "options": ["SSN", "ITIN"]
+                    }
+                  },
+                  {
+                    "id": "phone",
+                    "label": "Phone Number",
+                    "type": "tel",
+                    "required": true,
+                    "constraints": {
+                      "pattern": "^\\(?[0-9]{3}\\)?[-. ]?[0-9]{3}[-. ]?[0-9]{4}$"
+                    },
+                    "ui": {
+                      "placeholder": "(123) 456-7890"
+                    }
+                  },
+                  {
+                    "id": "tty_phone",
+                    "label": "TTY Phone",
+                    "type": "tel",
+                    "required": false
+                  },
+                  {
+                    "id": "date_of_birth",
+                    "label": "Date of Birth",
+                    "type": "date",
+                    "required": false
+                  },
+                  {
+                    "id": "gender",
+                    "label": "Gender",
+                    "type": "radio",
+                    "required": false,
+                    "ui": {
+                      "options": ["Female", "Male"]
+                    }
+                  }
+                ]
+              }
+            ]
+          }
+        ]
+      },
+
+      {
+        "id": "application_info_1",
+        "title": "Application Specific Information 1",
+        "sections": [
+          {
+            "id": "program_details",
+            "title": "Program Details",
+            "fields": [
+              {
+                "id": "program_type",
+                "label": "Program Type",
+                "type": "select",
+                "required": true,
+                "ui": {
+                  "options": [
+                    "Infant Toddler",
+                    "Preschool"
+                  ]
+                }
+              },
+              {
+                "id": "orientation_cert_number",
+                "label": "Pre Permit Orientation Cert #",
+                "type": "text",
+                "required": true
+              },
+              {
+                "id": "permittee_name",
+                "label": "Permittee (Sponsor Name)",
+                "type": "text",
+                "required": true
+              },
+              {
+                "id": "is_applicant_same_as_permittee",
+                "label": "Applicant same as Permittee?",
+                "type": "checkbox",
+                "ui": {
+                  "defaultChecked": true
+                }
+              },
+              {
+                "id": "permit_expiration_date",
+                "label": "Expiration Date",
+                "type": "date",
+                "required": false
+              },
+              {
+                "id": "permit_number",
+                "label": "Permit #",
+                "type": "text",
+                "required": false
+              }
+            ]
+          },
+          {
+            "id": "program_contact",
+            "title": "Program Contact",
+            "fields": [
+              {
+                "id": "program_phone",
+                "label": "Phone",
+                "type": "tel"
+              },
+              {
+                "id": "program_fax",
+                "label": "Fax",
+                "type": "tel"
+              },
+              {
+                "id": "program_email",
+                "label": "Email",
+                "type": "email",
+                "required": true
+              },
+              {
+                "id": "program_website",
+                "label": "Website",
+                "type": "text"
+              }
+            ]
+          },
+          {
+            "id": "program_days_hours",
+            "title": "Days Open (Hours)",
+            "fields": [
+              {
+                "id": "open_days",
+                "label": "Open Days",
+                "type": "checkbox",
+                "ui": {
+                  "options": [
+                    "Sunday",
+                    "Monday",
+                    "Tuesday",
+                    "Wednesday",
+                    "Thursday",
+                    "Friday",
+                    "Saturday"
+                  ]
+                }
+              },
+              {
+                "id": "nightcare",
+                "label": "Nightcare",
+                "type": "checkbox"
+              },
+              {
+                "id": "open_from",
+                "label": "Open From",
+                "type": "time",
+                "required": true
+              },
+              {
+                "id": "close_at",
+                "label": "Close At",
+                "type": "time",
+                "required": true
+              },
+              {
+                "id": "inspection_delivery_method",
+                "label": "Inspection Report Delivery Method",
+                "type": "select",
+                "ui": {
+                  "options": [
+                    "Email",
+                    "Fax",
+                    "Regular Mail"
+                  ]
+                }
+              },
+              {
+                "id": "inspection_language",
+                "label": "Inspection Language",
+                "type": "select",
+                "ui": {
+                  "options": [
+                    "English",
+                    "Spanish"
+                  ]
+                }
+              }
+            ]
+          },
+          {
+            "id": "school_year_dates",
+            "title": "School Year Dates",
+            "fields": [
+              {
+                "id": "school_year_from",
+                "label": "Regular School Year From",
+                "type": "date"
+              },
+              {
+                "id": "school_year_to",
+                "label": "Regular School Year To",
+                "type": "date"
+              },
+              {
+                "id": "has_summer_program",
+                "label": "Summer Program",
+                "type": "checkbox"
+              }
+            ]
+          },
+          {
+            "id": "school_breaks",
+            "title": "School Breaks",
+            "fields": [
+              {
+                "id": "school_breaks",
+                "label": "School Breaks",
+                "type": "group",
+                "metadata": {
+                  "multiple": true,
+                  "tableColumns": [
+                    "term",
+                    "from",
+                    "to"
+                  ]
+                },
+                "fields": [
+                  {
+                    "id": "term",
+                    "label": "Term",
+                    "type": "select",
+                    "required": true,
+                    "ui": {
+                      "options": [
+                        "Fall",
+                        "Spring",
+                        "Summer",
+                        "Winter"
+                      ]
+                    }
+                  },
+                  {
+                    "id": "from",
+                    "label": "From",
+                    "type": "date",
+                    "required": true
+                  },
+                  {
+                    "id": "to",
+                    "label": "To",
+                    "type": "date",
+                    "required": true
+                  }
+                ]
+              }
+            ]
+          },
+          {
+            "id": "holidays",
+            "title": "Holidays",
+            "fields": [
+              {
+                "id": "holidays",
+                "label": "Holiday List",
+                "type": "group",
+                "metadata": {
+                  "multiple": true,
+                  "tableColumns": [
+                    "holiday_name"
+                  ]
+                },
+                "fields": [
+                  {
+                    "id": "holiday_name",
+                    "label": "Holiday Name",
+                    "type": "text",
+                    "required": true
+                  }
+                ]
+              }
+            ]
+          },
+          {
+            "id": "food_services_info",
+            "title": "Food Services Information",
+            "fields": [
+              {
+                "id": "food_provided",
+                "label": "Is food provided for children in care?",
+                "type": "radio",
+                "required": true,
+                "ui": {
+                  "options": [
+                    "Yes",
+                    "No"
+                  ]
+                }
+              },
+              {
+                "id": "food_prepared_on_site",
+                "label": "Is food prepared on site?",
+                "type": "radio",
+                "ui": {
+                  "options": [
+                    "Yes",
+                    "No"
+                  ]
+                }
+              },
+              {
+                "id": "food_preparation_location",
+                "label": "Where is food prepared?",
+                "type": "text"
+              },
+              {
+                "id": "dohmh_food_service_permit",
+                "label": "DOHMH Food Service Permit #",
+                "type": "text"
+              },
+              {
+                "id": "person_on_certificate",
+                "label": "Person Name on Certificate",
+                "type": "text"
+              },
+              {
+                "id": "food_protection_cert_number",
+                "label": "Food Protection Certificate #",
+                "type": "text"
+              }
+            ]
+          }
+        ]
+      },
+      {
+        "id": "application_info_2",
+        "title": "Application Specific Information 2"
+      },
+      {
+        "id": "document_upload",
+        "title": "Upload Documents",
+        "description": "REQUIRED DOCUMENTS\nIn order for your application to be processed, based on information provided, you are required to upload the following documents:",
+        "sections": [
+          {
+            "id": "initial_site_survey",
+            "title": "Initial Site Survey Form",
+            "fields": [
+              {
+                "id": "site_survey_file",
+                "label": "Upload Initial Site Survey Form",
+                "type": "file",
+                "required": true,
+                "constraints": {
+                  "maxFileSizeMB": 25,
+                  "allowedTypes": [
+                    "application/pdf",
+                    "image/jpeg",
+                    "image/jpg",
+                    "image/png"
+                  ]
+                },
+                "metadata": {
+                  "proofCategory": "Initial Site Survey",
+                  "multiple": false
+                }
+              }
+            ]
+          },
+          {
+            "id": "personal_id_proof",
+            "title": "Proof of Personal Identification",
+            "fields": [
+              {
+                "id": "personal_id_file",
+                "label": "Upload Proof of Personal Identification",
+                "type": "file",
+                "required": true,
+                "constraints": {
+                  "maxFileSizeMB": 25,
+                  "allowedTypes": [
+                    "application/pdf",
+                    "image/jpeg",
+                    "image/jpg",
+                    "image/png"
+                  ]
+                },
+                "metadata": {
+                  "proofCategory": "Personal ID",
+                  "multiple": false
+                }
+              }
+            ]
+          },
+          {
+            "id": "fee_exemption_proof",
+            "title": "Proof of Fee Exemption",
+            "fields": [
+              {
+                "id": "fee_exemption_file",
+                "label": "Upload Proof of Fee Exemption (ACS Affiliation or Municipal Exemption)",
+                "type": "file",
+                "required": true,
+                "constraints": {
+                  "maxFileSizeMB": 25,
+                  "allowedTypes": [
+                    "application/pdf",
+                    "image/jpeg",
+                    "image/jpg",
+                    "image/png"
+                  ]
+                },
+                "metadata": {
+                  "proofCategory": "Fee Exemption",
+                  "multiple": false
+                }
+              }
+            ]
+          }
+        ]
+      },
+      {
+        "id": "step_6_placeholder",
+        "title": "To be defined"
+      },
+      {
+        "id": "step_7_placeholder",
+        "title": "To be defined"
+      },
+      {
+        "id": "step_8_placeholder",
+        "title": "To be defined"
+      }
+    ]
+  }
+}

--- a/test-form/public/index.html
+++ b/test-form/public/index.html
@@ -1,5 +1,5 @@
 <!DOCTYPE html>
-<html lang="en">
+<html>
   <head>
     <meta charset="utf-8" />
     <link rel="icon" href="%PUBLIC_URL%/favicon.ico" />

--- a/test-form/public/locales/ar/translation.json
+++ b/test-form/public/locales/ar/translation.json
@@ -1,0 +1,18 @@
+{
+  "brand": "ModelCity Services",
+  "dashboard": "Dashboard",
+  "login": "Login",
+  "logout": "Logout",
+  "profile": "Profile",
+  "serviceCatalog": "Service Catalog",
+  "savedApplications": "Saved Applications",
+  "privacyPolicy": "Privacy Policy",
+  "needHelp": "Need Help?",
+  "editProfile": "Edit Profile",
+  "firstName": "First Name",
+  "lastName": "Last Name",
+  "middleInitial": "Middle Initial",
+  "save": "Save",
+  "pleaseLogIn": "Please log in",
+  "language": "Language"
+}

--- a/test-form/public/locales/bn/translation.json
+++ b/test-form/public/locales/bn/translation.json
@@ -1,0 +1,18 @@
+{
+  "brand": "ModelCity Services",
+  "dashboard": "Dashboard",
+  "login": "Login",
+  "logout": "Logout",
+  "profile": "Profile",
+  "serviceCatalog": "Service Catalog",
+  "savedApplications": "Saved Applications",
+  "privacyPolicy": "Privacy Policy",
+  "needHelp": "Need Help?",
+  "editProfile": "Edit Profile",
+  "firstName": "First Name",
+  "lastName": "Last Name",
+  "middleInitial": "Middle Initial",
+  "save": "Save",
+  "pleaseLogIn": "Please log in",
+  "language": "Language"
+}

--- a/test-form/public/locales/en/translation.json
+++ b/test-form/public/locales/en/translation.json
@@ -1,0 +1,18 @@
+{
+  "brand": "ModelCity Services",
+  "dashboard": "Dashboard",
+  "login": "Login",
+  "logout": "Logout",
+  "profile": "Profile",
+  "serviceCatalog": "Service Catalog",
+  "savedApplications": "Saved Applications",
+  "privacyPolicy": "Privacy Policy",
+  "needHelp": "Need Help?",
+  "editProfile": "Edit Profile",
+  "firstName": "First Name",
+  "lastName": "Last Name",
+  "middleInitial": "Middle Initial",
+  "save": "Save",
+  "pleaseLogIn": "Please log in",
+  "language": "Language"
+}

--- a/test-form/public/locales/es/translation.json
+++ b/test-form/public/locales/es/translation.json
@@ -1,0 +1,18 @@
+{
+  "brand": "Servicios ModelCity",
+  "dashboard": "Tablero",
+  "login": "Iniciar sesión",
+  "logout": "Cerrar sesión",
+  "profile": "Perfil",
+  "serviceCatalog": "Catálogo de Servicios",
+  "savedApplications": "Solicitudes Guardadas",
+  "privacyPolicy": "Política de Privacidad",
+  "needHelp": "¿Necesita ayuda?",
+  "editProfile": "Editar Perfil",
+  "firstName": "Nombre",
+  "lastName": "Apellido",
+  "middleInitial": "Inicial del Segundo Nombre",
+  "save": "Guardar",
+  "pleaseLogIn": "Por favor inicie sesión",
+  "language": "Idioma"
+}

--- a/test-form/public/locales/fr/translation.json
+++ b/test-form/public/locales/fr/translation.json
@@ -1,0 +1,18 @@
+{
+  "brand": "ModelCity Services",
+  "dashboard": "Dashboard",
+  "login": "Login",
+  "logout": "Logout",
+  "profile": "Profile",
+  "serviceCatalog": "Service Catalog",
+  "savedApplications": "Saved Applications",
+  "privacyPolicy": "Privacy Policy",
+  "needHelp": "Need Help?",
+  "editProfile": "Edit Profile",
+  "firstName": "First Name",
+  "lastName": "Last Name",
+  "middleInitial": "Middle Initial",
+  "save": "Save",
+  "pleaseLogIn": "Please log in",
+  "language": "Language"
+}

--- a/test-form/public/locales/ht/translation.json
+++ b/test-form/public/locales/ht/translation.json
@@ -1,0 +1,18 @@
+{
+  "brand": "ModelCity Services",
+  "dashboard": "Dashboard",
+  "login": "Login",
+  "logout": "Logout",
+  "profile": "Profile",
+  "serviceCatalog": "Service Catalog",
+  "savedApplications": "Saved Applications",
+  "privacyPolicy": "Privacy Policy",
+  "needHelp": "Need Help?",
+  "editProfile": "Edit Profile",
+  "firstName": "First Name",
+  "lastName": "Last Name",
+  "middleInitial": "Middle Initial",
+  "save": "Save",
+  "pleaseLogIn": "Please log in",
+  "language": "Language"
+}

--- a/test-form/public/locales/ko/translation.json
+++ b/test-form/public/locales/ko/translation.json
@@ -1,0 +1,18 @@
+{
+  "brand": "ModelCity Services",
+  "dashboard": "Dashboard",
+  "login": "Login",
+  "logout": "Logout",
+  "profile": "Profile",
+  "serviceCatalog": "Service Catalog",
+  "savedApplications": "Saved Applications",
+  "privacyPolicy": "Privacy Policy",
+  "needHelp": "Need Help?",
+  "editProfile": "Edit Profile",
+  "firstName": "First Name",
+  "lastName": "Last Name",
+  "middleInitial": "Middle Initial",
+  "save": "Save",
+  "pleaseLogIn": "Please log in",
+  "language": "Language"
+}

--- a/test-form/public/locales/pl/translation.json
+++ b/test-form/public/locales/pl/translation.json
@@ -1,0 +1,18 @@
+{
+  "brand": "ModelCity Services",
+  "dashboard": "Dashboard",
+  "login": "Login",
+  "logout": "Logout",
+  "profile": "Profile",
+  "serviceCatalog": "Service Catalog",
+  "savedApplications": "Saved Applications",
+  "privacyPolicy": "Privacy Policy",
+  "needHelp": "Need Help?",
+  "editProfile": "Edit Profile",
+  "firstName": "First Name",
+  "lastName": "Last Name",
+  "middleInitial": "Middle Initial",
+  "save": "Save",
+  "pleaseLogIn": "Please log in",
+  "language": "Language"
+}

--- a/test-form/public/locales/ru/translation.json
+++ b/test-form/public/locales/ru/translation.json
@@ -1,0 +1,18 @@
+{
+  "brand": "ModelCity Services",
+  "dashboard": "Dashboard",
+  "login": "Login",
+  "logout": "Logout",
+  "profile": "Profile",
+  "serviceCatalog": "Service Catalog",
+  "savedApplications": "Saved Applications",
+  "privacyPolicy": "Privacy Policy",
+  "needHelp": "Need Help?",
+  "editProfile": "Edit Profile",
+  "firstName": "First Name",
+  "lastName": "Last Name",
+  "middleInitial": "Middle Initial",
+  "save": "Save",
+  "pleaseLogIn": "Please log in",
+  "language": "Language"
+}

--- a/test-form/public/locales/ur/translation.json
+++ b/test-form/public/locales/ur/translation.json
@@ -1,0 +1,18 @@
+{
+  "brand": "ModelCity Services",
+  "dashboard": "Dashboard",
+  "login": "Login",
+  "logout": "Logout",
+  "profile": "Profile",
+  "serviceCatalog": "Service Catalog",
+  "savedApplications": "Saved Applications",
+  "privacyPolicy": "Privacy Policy",
+  "needHelp": "Need Help?",
+  "editProfile": "Edit Profile",
+  "firstName": "First Name",
+  "lastName": "Last Name",
+  "middleInitial": "Middle Initial",
+  "save": "Save",
+  "pleaseLogIn": "Please log in",
+  "language": "Language"
+}

--- a/test-form/public/locales/zh/translation.json
+++ b/test-form/public/locales/zh/translation.json
@@ -1,0 +1,18 @@
+{
+  "brand": "ModelCity Services",
+  "dashboard": "Dashboard",
+  "login": "Login",
+  "logout": "Logout",
+  "profile": "Profile",
+  "serviceCatalog": "Service Catalog",
+  "savedApplications": "Saved Applications",
+  "privacyPolicy": "Privacy Policy",
+  "needHelp": "Need Help?",
+  "editProfile": "Edit Profile",
+  "firstName": "First Name",
+  "lastName": "Last Name",
+  "middleInitial": "Middle Initial",
+  "save": "Save",
+  "pleaseLogIn": "Please log in",
+  "language": "Language"
+}

--- a/test-form/server/translate_forms.js
+++ b/test-form/server/translate_forms.js
@@ -1,0 +1,60 @@
+const fs = require('fs');
+const path = require('path');
+const fetch = require('node-fetch');
+
+const API_KEY = process.env.GOOGLE_API_KEY;
+if (!API_KEY) {
+  console.error('GOOGLE_API_KEY not set');
+  process.exit(1);
+}
+
+const languages = ['ar','bn','zh','fr','ht','ko','pl','ru','es','ur'];
+const dataDir = path.join(__dirname, '..', 'public', 'data');
+
+async function translateText(text, target) {
+  const url = `https://translation.googleapis.com/language/translate/v2?key=${API_KEY}`;
+  const res = await fetch(url, {
+    method: 'POST',
+    headers: { 'Content-Type': 'application/json' },
+    body: JSON.stringify({ q: text, target, format: 'text' })
+  });
+  if (!res.ok) throw new Error(`Translate failed: ${res.status}`);
+  const json = await res.json();
+  return json.data.translations[0].translatedText;
+}
+
+async function translateFile(file) {
+  const json = JSON.parse(fs.readFileSync(path.join(dataDir, file), 'utf8'));
+  for (const lang of languages) {
+    const copy = JSON.parse(JSON.stringify(json));
+    const keys = [];
+    const vals = [];
+    const walk = (obj) => {
+      for (const k of Object.keys(obj)) {
+        const v = obj[k];
+        if (typeof v === 'string') {
+          keys.push([obj, k]);
+          vals.push(v);
+        } else if (typeof v === 'object' && v) {
+          walk(v);
+        }
+      }
+    };
+    walk(copy);
+    const translated = await Promise.all(vals.map((v) => translateText(v, lang)));
+    translated.forEach((t, i) => {
+      const [o, k] = keys[i];
+      o[k] = t;
+    });
+    const out = path.join(dataDir, file.replace('.json', `.${lang}.json`));
+    fs.writeFileSync(out, JSON.stringify(copy, null, 2));
+    console.log('Wrote', out);
+  }
+}
+
+(async () => {
+  const files = fs.readdirSync(dataDir).filter(f => f.endsWith('.json') && !f.match(/\.[a-z]{2}\.json$/));
+  for (const f of files) {
+    await translateFile(f);
+  }
+})();

--- a/test-form/src/App.js
+++ b/test-form/src/App.js
@@ -1,6 +1,8 @@
 import { useState, useContext, useEffect } from "react";
 import { Link, Routes, Route } from 'react-router-dom';
 import { AuthContext } from './context/AuthContext';
+import LanguageSelect from './components/shared/LanguageSelect/LanguageSelect';
+import { useTranslation } from 'react-i18next';
 import Profile from './pages/Profile';
 // import "./form.css"; // Old theme - commented out
 import FormPage from "./pages/FormPage";
@@ -28,6 +30,7 @@ function App() {
   const [currentService, setCurrentService] = useState('childcare');
   const [theme, setTheme] = useState('system');
   const { user } = useContext(AuthContext);
+  const { t } = useTranslation();
   const server = process.env.REACT_APP_SERVER_URL || '';
 
   useEffect(() => {
@@ -88,18 +91,15 @@ function App() {
           >
             ☰
           </button>
-          <div className="brand">ModelCity Services</div>
+          <div className="brand">{t('brand')}</div>
         </div>
 
         <nav className={`right ${menuOpen ? "open" : ""}`}>
-          <Link
-            to="/"
-            onClick={() => setPage('dashboard')}
-          >
-            Dashboard
+          <Link to="/" onClick={() => setPage('dashboard')}>
+            {t('dashboard')}
           </Link>
           {!user && (
-            <a href={`${server}/auth/login`}>Login</a>
+            <a href={`${server}/auth/login`}>{t('login')}</a>
           )}
           {user && (
             <div className="user-menu">
@@ -115,12 +115,15 @@ function App() {
               </button>
               {userMenuOpen && (
                 <div className="dropdown" role="menu">
-                  <Link to="/profile" onClick={() => setUserMenuOpen(false)}>Profile</Link>
-                  <a href={`${server}/auth/logout`}>Logout</a>
+                  <Link to="/profile" onClick={() => setUserMenuOpen(false)}>
+                    {t('profile')}
+                  </Link>
+                  <a href={`${server}/auth/logout`}>{t('logout')}</a>
                 </div>
               )}
             </div>
           )}
+          <LanguageSelect />
           <ThemeToggle theme={theme} onToggle={toggleTheme} />
         </nav>
       </header>
@@ -148,7 +151,7 @@ function App() {
 
       <footer className="form-footer">
         <span>© 2025 City of Service</span>
-        <a href="#privacy">Privacy Policy</a>
+        <a href="#privacy">{t('privacyPolicy')}</a>
       </footer>
     </div>
   );

--- a/test-form/src/components/core/FormRenderer/FormRenderer.jsx
+++ b/test-form/src/components/core/FormRenderer/FormRenderer.jsx
@@ -10,6 +10,7 @@ import { getApplication, upsertApplication } from '../../../utils/appStorage';
 import Button from '../../shared/Button/Button';
 import HelpChat from '../../shared/HelpChat';
 import useMediaQuery from '../../../utils/useMediaQuery';
+import { useTranslation } from 'react-i18next';
 
 /**
  * Renders a multi-step form specified in a JSON file.
@@ -25,6 +26,7 @@ export default function FormRenderer({
   formSpecPath = '/data/childcare_form.json',
 }) {
   const { showToast } = useToast();
+  const { t } = useTranslation();
   const [formSpec, setFormSpec] = useState(null);
   const [isLoading, setIsLoading] = useState(true);
   const [error, setError] = useState(null);
@@ -314,7 +316,7 @@ export default function FormRenderer({
             size="small"
             onClick={() => setChatOpen(true)}
           >
-            Need Help?
+            {t('needHelp')}
           </Button>
         </div>
         {errorSummary.length > 0 && (

--- a/test-form/src/components/shared/LanguageSelect/LanguageSelect.jsx
+++ b/test-form/src/components/shared/LanguageSelect/LanguageSelect.jsx
@@ -1,0 +1,31 @@
+import { useLanguage } from '../../../context/LanguageContext';
+import { useTranslation } from 'react-i18next';
+
+const languages = [
+  { code: 'en', label: 'English' },
+  { code: 'ar', label: '\u0627\u0644\u0639\u0631\u0628\u064a\u0629' },
+  { code: 'bn', label: '\u09ac\u09be\u0982\u09b2\u09be' },
+  { code: 'zh', label: '\u7b80\u4f53\u4e2d\u6587' },
+  { code: 'fr', label: 'Français' },
+  { code: 'ht', label: 'Krey\u00f2l Ayisyen' },
+  { code: 'ko', label: '\ud55c\uad6d\uc5b4' },
+  { code: 'pl', label: 'Polski' },
+  { code: 'ru', label: '\u0420\u0443\u0441\u0441\u043a\u0438\u0439' },
+  { code: 'es', label: 'Español' },
+  { code: 'ur', label: '\u0627\u0631\u062f\u0648' },
+];
+
+export default function LanguageSelect() {
+  const { language, setLanguage } = useLanguage();
+  const { t } = useTranslation();
+
+  return (
+    <select value={language} onChange={(e) => setLanguage(e.target.value)} aria-label={t('language')}>
+      {languages.map((lang) => (
+        <option key={lang.code} value={lang.code}>
+          {lang.label}
+        </option>
+      ))}
+    </select>
+  );
+}

--- a/test-form/src/context/LanguageContext.jsx
+++ b/test-form/src/context/LanguageContext.jsx
@@ -1,0 +1,30 @@
+import { createContext, useContext, useState, useEffect } from 'react';
+import i18n from '../i18n';
+
+const LanguageContext = createContext({ language: 'en', setLanguage: () => {} });
+
+export function LanguageProvider({ children }) {
+  const [language, setLanguage] = useState('en');
+
+  useEffect(() => {
+    const saved = localStorage.getItem('language');
+    if (saved) {
+      setLanguage(saved);
+      i18n.changeLanguage(saved);
+    }
+  }, []);
+
+  const update = (lng) => {
+    setLanguage(lng);
+    localStorage.setItem('language', lng);
+    i18n.changeLanguage(lng);
+  };
+
+  return (
+    <LanguageContext.Provider value={{ language, setLanguage: update }}>
+      {children}
+    </LanguageContext.Provider>
+  );
+}
+
+export const useLanguage = () => useContext(LanguageContext);

--- a/test-form/src/i18n.js
+++ b/test-form/src/i18n.js
@@ -1,0 +1,20 @@
+import i18n from 'i18next';
+import { initReactI18next } from 'react-i18next';
+import HttpBackend from 'i18next-http-backend';
+
+const supported = ['en','ar','bn','zh','fr','ht','ko','pl','ru','es','ur'];
+
+i18n
+  .use(HttpBackend)
+  .use(initReactI18next)
+  .init({
+    lng: localStorage.getItem('language') || 'en',
+    fallbackLng: 'en',
+    supportedLngs: supported,
+    interpolation: { escapeValue: false },
+    backend: {
+      loadPath: '/locales/{{lng}}/translation.json',
+    },
+  });
+
+export default i18n;

--- a/test-form/src/index.js
+++ b/test-form/src/index.js
@@ -8,18 +8,32 @@ import { config } from '@fortawesome/fontawesome-svg-core';
 import '@fortawesome/fontawesome-svg-core/styles.css';
 import { AuthProvider } from './context/AuthContext';
 import { ToastProvider } from './context/ToastContext';
+import { LanguageProvider, useLanguage } from './context/LanguageContext';
+import './i18n';
 
 config.autoAddCss = false;
 
 const root = ReactDOM.createRoot(document.getElementById('root'));
+
+function SetHtmlLang() {
+  const { language } = useLanguage();
+  React.useEffect(() => {
+    document.documentElement.lang = language;
+  }, [language]);
+  return null;
+}
+
 root.render(
   <React.StrictMode>
     <BrowserRouter>
-      <AuthProvider>
-        <ToastProvider>
-          <App />
-        </ToastProvider>
-      </AuthProvider>
+      <LanguageProvider>
+        <AuthProvider>
+          <ToastProvider>
+            <SetHtmlLang />
+            <App />
+          </ToastProvider>
+        </AuthProvider>
+      </LanguageProvider>
     </BrowserRouter>
   </React.StrictMode>
 );

--- a/test-form/src/pages/Dashboard.jsx
+++ b/test-form/src/pages/Dashboard.jsx
@@ -3,6 +3,7 @@ import { loadApplications, upsertApplication, deleteApplication } from '../utils
 import { AuthContext } from '../context/AuthContext';
 import ServiceCard from '../components/ServiceCard';
 import ApplicationCard from '../components/ApplicationCard';
+import { useTranslation } from 'react-i18next';
 
 const SERVICE_INFO = {
   childcare: {
@@ -22,6 +23,7 @@ const SERVICE_INFO = {
 export default function Dashboard({ onStart }) {
   const { user } = useContext(AuthContext);
   const [apps, setApps] = useState([]);
+  const { t } = useTranslation();
 
   useEffect(() => {
     if (user) {
@@ -61,7 +63,7 @@ export default function Dashboard({ onStart }) {
     // For now, let's use a more specific class that can be styled.
     <div className="jules-dashboard-page">
       {/* h1 will be styled by jules_base.css */}
-      <h1>Service Catalog</h1>
+      <h1>{t('serviceCatalog')}</h1>
       {/* A generic grid class, could be styled with CSS Grid or Flexbox in jules_layout.css or jules_misc.css */}
       <div className="jules-grid-container jules-service-catalog-grid">
         <ServiceCard
@@ -87,7 +89,7 @@ export default function Dashboard({ onStart }) {
       {user && apps.length > 0 && (
         <div className="jules-draft-list">
           {/* h2 will be styled by jules_base.css */}
-          <h2>Saved Applications</h2>
+          <h2>{t('savedApplications')}</h2>
           <div className="jules-grid-container jules-saved-applications-grid">
             {apps.map((app) => {
               const key = app.serviceKey || app.service_key || 'childcare';

--- a/test-form/src/pages/FormPage.jsx
+++ b/test-form/src/pages/FormPage.jsx
@@ -1,12 +1,14 @@
 import React from 'react';
 import FormRenderer from '../components/core/FormRenderer/FormRenderer';
+import { useLanguage } from '../context/LanguageContext';
 
 export default function FormPage({ applicationId, service = 'childcare', onExit }) {
-  let path = '/data/childcare_form.json';
+  const { language } = useLanguage();
+  let path = `/data/childcare_form.${language}.json`;
   if (service === 'dycd') {
-    path = '/data/dycd_form.json';
+    path = `/data/dycd_form.${language}.json`;
   } else if (service === 'DOHMH') {
-    path = '/data/group_cc_permit.json';
+    path = `/data/group_cc_permit.${language}.json`;
   }
   return (
     <FormRenderer

--- a/test-form/src/pages/Profile.jsx
+++ b/test-form/src/pages/Profile.jsx
@@ -3,11 +3,13 @@ import { AuthContext } from '../context/AuthContext';
 import TextInput from '../components/shared/TextInput/TextInput';
 import Button from '../components/shared/Button';
 import { getCsrfToken } from '../utils/csrf';
+import { useTranslation } from 'react-i18next';
 
 export default function Profile() {
   const { user, setUser } = useContext(AuthContext);
   const [form, setForm] = useState({ first_name: '', middle_initial: '', last_name: '' });
   const [status, setStatus] = useState('');
+  const { t } = useTranslation();
 
   useEffect(() => {
     if (user) {
@@ -43,15 +45,15 @@ export default function Profile() {
     }
   };
 
-  if (!user) return <p>Please log in</p>;
+  if (!user) return <p>{t('pleaseLogIn')}</p>;
 
   return (
     <form className="jules-profile-form" onSubmit={handleSubmit} aria-labelledby="profile-heading">
-      <h1 id="profile-heading">Edit Profile</h1>
+      <h1 id="profile-heading">{t('editProfile')}</h1>
       <TextInput
         id="first_name"
         name="first_name"
-        label="First Name"
+        label={t('firstName')}
         value={form.first_name}
         onChange={handleChange}
         required
@@ -59,19 +61,19 @@ export default function Profile() {
       <TextInput
         id="middle_initial"
         name="middle_initial"
-        label="Middle Initial"
+        label={t('middleInitial')}
         value={form.middle_initial}
         onChange={handleChange}
       />
       <TextInput
         id="last_name"
         name="last_name"
-        label="Last Name"
+        label={t('lastName')}
         value={form.last_name}
         onChange={handleChange}
         required
       />
-      <Button type="submit" variant="primary">Save</Button>
+      <Button type="submit" variant="primary">{t('save')}</Button>
       {status && <span role="status">{status}</span>}
     </form>
   );


### PR DESCRIPTION
## Summary
- add i18next and configure language context
- create language selector dropdown in the header
- load locale files and set `<html lang>` dynamically
- allow loading language-specific form JSON files
- include translation placeholders and Google Translate script

## Testing
- `npm install`
- `CI=true npm test --silent` *(fails: React-i18next instance warnings and other errors)*

------
https://chatgpt.com/codex/tasks/task_e_686d961487f0833185a1e1c5cd79aebc