### PR TITLE
Register business profile routes after middleware

### DIFF
--- a/test-form/server/index.js
+++ b/test-form/server/index.js
@@ -108,6 +108,9 @@ passport.deserializeUser(async (id, done) => {
 
 app.use(authRoutes);
 
+// Routes requiring session and CSRF protection
+app.use(businessProfileRoutes);
+
 const upload = storage.multerMiddleware();
 
 // --- File Upload ---
@@ -129,7 +132,6 @@ app.post('/api/applications/:appId/upload', upload, async (req, res) => {
 
 app.use(placesRoutes);
 app.use(applicationsRoutes);
-app.use(businessProfileRoutes);
 app.use(autofillRoutes);
 
 // --- Help Chat ---


### PR DESCRIPTION
## Summary
- mount business profile routes after configuring sessions and CSRF to ensure protections apply
- group protected routes together for clarity

## Testing
- `npm run test-server`
- `CI=true npm test src/__tests__/ChildcareFormNavigation.test.js` *(fails: cannot read properties of undefined reading 'addEventListener')*

------
https://chatgpt.com/codex/tasks/task_e_68a4e4a6c7548331a7626d7a08bbb41d