### PR TITLE
Preserve cross-step data when cleaning hidden fields

### DIFF
--- a/test-form/src/__tests__/FamilyMembersPersistence.test.jsx
+++ b/test-form/src/__tests__/FamilyMembersPersistence.test.jsx
@@ -1,0 +1,122 @@
+import { render, screen } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import FormRenderer from '../components/core/FormRenderer/FormRenderer';
+
+// Mock markdown rendering used in Step components
+jest.mock('react-markdown', () => ({ children }) => <div>{children}</div>);
+jest.mock('remark-gfm', () => ({}));
+jest.mock('../utils/useMediaQuery', () => () => false);
+
+window.matchMedia = jest.fn().mockImplementation((query) => ({
+  matches: false,
+  media: query,
+  onchange: null,
+  addListener: jest.fn(),
+  removeListener: jest.fn(),
+  addEventListener: jest.fn(),
+  removeEventListener: jest.fn(),
+  dispatchEvent: jest.fn(),
+}));
+
+const formSpec = {
+  form: {
+    steps: [
+      {
+        id: 'children_needing_care',
+        title: 'Children',
+        sections: [
+          {
+            id: 'child_details',
+            title: 'Child Details',
+            required: true,
+            fields: [
+              {
+                id: 'children',
+                label: 'Children',
+                type: 'group',
+                metadata: {
+                  multiple: true,
+                  tableColumns: ['do_both_parents_reside_in_home'],
+                },
+                fields: [
+                  {
+                    id: 'do_both_parents_reside_in_home',
+                    label: 'Do both parents reside in the home?',
+                    type: 'radio',
+                    required: true,
+                    ui: { options: ['Yes', 'No'] },
+                  },
+                ],
+              },
+            ],
+          },
+        ],
+      },
+      {
+        id: 'family_members',
+        title: 'Family Members',
+        sections: [
+          {
+            id: 'family_member_details',
+            title: 'Household Member Details',
+            fields: [
+              {
+                id: 'familymember',
+                label: 'Family Members',
+                type: 'group',
+                requiredCondition: {
+                  repeatingGroup: 'children',
+                  operator: 'ANY',
+                  condition: {
+                    field: 'do_both_parents_reside_in_home',
+                    operator: 'equals',
+                    value: 'Yes',
+                  },
+                },
+                metadata: { multiple: true, tableColumns: ['name'] },
+                fields: [
+                  { id: 'name', label: 'Name', type: 'text', required: true },
+                ],
+              },
+            ],
+          },
+        ],
+      },
+      {
+        id: 'final',
+        title: 'Final',
+        sections: [{ id: 'dummy', title: 'Done', fields: [] }],
+      },
+    ],
+  },
+};
+
+describe('family member persistence across steps', () => {
+  test('entries remain after navigating forward and back', async () => {
+    const user = userEvent.setup();
+    render(<FormRenderer formSpec={formSpec} />);
+
+    // Add a child with both parents residing in the home
+    await user.click(screen.getByRole('button', { name: /add children/i }));
+    await user.click(screen.getByRole('radio', { name: /yes/i }));
+    await user.click(screen.getByRole('button', { name: /^save$/i }));
+    await user.click(screen.getByRole('button', { name: /next/i }));
+
+    // Attempt to continue without adding family members (should be required)
+    await user.click(screen.getByRole('button', { name: /next/i }));
+    expect(await screen.findByText(/required/i)).toBeInTheDocument();
+
+    // Add a family member entry
+    await user.click(screen.getByRole('button', { name: /add family members/i }));
+    await user.type(screen.getByLabelText(/name/i), 'John');
+    await user.click(screen.getByRole('button', { name: /^save$/i }));
+
+    // Navigate to next step and then back
+    await user.click(screen.getByRole('button', { name: /next/i }));
+    await user.click(screen.getByRole('button', { name: /back/i }));
+
+    // The previously added family member should persist
+    expect(screen.getByText('John')).toBeInTheDocument();
+  });
+});
+

--- a/test-form/src/components/core/Step/Step.jsx
+++ b/test-form/src/components/core/Step/Step.jsx
@@ -408,7 +408,11 @@ export default function Step({
       onValidationFail?.(summary);
       return;
     }
-    const cleaned = cleanupHiddenFields({ sections }, formData);
+    const cleaned = cleanupHiddenFields(
+      { sections },
+      formData,
+      { ...fullData, ...formData }
+    );
     setFormData(cleaned);
     onDataChange && onDataChange(cleaned);
     onNext && onNext(cleaned);
@@ -445,7 +449,11 @@ export default function Step({
       return;       // prevent navigation if step is invalid
     }
 
-    const cleaned = cleanupHiddenFields({ sections }, formData);
+    const cleaned = cleanupHiddenFields(
+      { sections },
+      formData,
+      { ...fullData, ...formData }
+    );
     setFormData(cleaned);
     onDataChange && onDataChange(cleaned);
     onBackToReview && onBackToReview(cleaned);

--- a/test-form/src/utils/formHelpers.js
+++ b/test-form/src/utils/formHelpers.js
@@ -48,13 +48,13 @@ export function evaluateRepeatingGroupCondition(condition, data) {
   }
 }
 
-export function cleanupHiddenFields(step, formData) {
+export function cleanupHiddenFields(step, formData, evaluationData = formData) {
   const cleaned = { ...formData };
   if (!step || !Array.isArray(step.sections)) return cleaned;
 
   step.sections.forEach((section) => {
     const sectionVisible = section.visibilityCondition
-      ? evaluateCondition(section.visibilityCondition, formData)
+      ? evaluateCondition(section.visibilityCondition, evaluationData)
       : true;
 
     if (Array.isArray(section.fields)) {
@@ -74,10 +74,10 @@ export function cleanupHiddenFields(step, formData) {
         }
         const isVisible =
           (field.visibilityCondition
-            ? evaluateCondition(field.visibilityCondition, formData)
+            ? evaluateCondition(field.visibilityCondition, evaluationData)
             : true) &&
           (field.requiredCondition
-            ? evaluateCondition(field.requiredCondition, formData)
+            ? evaluateCondition(field.requiredCondition, evaluationData)
             : true);
 
         if (!isVisible && cleaned[field.id] !== undefined) {
@@ -88,10 +88,10 @@ export function cleanupHiddenFields(step, formData) {
           field.fields.forEach((subField) => {
             const isSubVisible =
               (subField.visibilityCondition
-                ? evaluateCondition(subField.visibilityCondition, formData)
+                ? evaluateCondition(subField.visibilityCondition, evaluationData)
                 : true) &&
               (subField.requiredCondition
-                ? evaluateCondition(subField.requiredCondition, formData)
+                ? evaluateCondition(subField.requiredCondition, evaluationData)
                 : true);
 
             if (!isSubVisible && cleaned[subField.id] !== undefined) {


### PR DESCRIPTION
## Summary
- evaluate hidden field conditions against full dataset to avoid losing data from other steps
- ensure step navigation cleans using merged form data
- add regression test for family member entries persisting across steps

## Testing
- `CI=true npm test src/__tests__/FamilyMembersPersistence.test.jsx`
- `CI=true npm test src/__tests__/ChildcareFormNavigation.test.js` *(fails: Cannot read properties of undefined (reading 'addEventListener'))*

------
https://chatgpt.com/codex/tasks/task_e_68a4af578bb8833195d403bfb5708b30