### PR TITLE
Add business profile routes

### DIFF
--- a/test-form/server/index.js
+++ b/test-form/server/index.js
@@ -14,6 +14,7 @@ const pool = require('./db');
 const authRoutes = require('./routes/auth');
 const applicationsRoutes = require('./routes/applications');
 const placesRoutes = require('./routes/places');
+const businessProfileRoutes = require('./routes/businessProfile');
 const autofillRoutes = require('./routes/autofill');
 const { getApplications, getApplication } = applicationsRoutes;
 
@@ -128,6 +129,7 @@ app.post('/api/applications/:appId/upload', upload, async (req, res) => {
 
 app.use(placesRoutes);
 app.use(applicationsRoutes);
+app.use(businessProfileRoutes);
 app.use(autofillRoutes);
 
 // --- Help Chat ---

--- a/test-form/server/routes/businessProfile.js
+++ b/test-form/server/routes/businessProfile.js
@@ -1,0 +1,97 @@
+const express = require('express');
+const pool = require('../db');
+
+const router = express.Router();
+
+router.get('/api/profile/business/:businessId', async (req, res) => {
+  if (!req.isAuthenticated || !req.isAuthenticated()) {
+    return res.status(401).json({ error: 'Not authenticated' });
+  }
+  try {
+    const result = await pool.query(
+      'SELECT * FROM businesses WHERE id=$1 AND user_id=$2',
+      [req.params.businessId, req.user.id]
+    );
+    const business = result.rows[0];
+    if (!business) {
+      return res.status(404).json({ error: 'Not found' });
+    }
+    res.json(business);
+  } catch (err) {
+    console.error(err);
+    res.status(500).json({ error: 'Failed to load business profile' });
+  }
+});
+
+router.put('/api/profile/business/:businessId', async (req, res) => {
+  if (!req.isAuthenticated || !req.isAuthenticated()) {
+    return res.status(401).json({ error: 'Not authenticated' });
+  }
+  const {
+    legal_name = null,
+    structure = null,
+    ein = null,
+    industry = null,
+    sector = null,
+    address_line1 = null,
+    address_line2 = null,
+    city = null,
+    state = null,
+    zip_code = null,
+    primary_contact_name = null,
+    primary_contact_email = null,
+    primary_contact_phone = null,
+  } = req.body || {};
+  try {
+    const result = await pool.query(
+      `INSERT INTO businesses (
+         id, user_id, legal_name, structure, ein, industry, sector,
+         address_line1, address_line2, city, state, zip_code,
+         primary_contact_name, primary_contact_email, primary_contact_phone)
+       VALUES ($1,$2,$3,$4,$5,$6,$7,$8,$9,$10,$11,$12,$13,$14,$15)
+       ON CONFLICT (id) DO UPDATE SET
+         legal_name = EXCLUDED.legal_name,
+         structure = EXCLUDED.structure,
+         ein = EXCLUDED.ein,
+         industry = EXCLUDED.industry,
+         sector = EXCLUDED.sector,
+         address_line1 = EXCLUDED.address_line1,
+         address_line2 = EXCLUDED.address_line2,
+         city = EXCLUDED.city,
+         state = EXCLUDED.state,
+         zip_code = EXCLUDED.zip_code,
+         primary_contact_name = EXCLUDED.primary_contact_name,
+         primary_contact_email = EXCLUDED.primary_contact_email,
+         primary_contact_phone = EXCLUDED.primary_contact_phone,
+         updated_at = NOW()
+       WHERE businesses.user_id = EXCLUDED.user_id
+       RETURNING *`,
+      [
+        req.params.businessId,
+        req.user.id,
+        legal_name,
+        structure,
+        ein,
+        industry,
+        sector,
+        address_line1,
+        address_line2,
+        city,
+        state,
+        zip_code,
+        primary_contact_name,
+        primary_contact_email,
+        primary_contact_phone,
+      ]
+    );
+    if (result.rowCount === 0) {
+      return res.status(403).json({ error: 'Forbidden' });
+    }
+    res.json(result.rows[0]);
+  } catch (err) {
+    console.error(err);
+    res.status(500).json({ error: 'Failed to save business profile' });
+  }
+});
+
+module.exports = router;

--- a/test-form/server/routes/businessProfile.test.js
+++ b/test-form/server/routes/businessProfile.test.js
@@ -1,0 +1,67 @@
+const request = require('supertest');
+const express = require('express');
+
+jest.mock('../db', () => ({
+  query: jest.fn(),
+}));
+
+const pool = require('../db');
+const router = require('./businessProfile');
+
+const app = express();
+app.use(express.json());
+app.use((req, res, next) => {
+  req.isAuthenticated = () => true;
+  req.user = { id: 'user1' };
+  next();
+});
+app.use(router);
+
+describe('Business Profile API', () => {
+  beforeEach(() => {
+    pool.query.mockReset();
+  });
+
+  test('GET /api/profile/business/:businessId returns business', async () => {
+    const biz = { id: 'b1', user_id: 'user1', legal_name: 'Acme' };
+    pool.query.mockResolvedValueOnce({ rows: [biz] });
+
+    const res = await request(app).get('/api/profile/business/b1');
+
+    expect(res.statusCode).toBe(200);
+    expect(res.body).toEqual(biz);
+    expect(pool.query).toHaveBeenCalledWith(
+      'SELECT * FROM businesses WHERE id=$1 AND user_id=$2',
+      ['b1', 'user1']
+    );
+  });
+
+  test('PUT /api/profile/business/:businessId upserts business', async () => {
+    const saved = { id: 'b1', user_id: 'user1', legal_name: 'New' };
+    pool.query.mockResolvedValueOnce({ rows: [saved], rowCount: 1 });
+
+    const res = await request(app)
+      .put('/api/profile/business/b1')
+      .send({ legal_name: 'New' });
+
+    expect(res.statusCode).toBe(200);
+    expect(res.body).toEqual(saved);
+    const call = pool.query.mock.calls[0];
+    expect(call[0]).toMatch(/INSERT INTO businesses/);
+    expect(call[0]).toMatch(/ON CONFLICT \(id\) DO UPDATE/);
+    expect(call[1][0]).toBe('b1');
+    expect(call[1][1]).toBe('user1');
+    expect(call[1][2]).toBe('New');
+  });
+
+  test('PUT returns 403 when user does not own record', async () => {
+    pool.query.mockResolvedValueOnce({ rows: [], rowCount: 0 });
+
+    const res = await request(app)
+      .put('/api/profile/business/b1')
+      .send({ legal_name: 'New' });
+
+    expect(res.statusCode).toBe(403);
+    expect(res.body).toEqual({ error: 'Forbidden' });
+  });
+});


### PR DESCRIPTION
## Summary
- add businessProfile router handling GET and PUT for business records
- include router in server index
- cover new routes with Jest tests

## Testing
- `npm run test-server`


------
https://chatgpt.com/codex/tasks/task_e_68a4e2b3bb9083319da0ce6b6777e96a