### PR TITLE
Load language-specific form JSON

### DIFF
--- a/test-form/src/pages/FormPage.jsx
+++ b/test-form/src/pages/FormPage.jsx
@@ -1,11 +1,13 @@
 import React from 'react';
 import FormRenderer from '../components/core/FormRenderer/FormRenderer';
+import { useLanguage } from '../context/LanguageContext';
 export default function FormPage({ applicationId, service = 'childcare', onExit }) {
-  let path = '/data/childcare_form.en.json';
+  const { language } = useLanguage();
+  let path = `/data/childcare_form.${language}.json`;
   if (service === 'dycd') {
-    path = '/data/dycd_form.en.json';
+    path = `/data/dycd_form.${language}.json`;
   } else if (service === 'DOHMH') {
-    path = '/data/group_cc_permit.en.json';
+    path = `/data/group_cc_permit.${language}.json`;
   }
   return (
     <FormRenderer

--- a/test-form/src/pages/FormPage.test.jsx
+++ b/test-form/src/pages/FormPage.test.jsx
@@ -12,7 +12,7 @@ beforeEach(() => {
 test('uses FormRenderer for dycd service', () => {
   render(<FormPage service="dycd" />);
   expect(FormRenderer).toHaveBeenCalledWith(
-    expect.objectContaining({ formSpecPath: '/data/dycd_form.json' }),
+    expect.objectContaining({ formSpecPath: '/data/dycd_form.en.json' }),
     undefined,
   );
 });
@@ -20,7 +20,7 @@ test('uses FormRenderer for dycd service', () => {
 test('uses FormRenderer for childcare service', () => {
   render(<FormPage service="childcare" />);
   expect(FormRenderer).toHaveBeenCalledWith(
-    expect.objectContaining({ formSpecPath: '/data/childcare_form.json' }),
+    expect.objectContaining({ formSpecPath: '/data/childcare_form.en.json' }),
     undefined,
   );
 });
@@ -28,7 +28,7 @@ test('uses FormRenderer for childcare service', () => {
 test('uses FormRenderer for DOHMH service', () => {
   render(<FormPage service="DOHMH" />);
   expect(FormRenderer).toHaveBeenCalledWith(
-    expect.objectContaining({ formSpecPath: '/data/group_cc_permit.json' }),
+    expect.objectContaining({ formSpecPath: '/data/group_cc_permit.en.json' }),
     undefined,
   );
 });


### PR DESCRIPTION
## Summary
- read language from context in FormPage and compute the form JSON path using it
- adjust tests to expect language-specific JSON files

## Testing
- `CI=true npm test -- src/pages/FormPage.test.jsx --watchAll=false`

------
https://chatgpt.com/codex/tasks/task_e_686dcf1965448331afab0492b2a4c1ef