### PR TITLE
Add businesses table to schema

### DIFF
--- a/test-form/server/db/schema.sql
+++ b/test-form/server/db/schema.sql
@@ -42,3 +42,25 @@ CREATE TABLE application_files (
   uploaded_at TIMESTAMP WITH TIME ZONE DEFAULT NOW()
 );
 
+CREATE TABLE businesses (
+  id UUID PRIMARY KEY DEFAULT gen_random_uuid(),
+  user_id UUID REFERENCES users(id),
+  legal_name TEXT,
+  structure TEXT,
+  ein TEXT,
+  industry TEXT,
+  sector TEXT,
+  address_line1 TEXT,
+  address_line2 TEXT,
+  city TEXT,
+  state TEXT,
+  zip_code TEXT,
+  primary_contact_name TEXT,
+  primary_contact_email TEXT,
+  primary_contact_phone TEXT,
+  created_at TIMESTAMP WITH TIME ZONE DEFAULT NOW(),
+  updated_at TIMESTAMP WITH TIME ZONE DEFAULT NOW()
+);
+
+CREATE INDEX businesses_user_id_idx ON businesses (user_id);
+


### PR DESCRIPTION
## Summary
- add businesses table with legal name, structure, EIN, industry, sector, address details, primary contact info, timestamps, and user reference
- index businesses by user_id

## Testing
- `npm test -- --watchAll=false` *(fails: TypeError: Cannot read properties of undefined (reading 'addEventListener'))*
- `npm run test-server`
- `npm run lint` *(fails: 12 problems (10 errors, 2 warnings))*

------
https://chatgpt.com/codex/tasks/task_e_68a4e164f0b48331851e7b6941daec46