### PR TITLE
Fix translation of dropdown and radio options

### DIFF
--- a/test-form/src/utils/loadFormSpec.js
+++ b/test-form/src/utils/loadFormSpec.js
@@ -85,7 +85,7 @@ function mergeField(baseField, locField = {}) {
 }
 
 function filterUi(ui) {
-  const allowed = ['placeholder', 'title'];
+  const allowed = ['placeholder', 'title', 'options'];
   const out = {};
   allowed.forEach((k) => {
     if (ui && ui[k] !== undefined) out[k] = ui[k];


### PR DESCRIPTION
## Summary
- merge localized UI options from translated form specs

## Testing
- `npm install` *(fails: `sh: 1: react-scripts: not found`)*
- `CI=true npm test -- --runInBand` *(fails: tests report missing addEventListener, etc.)*

------
https://chatgpt.com/codex/tasks/task_e_686ddcc622ec8331869e2b6a5c699d3d