### PR TITLE
Update language selector styling

### DIFF
--- a/test-form/src/components/shared/LanguageSelect/LanguageSelect.jsx
+++ b/test-form/src/components/shared/LanguageSelect/LanguageSelect.jsx
@@ -20,12 +20,21 @@ export default function LanguageSelect() {
   const { t } = useTranslation();
 
   return (
-    <select value={language} onChange={(e) => setLanguage(e.target.value)} aria-label={t('language')}>
-      {languages.map((lang) => (
-        <option key={lang.code} value={lang.code}>
-          {lang.label}
-        </option>
-      ))}
-    </select>
+    <div className="jules-form-field">
+      <div className="jules-input-wrapper jules-select-wrapper">
+        <select
+          className="jules-input"
+          value={language}
+          onChange={(e) => setLanguage(e.target.value)}
+          aria-label={t('language')}
+        >
+          {languages.map((lang) => (
+            <option key={lang.code} value={lang.code}>
+              {lang.label}
+            </option>
+          ))}
+        </select>
+      </div>
+    </div>
   );
 }


### PR DESCRIPTION
## Summary
- style language selection dropdown according to design system

## Testing
- `npm test -- -w 0` *(fails: unable to find accessible elements)*
- `npm run lint` *(fails: 10 errors, 2 warnings)*

------
https://chatgpt.com/codex/tasks/task_e_686da371220483319a312ec528cf1f8e