### PR TITLE
Add business profile auth tests

### DIFF
--- a/test-form/server/routes/businessProfile.test.js
+++ b/test-form/server/routes/businessProfile.test.js
@@ -64,4 +64,38 @@ describe('Business Profile API', () => {
     expect(res.statusCode).toBe(403);
     expect(res.body).toEqual({ error: 'Forbidden' });
   });
+
+  test('GET returns 401 when unauthenticated', async () => {
+    const unauthApp = express();
+    unauthApp.use(express.json());
+    unauthApp.use((req, res, next) => {
+      req.isAuthenticated = () => false;
+      next();
+    });
+    unauthApp.use(router);
+
+    const res = await request(unauthApp).get('/api/profile/business/b1');
+
+    expect(res.statusCode).toBe(401);
+    expect(res.body).toEqual({ error: 'Not authenticated' });
+    expect(pool.query).not.toHaveBeenCalled();
+  });
+
+  test('PUT returns 401 when unauthenticated', async () => {
+    const unauthApp = express();
+    unauthApp.use(express.json());
+    unauthApp.use((req, res, next) => {
+      req.isAuthenticated = () => false;
+      next();
+    });
+    unauthApp.use(router);
+
+    const res = await request(unauthApp)
+      .put('/api/profile/business/b1')
+      .send({ legal_name: 'New' });
+
+    expect(res.statusCode).toBe(401);
+    expect(res.body).toEqual({ error: 'Not authenticated' });
+    expect(pool.query).not.toHaveBeenCalled();
+  });
 });

--- a/test-form/src/pages/BusinessProfile.test.jsx
+++ b/test-form/src/pages/BusinessProfile.test.jsx
@@ -1,0 +1,46 @@
+import React from 'react';
+import { render, screen } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import { MemoryRouter, Routes, Route } from 'react-router-dom';
+import BusinessProfile from './BusinessProfile';
+import { AuthContext } from '../context/AuthContext';
+
+test('submits form data to server', async () => {
+  document.cookie = 'XSRF-TOKEN=token123';
+
+  global.fetch = jest
+    .fn()
+    .mockResolvedValueOnce({ ok: true, json: () => Promise.resolve({}) })
+    .mockResolvedValueOnce({ ok: true, json: () => Promise.resolve({}) });
+
+  const user = userEvent.setup();
+
+  render(
+    <AuthContext.Provider value={{ user: { id: 'u1' }, setUser: jest.fn() }}>
+      <MemoryRouter initialEntries={['/profile/biz123']}>
+        <Routes>
+          <Route path="/profile/:businessId" element={<BusinessProfile />} />
+        </Routes>
+      </MemoryRouter>
+    </AuthContext.Provider>
+  );
+
+  await user.type(screen.getByLabelText(/legalName/i), 'Acme');
+  await user.click(screen.getByRole('button', { name: /save/i }));
+
+  expect(global.fetch).toHaveBeenNthCalledWith(
+    2,
+    '/api/profile/business/biz123',
+    expect.objectContaining({
+      method: 'PUT',
+      headers: expect.objectContaining({
+        'Content-Type': 'application/json',
+        'X-CSRF-Token': 'token123',
+      }),
+    })
+  );
+
+  const body = JSON.parse(global.fetch.mock.calls[1][1].body);
+  expect(body.legal_name).toBe('Acme');
+});
+


### PR DESCRIPTION
## Summary
- ensure unauthenticated users receive 401 on business profile GET and PUT
- verify BusinessProfile form submits expected payload

## Testing
- `npm run test-server`
- `npm test -- src/pages/BusinessProfile.test.jsx`


------
https://chatgpt.com/codex/tasks/task_e_68a4e9120d448331a4c3bf6fc0375983