### PR TITLE
Add sample autofill configuration and local registration endpoint

### DIFF
--- a/README.md
+++ b/README.md
@@ -132,3 +132,21 @@ Sections using the table layout automatically adapt on smaller screens. Set `ui.
 ```
 
 In desktop view all columns appear in a single row. On mobile, only the first two columns show in the table while the "Notes" field appears below each row with its label displayed above the value.
+
+## Autofill configuration registration
+
+To publish the sample autofill configuration to the local API, run:
+
+```bash
+node scripts/registerAutofill.js
+```
+
+This script posts the contents of `config/autofill/sample_agency_form.json` to `http://localhost:3000/api/common-intake/autofill/register`.
+
+You can also call the API directly with curl:
+
+```bash
+curl -X POST http://localhost:3000/api/common-intake/autofill/register \
+  -H "Content-Type: application/json" \
+  --data-binary @config/autofill/sample_agency_form.json
+```

--- a/config/autofill/sample_agency_form.json
+++ b/config/autofill/sample_agency_form.json
@@ -1,0 +1,24 @@
+{
+  "version": "1.0.0",
+  "owner": "Sample Agency Intake Team",
+  "contact": "intake-team@samplecity.gov",
+  "id": "sample-agency-form",
+  "fields": [
+    {
+      "id": "firstName",
+      "dataGovGroup": "core",
+      "allowAutofill": true,
+      "allowSave": true,
+      "writerPolicy": "single",
+      "mapToTargetFormDataElementId": "applicant_first_name"
+    },
+    {
+      "id": "lastName",
+      "dataGovGroup": "core",
+      "allowAutofill": true,
+      "allowSave": true,
+      "writerPolicy": "single",
+      "mapToTargetFormDataElementId": "applicant_last_name"
+    }
+  ]
+}

--- a/scripts/registerAutofill.js
+++ b/scripts/registerAutofill.js
@@ -1,0 +1,28 @@
+const fs = require('fs').promises;
+
+async function main() {
+  const filePath = process.argv[2] || 'config/autofill/sample_agency_form.json';
+  const payload = await fs.readFile(filePath, 'utf8');
+  const url = process.argv[3] || 'http://localhost:3000/api/common-intake/autofill/register';
+
+  try {
+    const response = await fetch(url, {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: payload
+    });
+
+    const text = await response.text();
+    if (!response.ok) {
+      console.error(`Registration failed with status ${response.status}: ${text}`);
+      process.exit(1);
+    }
+
+    console.log('Registration succeeded:', text);
+  } catch (err) {
+    console.error('Registration error:', err.message);
+    process.exit(1);
+  }
+}
+
+main();

--- a/test-form/server/index.js
+++ b/test-form/server/index.js
@@ -14,6 +14,7 @@ const pool = require('./db');
 const authRoutes = require('./routes/auth');
 const applicationsRoutes = require('./routes/applications');
 const placesRoutes = require('./routes/places');
+const autofillRoutes = require('./routes/autofill');
 const { getApplications, getApplication } = applicationsRoutes;
 
 const app = express();
@@ -50,6 +51,7 @@ if ((process.env.FILE_STORAGE || 'LOCAL').toUpperCase() !== 'GCP') {
   app.use('/uploads', express.static(path.join(__dirname, 'uploads')));
 }
 app.use(express.urlencoded({ extended: true }));
+app.use(autofillRoutes);
 app.use(csurf());
 app.use((req, res, next) => {
   res.cookie('XSRF-TOKEN', req.csrfToken());

--- a/test-form/server/routes/autofill.js
+++ b/test-form/server/routes/autofill.js
@@ -1,0 +1,25 @@
+const express = require('express');
+const fs = require('fs');
+const path = require('path');
+
+const router = express.Router();
+
+const registrationsDir = path.join(__dirname, '../data/autofill');
+fs.mkdirSync(registrationsDir, { recursive: true });
+
+router.post('/api/common-intake/autofill/register', (req, res) => {
+  try {
+    const payload = req.body || {};
+    if (!payload.id) {
+      return res.status(400).json({ error: 'Missing id' });
+    }
+    const filePath = path.join(registrationsDir, `${payload.id}.json`);
+    fs.writeFileSync(filePath, JSON.stringify(payload, null, 2));
+    res.json({ status: 'registered', id: payload.id });
+  } catch (err) {
+    console.error('Registration save failed:', err);
+    res.status(500).json({ error: 'Failed to register configuration' });
+  }
+});
+
+module.exports = router;


### PR DESCRIPTION
## Summary
- add Express route for `POST /api/common-intake/autofill/register` that saves posted configs
- update registration script and docs to target the local API endpoint

## Testing
- `npm test` *(fails: Could not read package.json)*
- `node scripts/registerAutofill.js` *(fails: fetch failed)*

------
https://chatgpt.com/codex/tasks/task_e_68a4ced5930883318d637d7e8bfee3b4