### PR TITLE
Fix translated radio options causing hidden fields

### DIFF
--- a/test-form/src/utils/loadFormSpec.js
+++ b/test-form/src/utils/loadFormSpec.js
@@ -68,13 +68,45 @@ function mergeSection(baseSec, locSec = {}) {
   return merged;
 }
 
+function mergeOptions(baseOpts = [], locOpts = []) {
+  if (!Array.isArray(baseOpts)) return locOpts;
+  if (!Array.isArray(locOpts)) return baseOpts;
+
+  return baseOpts.map((opt, idx) => {
+    const baseValue = typeof opt === 'string' ? opt : opt.value;
+    const baseLabel = typeof opt === 'string' ? opt : opt.label;
+    const loc = locOpts[idx];
+
+    let label = baseLabel;
+    if (typeof loc === 'string') {
+      label = loc;
+    } else if (loc && typeof loc === 'object') {
+      label = loc.label || loc.value || baseLabel;
+    }
+
+    if (typeof opt === 'string') {
+      return { value: baseValue, label };
+    }
+
+    return { ...opt, value: baseValue, label };
+  });
+}
+
 function mergeField(baseField, locField = {}) {
   const merged = { ...baseField };
   if (locField.label) merged.label = locField.label;
   if (locField.tooltip) merged.tooltip = locField.tooltip;
-  if (locField.options) merged.options = locField.options;
+
+  if (locField.options) {
+    merged.options = mergeOptions(baseField.options, locField.options);
+  }
+
   if (locField.ui) {
-    merged.ui = { ...baseField.ui, ...filterUi(locField.ui) };
+    const filtered = filterUi(locField.ui);
+    if (filtered.options) {
+      filtered.options = mergeOptions(baseField.ui?.options, filtered.options);
+    }
+    merged.ui = { ...baseField.ui, ...filtered };
   }
   if (baseField.type === 'group' && Array.isArray(baseField.fields)) {
     merged.fields = baseField.fields.map((sf, idx) =>

--- a/test-form/src/utils/loadFormSpec.test.js
+++ b/test-form/src/utils/loadFormSpec.test.js
@@ -1,0 +1,56 @@
+import loadMergedFormSpec from './loadFormSpec';
+
+describe('loadMergedFormSpec option merging', () => {
+  const base = {
+    form: {
+      steps: [
+        {
+          sections: [
+            {
+              fields: [
+                { id: 'radio', type: 'radio', ui: { options: ['Yes', 'No'] } },
+              ],
+            },
+          ],
+        },
+      ],
+    },
+  };
+  const loc = {
+    form: {
+      steps: [
+        {
+          sections: [
+            {
+              fields: [
+                { ui: { options: ['Sí', 'No'] } },
+              ],
+            },
+          ],
+        },
+      ],
+    },
+  };
+
+  beforeEach(() => {
+    global.fetch = jest.fn((url) => {
+      if (url === '/data/childcare_form.json') {
+        return Promise.resolve({ ok: true, json: () => Promise.resolve(base) });
+      }
+      if (url === '/data/childcare_form.es.json') {
+        return Promise.resolve({ ok: true, json: () => Promise.resolve(loc) });
+      }
+      return Promise.reject(new Error(`Unexpected url ${url}`));
+    });
+  });
+
+  test('preserves option values while applying translations', async () => {
+    const merged = await loadMergedFormSpec('childcare', 'es');
+    const opts =
+      merged.form.steps[0].sections[0].fields[0].ui.options;
+    expect(opts).toEqual([
+      { value: 'Yes', label: 'Sí' },
+      { value: 'No', label: 'No' },
+    ]);
+  });
+});


### PR DESCRIPTION
## Summary
- ensure merging translations preserves option values
- add unit test for merging form specs

## Testing
- `npm test --silent` *(fails: React Router warnings and useMediaQuery window.matchMedia errors)*

------
https://chatgpt.com/codex/tasks/task_e_686ddeff9a3883319019037bd60c4388