### PR TITLE
Fix language dropdown size and spacing

### DIFF
--- a/test-form/src/components/shared/LanguageSelect/LanguageSelect.jsx
+++ b/test-form/src/components/shared/LanguageSelect/LanguageSelect.jsx
@@ -20,7 +20,7 @@ export default function LanguageSelect() {
   const { t } = useTranslation();
 
   return (
-    <div className="jules-form-field">
+    <div className="jules-form-field language-select">
       <div className="jules-input-wrapper jules-select-wrapper">
         <select
           className="jules-input"

--- a/test-form/src/jules_layout.css
+++ b/test-form/src/jules_layout.css
@@ -68,6 +68,15 @@
   color: var(--jules-text-color-link-hover);
 }
 
+.form-header .language-select {
+  margin-left: var(--jules-space-lg);
+}
+
+.form-header .language-select select {
+  font-size: var(--jules-font-size-base);
+  width: auto;
+}
+
 .theme-toggle:focus-visible {
   outline: var(--jules-focus-ring-width) solid var(--jules-focus-ring-color);
   outline-offset: var(--jules-focus-ring-offset);


### PR DESCRIPTION
## Summary
- mark LanguageSelect wrapper with `language-select` class
- style header language dropdown so it's the same size as other menu items

## Testing
- `npm test --silent` *(fails: react-scripts not found)*

------
https://chatgpt.com/codex/tasks/task_e_686dbd7453888331841e540df1db5cdb