### PR TITLE
Fix localized form data mapping

### DIFF
--- a/test-form/src/components/core/FormRenderer/FormRenderer.jsx
+++ b/test-form/src/components/core/FormRenderer/FormRenderer.jsx
@@ -24,10 +24,11 @@ export default function FormRenderer({
   applicationId,
   onExit,
   formSpecPath = '/data/childcare_form.json',
+  formSpec: providedSpec,
 }) {
   const { showToast } = useToast();
   const { t } = useTranslation();
-  const [formSpec, setFormSpec] = useState(null);
+  const [formSpec, setFormSpec] = useState(providedSpec || null);
   const [isLoading, setIsLoading] = useState(true);
   const [error, setError] = useState(null);
 
@@ -54,11 +55,16 @@ export default function FormRenderer({
   const [chatOpen, setChatOpen] = useState(false);
 
   useEffect(() => {
+    if (providedSpec) {
+      setIsLoading(false);
+      setFormSpec(providedSpec);
+      return;
+    }
+
     const fetchFormSpec = async () => {
       setIsLoading(true);
       setError(null);
       try {
-        // Load form specification from the provided path
         const response = await fetch(formSpecPath);
 
         if (!response.ok) {
@@ -77,7 +83,7 @@ export default function FormRenderer({
     };
 
     fetchFormSpec();
-  }, [formSpecPath]);
+  }, [formSpecPath, providedSpec]);
 
   useEffect(() => {
     if (formSpec) {

--- a/test-form/src/pages/FormPage.jsx
+++ b/test-form/src/pages/FormPage.jsx
@@ -1,19 +1,22 @@
-import React from 'react';
+import React, { useEffect, useState } from 'react';
 import FormRenderer from '../components/core/FormRenderer/FormRenderer';
 import { useLanguage } from '../context/LanguageContext';
+import loadMergedFormSpec from '../utils/loadFormSpec';
 export default function FormPage({ applicationId, service = 'childcare', onExit }) {
   const { language } = useLanguage();
-  let path = `/data/childcare_form.${language}.json`;
-  if (service === 'dycd') {
-    path = `/data/dycd_form.${language}.json`;
-  } else if (service === 'DOHMH') {
-    path = `/data/group_cc_permit.${language}.json`;
-  }
+  const [spec, setSpec] = useState(null);
+
+  useEffect(() => {
+    loadMergedFormSpec(service === 'DOHMH' ? 'group_cc_permit' : service, language)
+      .then(setSpec)
+      .catch((e) => {
+        console.error('Failed to load form spec', e);
+      });
+  }, [service, language]);
+
+  if (!spec) return <div>Loading form definition...</div>;
+
   return (
-    <FormRenderer
-      applicationId={applicationId}
-      onExit={onExit}
-      formSpecPath={path}
-    />
+    <FormRenderer applicationId={applicationId} onExit={onExit} formSpec={spec} />
   );
 }

--- a/test-form/src/utils/loadFormSpec.js
+++ b/test-form/src/utils/loadFormSpec.js
@@ -1,0 +1,96 @@
+export async function loadMergedFormSpec(service, language) {
+  const basePath = `/data/${service}_form.json`;
+  const localizedPath = `/data/${service}_form.${language}.json`;
+
+  const baseResp = await fetch(basePath);
+  if (!baseResp.ok) {
+    throw new Error(`Failed to load base form spec: ${baseResp.status}`);
+  }
+  const baseSpec = await baseResp.json();
+
+  if (!language || language === 'en') {
+    return baseSpec;
+  }
+
+  try {
+    const locResp = await fetch(localizedPath);
+    if (!locResp.ok) {
+      return baseSpec;
+    }
+    const locSpec = await locResp.json();
+    return mergeFormSpecs(baseSpec, locSpec);
+  } catch (e) {
+    console.error('Failed loading localized spec', e);
+    return baseSpec;
+  }
+}
+
+function mergeFormSpecs(baseSpec, locSpec) {
+  if (!locSpec || !locSpec.form) return baseSpec;
+  const merged = { ...baseSpec };
+  merged.form = mergeForm(baseSpec.form, locSpec.form);
+  return merged;
+}
+
+function mergeForm(baseForm, locForm) {
+  const merged = { ...baseForm };
+  if (locForm.title) merged.title = locForm.title;
+  if (locForm.description) merged.description = locForm.description;
+  if (Array.isArray(baseForm.steps)) {
+    merged.steps = baseForm.steps.map((step, idx) =>
+      mergeStep(step, locForm.steps ? locForm.steps[idx] : undefined),
+    );
+  }
+  return merged;
+}
+
+function mergeStep(baseStep, locStep = {}) {
+  const merged = { ...baseStep };
+  if (locStep.title) merged.title = locStep.title;
+  if (locStep.description) merged.description = locStep.description;
+  if (Array.isArray(baseStep.sections)) {
+    merged.sections = baseStep.sections.map((sec, idx) =>
+      mergeSection(sec, locStep.sections ? locStep.sections[idx] : undefined),
+    );
+  }
+  return merged;
+}
+
+function mergeSection(baseSec, locSec = {}) {
+  const merged = { ...baseSec };
+  if (locSec.title) merged.title = locSec.title;
+  if (locSec.description) merged.description = locSec.description;
+  if (Array.isArray(baseSec.fields)) {
+    merged.fields = baseSec.fields.map((f, idx) =>
+      mergeField(f, locSec.fields ? locSec.fields[idx] : undefined),
+    );
+  }
+  return merged;
+}
+
+function mergeField(baseField, locField = {}) {
+  const merged = { ...baseField };
+  if (locField.label) merged.label = locField.label;
+  if (locField.tooltip) merged.tooltip = locField.tooltip;
+  if (locField.options) merged.options = locField.options;
+  if (locField.ui) {
+    merged.ui = { ...baseField.ui, ...filterUi(locField.ui) };
+  }
+  if (baseField.type === 'group' && Array.isArray(baseField.fields)) {
+    merged.fields = baseField.fields.map((sf, idx) =>
+      mergeField(sf, locField.fields ? locField.fields[idx] : undefined),
+    );
+  }
+  return merged;
+}
+
+function filterUi(ui) {
+  const allowed = ['placeholder', 'title'];
+  const out = {};
+  allowed.forEach((k) => {
+    if (ui && ui[k] !== undefined) out[k] = ui[k];
+  });
+  return out;
+}
+
+export default loadMergedFormSpec;


### PR DESCRIPTION
## Summary
- load localized form spec using base english structure
- merge translated labels into base form structure
- update FormRenderer to accept form objects
- load merged spec in FormPage

## Testing
- `npm test --silent` *(fails: Cannot read properties of undefined (reading 'addEventListener'))*

------
https://chatgpt.com/codex/tasks/task_e_686dd3ff3f908331b1f3b1f58045b96f