### PR TITLE
Add business profile route

### DIFF
--- a/test-form/src/App.js
+++ b/test-form/src/App.js
@@ -7,6 +7,7 @@ import Profile from './pages/Profile';
 // import "./form.css"; // Old theme - commented out
 import FormPage from "./pages/FormPage";
 import Dashboard from "./pages/Dashboard";
+import BusinessProfile from "./pages/BusinessProfile";
 import ThemeToggle from './components/shared/ThemeToggle';
 import './App.css'; // App specific styles, kept for now
 
@@ -132,6 +133,7 @@ function App() {
       <main className="form-main">
         <Routes>
           <Route path="/profile" element={<Profile />} />
+          <Route path="/business/:businessId" element={<BusinessProfile />} />
           <Route
             path="*"
             element={


### PR DESCRIPTION
## Summary
- import and render BusinessProfile component for `/business/:businessId`

## Testing
- `npm test -- --watchAll=false` *(fails: TypeError: Cannot read properties of undefined (reading 'matches') and other failing tests)*
- `npm run lint` *(fails: 10 errors, 2 warnings)*

------
https://chatgpt.com/codex/tasks/task_e_68a4e7b8e7f8833192937276279b6466