### PR TITLE
Fix DOHMH form spec path

### DIFF
--- a/test-form/src/utils/loadFormSpec.js
+++ b/test-form/src/utils/loadFormSpec.js
@@ -1,6 +1,13 @@
+const FORM_PREFIX = {
+  childcare: 'childcare_form',
+  dycd: 'dycd_form',
+  group_cc_permit: 'group_cc_permit',
+};
+
 export async function loadMergedFormSpec(service, language) {
-  const basePath = `/data/${service}_form.json`;
-  const localizedPath = `/data/${service}_form.${language}.json`;
+  const prefix = FORM_PREFIX[service] || `${service}_form`;
+  const basePath = `/data/${prefix}.json`;
+  const localizedPath = `/data/${prefix}.${language}.json`;
 
   const baseResp = await fetch(basePath);
   if (!baseResp.ok) {

--- a/test-form/src/utils/loadFormSpec.test.js
+++ b/test-form/src/utils/loadFormSpec.test.js
@@ -54,3 +54,19 @@ describe('loadMergedFormSpec option merging', () => {
     ]);
   });
 });
+
+describe('loadMergedFormSpec path resolution', () => {
+  test('uses no _form suffix for group_cc_permit service', async () => {
+    const base = { form: {} };
+    global.fetch = jest.fn((url) => {
+      if (url === '/data/group_cc_permit.json') {
+        return Promise.resolve({ ok: true, json: () => Promise.resolve(base) });
+      }
+      return Promise.reject(new Error(`Unexpected url ${url}`));
+    });
+
+    await loadMergedFormSpec('group_cc_permit', 'en');
+
+    expect(global.fetch).toHaveBeenCalledWith('/data/group_cc_permit.json');
+  });
+});


### PR DESCRIPTION
## Summary
- handle service specific form spec prefixes
- add regression test for `group_cc_permit` path

## Testing
- `npm test --silent -- -t loadMergedFormSpec` *(fails: react-scripts not found)*

------
https://chatgpt.com/codex/tasks/task_e_686e4a7930308331918d1304baef1041