### PR TITLE
Add Business Profile option to user menu

### DIFF
--- a/test-form/public/locales/ar/translation.json
+++ b/test-form/public/locales/ar/translation.json
@@ -4,6 +4,7 @@
   "login": "تسجيل الدخول",
   "logout": "تسجيل الخروج",
   "profile": "حساب تعريفي",
+  "businessProfile": "ملف الأعمال",
   "serviceCatalog": "كتالوج الخدمة",
   "savedApplications": "التطبيقات المحفوظة",
   "privacyPolicy": "سياسة الخصوصية",

--- a/test-form/public/locales/bn/translation.json
+++ b/test-form/public/locales/bn/translation.json
@@ -4,6 +4,7 @@
   "login": "লগইন",
   "logout": "লগআউট",
   "profile": "প্রোফাইলের",
+  "businessProfile": "ব্যবসা প্রোফাইল",
   "serviceCatalog": "পরিষেবা ক্যাটালগ",
   "savedApplications": "সংরক্ষিত অ্যাপ্লিকেশন",
   "privacyPolicy": "গোপনীয়তা নীতি",

--- a/test-form/public/locales/en/translation.json
+++ b/test-form/public/locales/en/translation.json
@@ -4,6 +4,7 @@
   "login": "Login",
   "logout": "Logout",
   "profile": "Profile",
+  "businessProfile": "Business Profile",
   "serviceCatalog": "Service Catalog",
   "savedApplications": "Saved Applications",
   "privacyPolicy": "Privacy Policy",

--- a/test-form/public/locales/es/translation.json
+++ b/test-form/public/locales/es/translation.json
@@ -4,6 +4,7 @@
   "login": "Acceso",
   "logout": "Cerrar sesión",
   "profile": "Perfil",
+  "businessProfile": "Perfil empresarial",
   "serviceCatalog": "Catálogo de servicios",
   "savedApplications": "Aplicaciones guardadas",
   "privacyPolicy": "política de privacidad",

--- a/test-form/public/locales/fr/translation.json
+++ b/test-form/public/locales/fr/translation.json
@@ -4,6 +4,7 @@
   "login": "Se connecter",
   "logout": "Déconnexion",
   "profile": "Profil",
+  "businessProfile": "Profil d'entreprise",
   "serviceCatalog": "Catalogue de services",
   "savedApplications": "Applications enregistrées",
   "privacyPolicy": "politique de confidentialité",

--- a/test-form/public/locales/ht/translation.json
+++ b/test-form/public/locales/ht/translation.json
@@ -4,6 +4,7 @@
   "login": "Konekte",
   "logout": "Dekonekte",
   "profile": "Pwofil",
+  "businessProfile": "Pwofil Biznis",
   "serviceCatalog": "Katalòg Sèvis",
   "savedApplications": "Aplikasyon ki anrejistre yo",
   "privacyPolicy": "Règleman sou enfòmasyon prive",

--- a/test-form/public/locales/ko/translation.json
+++ b/test-form/public/locales/ko/translation.json
@@ -4,6 +4,7 @@
   "login": "로그인",
   "logout": "로그아웃",
   "profile": "윤곽",
+  "businessProfile": "비즈니스 프로필",
   "serviceCatalog": "서비스 카탈로그",
   "savedApplications": "저장된 애플리케이션",
   "privacyPolicy": "개인정보 보호정책",

--- a/test-form/public/locales/pl/translation.json
+++ b/test-form/public/locales/pl/translation.json
@@ -4,6 +4,7 @@
   "login": "Login",
   "logout": "Wyloguj",
   "profile": "Profil",
+  "businessProfile": "Profil firmy",
   "serviceCatalog": "Katalog usług",
   "savedApplications": "Zapisane aplikacje",
   "privacyPolicy": "Polityka prywatności",

--- a/test-form/public/locales/ru/translation.json
+++ b/test-form/public/locales/ru/translation.json
@@ -4,6 +4,7 @@
   "login": "Авторизоваться",
   "logout": "Выйти",
   "profile": "Профиль",
+  "businessProfile": "Профиль бизнеса",
   "serviceCatalog": "Каталог услуг",
   "savedApplications": "Сохраненные приложения",
   "privacyPolicy": "политика конфиденциальности",

--- a/test-form/public/locales/ur/translation.json
+++ b/test-form/public/locales/ur/translation.json
@@ -4,6 +4,7 @@
   "login": "لاگ ان",
   "logout": "لاگ آؤٹ",
   "profile": "پروفائل",
+  "businessProfile": "کاروباری پروفائل",
   "serviceCatalog": "سروس کیٹلاگ",
   "savedApplications": "محفوظ کردہ ایپلیکیشنز",
   "privacyPolicy": "رازداری کی پالیسی",

--- a/test-form/public/locales/zh/translation.json
+++ b/test-form/public/locales/zh/translation.json
@@ -4,6 +4,7 @@
   "login": "登录",
   "logout": "登出",
   "profile": "轮廓",
+  "businessProfile": "商业资料",
   "serviceCatalog": "服务目录",
   "savedApplications": "已保存的申请",
   "privacyPolicy": "隐私政策",

--- a/test-form/src/App.js
+++ b/test-form/src/App.js
@@ -119,6 +119,12 @@ function App() {
                   <Link to="/profile" onClick={() => setUserMenuOpen(false)}>
                     {t('profile')}
                   </Link>
+                  <Link
+                    to={`/business/${user.business_id || user.id}`}
+                    onClick={() => setUserMenuOpen(false)}
+                  >
+                    {t('businessProfile')}
+                  </Link>
                   <a href={`${server}/auth/logout`}>{t('logout')}</a>
                 </div>
               )}

--- a/test-form/src/__tests__/AuthNavigation.test.jsx
+++ b/test-form/src/__tests__/AuthNavigation.test.jsx
@@ -22,10 +22,11 @@ test('shows Login when unauthenticated', () => {
   expect(screen.getByRole('link', { name: /login/i })).toBeInTheDocument();
 });
 
-test('shows Profile and Logout when authenticated', async () => {
+test('shows Profile, Business Profile, and Logout when authenticated', async () => {
   const user = userEvent.setup();
-  renderWithUser({ first_name: 'Jane' });
+  renderWithUser({ first_name: 'Jane', id: 'u1' });
   await user.click(screen.getByRole('button', { name: /user menu/i }));
   expect(screen.getByRole('link', { name: /profile/i })).toBeInTheDocument();
+  expect(screen.getByRole('link', { name: /business profile/i })).toBeInTheDocument();
   expect(screen.getByRole('link', { name: /logout/i })).toBeInTheDocument();
 });


### PR DESCRIPTION
## Summary
- add Business Profile link in avatar dropdown
- provide translations for Business Profile
- expect Business Profile link in authenticated navigation test

## Testing
- `CI=true npm test` *(fails: Cannot read properties of undefined (reading 'addEventListener'))*
- `npm run lint` *(fails: 12 problems)*

------
https://chatgpt.com/codex/tasks/task_e_68a4ecb8c27c8331a16142649f1c4ee5